### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@
         :target: https://travis-ci.org/zopefoundation/zope.interface
 
 .. image:: https://readthedocs.org/projects/zopeinterface/badge/?version=latest
-        :target: http://zopeinterface.readthedocs.org/en/latest/
+        :target: https://zopeinterface.readthedocs.io/en/latest/
         :alt: Documentation Status
 
 This package is intended to be independently reusable in any Python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ version: build-{build}-{branch}
 environment:
   matrix:
     # http://www.appveyor.com/docs/installed-software#python lists available
-    # versions.  See http://python-packaging-user-guide.readthedocs.org/en/latest/appveyor/
+    # versions.  See https://python-packaging-user-guide.readthedocs.io/en/latest/appveyor/
     # for an explanation of the DISTUTILS_USE_SDK environment variable for Python 3.3 and 3.4.
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python27-x64"


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.