### PR TITLE
Test pure builds on Travis CI and AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
     - pypy
     - pypy3
 install:
-    - pip install .
+    - pip install tox-travis
 script:
-    - python setup.py test -q
+    - tox
 notifications:
     email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,13 +6,22 @@ environment:
     # versions.  See http://python-packaging-user-guide.readthedocs.org/en/latest/appveyor/
     # for an explanation of the DISTUTILS_USE_SDK environment variable for Python 3.3 and 3.4.
     - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27"
+      PURE_PYTHON: "1"
     - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python27-x64"
+      PURE_PYTHON: "1"
     - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python33-x64"
       DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python34"
+      PURE_PYTHON: "1"
     - PYTHON: "C:\\Python34-x64"
       DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+      PURE_PYTHON: "1"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,3 +44,7 @@ commands =
 deps =
     Sphinx
     repoze.sphinx.autointerface
+
+[tox:travis]
+2.7 = py27,py27-pure,coverage,docs
+3.4 = py34,py34-pure


### PR DESCRIPTION
This also enables testing of `tox -e docs` and `tox -e coverage` on Travis because why not?