### PR TITLE
Make zope.interface installable on Py3.5 w/o a C compiler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ class optional_build_ext(build_ext):
     def build_extension(self, ext):
         try:
             build_ext.build_extension(self, ext)
-        except (CCompilerError, DistutilsExecError) as e:
+        except (CCompilerError, DistutilsExecError, OSError) as e:
             self._unavailable(e)
 
     def _unavailable(self, e):


### PR DESCRIPTION
Fixes #24.