### PR TITLE
zope.interface does not in fact depend on setuptools at install time.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ else:
         include_package_data = True,
         zip_safe = False,
         tests_require = tests_require,
-        install_requires = ['setuptools'],
         extras_require={'docs': ['Sphinx', 'repoze.sphinx.autointerface'],
                         'test': tests_require,
                         'testing': testing_extras,


### PR DESCRIPTION
At most, it depends on it to actually run the setup.py (but this appears to also not be the case).

Putting install_requires=["setuptools"] does bad things to pip install
-U. pip doesn't have a minimal upgrade mode currently, so having this there means users installing zope will have their setuptools updated
when they upgrade zope.interface, which is a risky upgrade and one that
is not necessary for zope.interface to run.

This especially breaks things when setuptools has an accidentally bad release (as it currently appears), because zope will continuously try to upgrade to it.

