### PR TITLE
README.rst: Add PyPI latest version badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 ``zope.interface``
 ==================
 
+.. image:: https://pypip.in/version/zope.interface/badge.svg?style=flat
+    :target: https://pypi.python.org/pypi/zope.interface/
+    :alt: Latest Version
+
 .. image:: https://travis-ci.org/zopefoundation/zope.interface.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.interface
 


### PR DESCRIPTION
I find it handy to be able to flip back and forth easily between the source code repo and PyPI.

Preview at https://github.com/msabramo/zope.interface/blob/add_pypi_badge/README.rst