### PR TITLE
Remove the _u compat function.

### DIFF
--- a/src/zope/interface/_compat.py
+++ b/src/zope/interface/_compat.py
@@ -18,9 +18,6 @@ import types
 
 if sys.version_info[0] < 3: #pragma NO COVER
 
-    def _u(s):
-        return unicode(s, 'unicode_escape')
-
     def _normalize_name(name):
         if isinstance(name, basestring):
             return unicode(name)
@@ -35,9 +32,6 @@ if sys.version_info[0] < 3: #pragma NO COVER
     PYTHON2 = True
 
 else: #pragma NO COVER
-
-    def _u(s):
-        return s
 
     def _normalize_name(name):
         if isinstance(name, bytes):

--- a/src/zope/interface/adapter.py
+++ b/src/zope/interface/adapter.py
@@ -18,10 +18,10 @@ import weakref
 from zope.interface import providedBy
 from zope.interface import Interface
 from zope.interface import ro
-from zope.interface._compat import _u
+
 from zope.interface._compat import _normalize_name
 
-_BLANK = _u('')
+_BLANK = u''
 
 class BaseAdapterRegistry(object):
 

--- a/src/zope/interface/interfaces.py
+++ b/src/zope/interface/interfaces.py
@@ -18,9 +18,9 @@ __docformat__ = 'restructuredtext'
 from zope.interface.interface import Attribute
 from zope.interface.interface import Interface
 from zope.interface.declarations import implementer
-from zope.interface._compat import _u
 
-_BLANK = _u('')
+
+_BLANK = u''
 
 class IElement(Interface):
     """Objects that have basic documentation and tagged values.

--- a/src/zope/interface/registry.py
+++ b/src/zope/interface/registry.py
@@ -34,7 +34,6 @@ from zope.interface.declarations import implementer
 from zope.interface.declarations import implementer_only
 from zope.interface.declarations import providedBy
 from zope.interface.adapter import AdapterRegistry
-from zope.interface._compat import _u
 from zope.interface._compat import CLASS_TYPES
 from zope.interface._compat import STRING_TYPES
 
@@ -79,8 +78,8 @@ class Components(object):
         lambda self, bases: self._setBases(bases),
         )
 
-    def registerUtility(self, component=None, provided=None, name=_u(''),
-                        info=_u(''), event=True, factory=None):
+    def registerUtility(self, component=None, provided=None, name=u'',
+                        info=u'', event=True, factory=None):
         if factory:
             if component:
                 raise TypeError("Can't specify factory and component.")
@@ -89,7 +88,7 @@ class Components(object):
         if provided is None:
             provided = _getUtilityProvided(component)
 
-        if name == _u(''):
+        if name == u'':
             name = _getName(component)
 
         reg = self._utility_registrations.get((provided, name))
@@ -117,7 +116,7 @@ class Components(object):
                                     factory)
                 ))
 
-    def unregisterUtility(self, component=None, provided=None, name=_u(''),
+    def unregisterUtility(self, component=None, provided=None, name=u'',
                           factory=None):
         if factory:
             if component:
@@ -163,10 +162,10 @@ class Components(object):
              ) in iter(self._utility_registrations.items()):
             yield UtilityRegistration(self, provided, name, *data)
 
-    def queryUtility(self, provided, name=_u(''), default=None):
+    def queryUtility(self, provided, name=u'', default=None):
         return self.utilities.lookup((), provided, name, default)
 
-    def getUtility(self, provided, name=_u('')):
+    def getUtility(self, provided, name=u''):
         utility = self.utilities.lookup((), provided, name)
         if utility is None:
             raise ComponentLookupError(provided, name)
@@ -180,11 +179,11 @@ class Components(object):
         return self.utilities.subscriptions((), interface)
 
     def registerAdapter(self, factory, required=None, provided=None,
-                        name=_u(''), info=_u(''), event=True):
+                        name=u'', info=u'', event=True):
         if provided is None:
             provided = _getAdapterProvided(factory)
         required = _getAdapterRequired(factory, required)
-        if name == _u(''):
+        if name == u'':
             name = _getName(factory)
         self._adapter_registrations[(required, provided, name)
                                     ] = factory, info
@@ -198,7 +197,7 @@ class Components(object):
 
 
     def unregisterAdapter(self, factory=None,
-                          required=None, provided=None, name=_u(''),
+                          required=None, provided=None, name=u'',
                           ):
         if provided is None:
             if factory is None:
@@ -230,21 +229,21 @@ class Components(object):
             yield AdapterRegistration(self, required, provided, name,
                                       component, info)
 
-    def queryAdapter(self, object, interface, name=_u(''), default=None):
+    def queryAdapter(self, object, interface, name=u'', default=None):
         return self.adapters.queryAdapter(object, interface, name, default)
 
-    def getAdapter(self, object, interface, name=_u('')):
+    def getAdapter(self, object, interface, name=u''):
         adapter = self.adapters.queryAdapter(object, interface, name)
         if adapter is None:
             raise ComponentLookupError(object, interface, name)
         return adapter
 
-    def queryMultiAdapter(self, objects, interface, name=_u(''),
+    def queryMultiAdapter(self, objects, interface, name=u'',
                           default=None):
         return self.adapters.queryMultiAdapter(
             objects, interface, name, default)
 
-    def getMultiAdapter(self, objects, interface, name=_u('')):
+    def getMultiAdapter(self, objects, interface, name=u''):
         adapter = self.adapters.queryMultiAdapter(objects, interface, name)
         if adapter is None:
             raise ComponentLookupError(objects, interface, name)
@@ -260,7 +259,7 @@ class Components(object):
 
     def registerSubscriptionAdapter(self,
                                     factory, required=None, provided=None,
-                                    name=_u(''), info=_u(''),
+                                    name=u'', info=u'',
                                     event=True):
         if name:
             raise TypeError("Named subscribers are not yet supported")
@@ -283,7 +282,7 @@ class Components(object):
             yield SubscriptionRegistration(self, *data)
 
     def unregisterSubscriptionAdapter(self, factory=None,
-                          required=None, provided=None, name=_u(''),
+                          required=None, provided=None, name=u'',
                           ):
         if name:
             raise TypeError("Named subscribers are not yet supported")
@@ -329,7 +328,7 @@ class Components(object):
 
     def registerHandler(self,
                         factory, required=None,
-                        name=_u(''), info=_u(''),
+                        name=u'', info=u'',
                         event=True):
         if name:
             raise TypeError("Named handlers are not yet supported")
@@ -348,7 +347,7 @@ class Components(object):
         for data in self._handler_registrations:
             yield HandlerRegistration(self, *data)
 
-    def unregisterHandler(self, factory=None, required=None, name=_u('')):
+    def unregisterHandler(self, factory=None, required=None, name=u''):
         if name:
             raise TypeError("Named subscribers are not yet supported")
 
@@ -390,7 +389,7 @@ def _getName(component):
     try:
         return component.__component_name__
     except AttributeError:
-        return _u('')
+        return u''
 
 def _getUtilityProvided(component):
     provided = list(providedBy(component))
@@ -538,4 +537,3 @@ class HandlerRegistration(AdapterRegistration):
             self.name,
             getattr(self.factory, '__name__', repr(self.factory)), self.info,
             )
-

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -1350,8 +1350,8 @@ class Test_utils(unittest.TestCase):
 
     def test__normalize_name_unicode(self):
         from zope.interface.adapter import _normalize_name
-        from zope.interface._compat import _u
-        USTR = _u('ustr')
+        
+        USTR = u'ustr'
         self.assertEqual(_normalize_name(USTR), USTR)
 
     def test__normalize_name_other(self):

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -15,7 +15,7 @@
 """
 import unittest
 
-from zope.interface._compat import _skip_under_py3k, _u
+from zope.interface._compat import _skip_under_py3k
 
 
 class _Py3ClassAdvice(object):
@@ -46,20 +46,20 @@ class NamedTests(unittest.TestCase):
     def test_class(self):
         from zope.interface.declarations import named
 
-        @named(_u('foo'))
+        @named(u'foo')
         class Foo(object):
             pass
 
-        self.assertEqual(Foo.__component_name__, _u('foo'))
+        self.assertEqual(Foo.__component_name__, u'foo')
 
     def test_function(self):
         from zope.interface.declarations import named
 
-        @named(_u('foo'))
+        @named(u'foo')
         def doFoo(object):
             pass
 
-        self.assertEqual(doFoo.__component_name__, _u('foo'))
+        self.assertEqual(doFoo.__component_name__, u'foo')
 
     def test_instance(self):
         from zope.interface.declarations import named
@@ -67,9 +67,9 @@ class NamedTests(unittest.TestCase):
         class Foo(object):
             pass
         foo = Foo()
-        named(_u('foo'))(foo)
+        named(u'foo')(foo)
 
-        self.assertEqual(foo.__component_name__, _u('foo'))
+        self.assertEqual(foo.__component_name__, u'foo')
 
 
 class DeclarationTests(unittest.TestCase):

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -1054,10 +1054,10 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface import Interface
         from zope.interface.verify import verifyClass
-        from zope.interface._compat import _u
+        
 
         class ICheckMe(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 pass
@@ -1075,10 +1075,10 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface import Interface
         from zope.interface.verify import verifyObject
-        from zope.interface._compat import _u
+        
 
         class ICheckMe(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 pass
@@ -1105,10 +1105,10 @@ class InterfaceTests(unittest.TestCase):
     def test_names_simple(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class ISimple(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 pass
@@ -1118,16 +1118,16 @@ class InterfaceTests(unittest.TestCase):
     def test_names_derived(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class IBase(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 pass
 
         class IDerived(IBase):
-            attr2 = Attribute(_u('My attr2'))
+            attr2 = Attribute(u'My attr2')
 
             def method():
                 pass
@@ -1144,10 +1144,10 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class ISimple(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
@@ -1168,16 +1168,16 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface import Interface
         from zope.interface.interface import Method
-        from zope.interface._compat import _u
+        
 
         class IBase(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
 
         class IDerived(IBase):
-            attr2 = Attribute(_u('My attr2'))
+            attr2 = Attribute(u'My attr2')
 
             def method():
                 "My method, overridden"
@@ -1233,10 +1233,10 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class ISimple(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
@@ -1255,16 +1255,16 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class IBase(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
 
         class IDerived(IBase):
-            attr2 = Attribute(_u('My attr2'))
+            attr2 = Attribute(u'My attr2')
 
             def method():
                 "My method, overridden"
@@ -1304,10 +1304,10 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class ISimple(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
@@ -1326,16 +1326,16 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class IBase(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
 
         class IDerived(IBase):
-            attr2 = Attribute(_u('My attr2'))
+            attr2 = Attribute(u'My attr2')
 
             def method():
                 "My method, overridden"
@@ -1374,10 +1374,10 @@ class InterfaceTests(unittest.TestCase):
     def test___contains__simple(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class ISimple(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
@@ -1388,16 +1388,16 @@ class InterfaceTests(unittest.TestCase):
     def test___contains__derived(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class IBase(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
 
         class IDerived(IBase):
-            attr2 = Attribute(_u('My attr2'))
+            attr2 = Attribute(u'My attr2')
 
             def method():
                 "My method, overridden"
@@ -1421,10 +1421,10 @@ class InterfaceTests(unittest.TestCase):
     def test___iter__simple(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class ISimple(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
@@ -1434,16 +1434,16 @@ class InterfaceTests(unittest.TestCase):
     def test___iter__derived(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        from zope.interface._compat import _u
+        
 
         class IBase(Interface):
-            attr = Attribute(_u('My attr'))
+            attr = Attribute(u'My attr')
 
             def method():
                 "My method"
 
         class IDerived(IBase):
-            attr2 = Attribute(_u('My attr2'))
+            attr2 = Attribute(u'My attr2')
 
             def method():
                 "My method, overridden"

--- a/src/zope/interface/tests/test_registry.py
+++ b/src/zope/interface/tests/test_registry.py
@@ -73,22 +73,22 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerUtility_with_component_name(self):
         from zope.interface.declarations import named, InterfaceClass
-        from zope.interface._compat import _u
+        
 
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
 
-        @named(_u('foo'))
+        @named(u'foo')
         class Foo(object):
             pass
         foo = Foo()
-        _info = _u('info')
+        _info = u'info'
 
         comp = self._makeOne()
         comp.registerUtility(foo, ifoo, info=_info)
         self.assertEqual(
-            comp._utility_registrations[ifoo, _u('foo')],
+            comp._utility_registrations[ifoo, u'foo'],
             (foo, _info, None))
 
     def test_registerUtility_both_factory_and_component(self):
@@ -103,12 +103,12 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Registered
         from zope.interface.registry import UtilityRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = object()
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
@@ -135,12 +135,12 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Registered
         from zope.interface.registry import UtilityRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = object()
         def _factory():
             return _to_reg
@@ -163,14 +163,14 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerUtility_no_provided_available(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         class Foo(object):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = Foo()
         comp = self._makeOne()
         self.assertRaises(TypeError,
@@ -181,14 +181,14 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Registered
         from zope.interface.registry import UtilityRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         class Foo(object):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = Foo()
         directlyProvides(_to_reg, ifoo)
         comp = self._makeOne()
@@ -210,12 +210,12 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerUtility_duplicates_existing_reg(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = object()
         comp = self._makeOne()
         comp.registerUtility(_to_reg, ifoo, _name, _info)
@@ -226,13 +226,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerUtility_w_different_info(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info1 = _u('info1')
-        _info2 = _u('info2')
-        _name = _u('name')
+        _info1 = u'info1'
+        _info2 = u'info2'
+        _name = u'name'
         _to_reg = object()
         comp = self._makeOne()
         comp.registerUtility(_to_reg, ifoo, _name, _info1)
@@ -242,18 +242,18 @@ class ComponentsTests(unittest.TestCase):
         self.assertEqual(len(_events), 2)  # unreg, reg
         self.assertEqual(comp._utility_registrations[(ifoo, _name)],
                          (_to_reg, _info2, None))  # replaced
-        self.assertEqual(comp.utilities._subscribers[0][ifoo][_u('')],
+        self.assertEqual(comp.utilities._subscribers[0][ifoo][u''],
                          (_to_reg,))
 
     def test_registerUtility_w_different_names_same_component(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name1 = _u('name1')
-        _name2 = _u('name2')
+        _info = u'info'
+        _name1 = u'name1'
+        _name2 = u'name2'
         _other_reg = object()
         _to_reg = object()
         comp = self._makeOne()
@@ -266,7 +266,7 @@ class ComponentsTests(unittest.TestCase):
                          (_other_reg, _info, None))
         self.assertEqual(comp._utility_registrations[(ifoo, _name2)],
                          (_to_reg, _info, None))
-        self.assertEqual(comp.utilities._subscribers[0][ifoo][_u('')],
+        self.assertEqual(comp.utilities._subscribers[0][ifoo][u''],
                          (_other_reg, _to_reg,))
 
     def test_registerUtility_replaces_existing_reg(self):
@@ -274,12 +274,12 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.interfaces import Unregistered
         from zope.interface.interfaces import Registered
         from zope.interface.registry import UtilityRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _before, _after = object(), object()
         comp = self._makeOne()
         comp.registerUtility(_before, ifoo, _name, _info)
@@ -312,13 +312,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerUtility_w_existing_subscr(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name1 = _u('name1')
-        _name2 = _u('name2')
+        _info = u'info'
+        _name1 = u'name1'
+        _name2 = u'name2'
         _to_reg = object()
         comp = self._makeOne()
         comp.registerUtility(_to_reg, ifoo, _name1, _info)
@@ -329,12 +329,12 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerUtility_wo_event(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = object()
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
@@ -357,11 +357,11 @@ class ComponentsTests(unittest.TestCase):
 
     def test_unregisterUtility_w_component_miss(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _name = _u('name')
+        _name = u'name'
         _to_reg = object()
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
@@ -374,11 +374,11 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Unregistered
         from zope.interface.registry import UtilityRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _name = _u('name')
+        _name = u'name'
         _to_reg = object()
         comp = self._makeOne()
         comp.registerUtility(_to_reg, ifoo, _name)
@@ -405,12 +405,12 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Unregistered
         from zope.interface.registry import UtilityRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = object()
         def _factory():
             return _to_reg
@@ -437,14 +437,14 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Unregistered
         from zope.interface.registry import UtilityRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         class Foo(object):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = Foo()
         directlyProvides(_to_reg, ifoo)
         comp = self._makeOne()
@@ -471,14 +471,14 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Unregistered
         from zope.interface.registry import UtilityRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         class Foo(object):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = Foo()
         directlyProvides(_to_reg, ifoo)
         comp = self._makeOne()
@@ -503,13 +503,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_unregisterUtility_w_existing_subscr(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name1 = _u('name1')
-        _name2 = _u('name2')
+        _info = u'info'
+        _name1 = u'name1'
+        _name2 = u'name2'
         _to_reg = object()
         comp = self._makeOne()
         comp.registerUtility(_to_reg, ifoo, _name1, _info)
@@ -521,13 +521,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_unregisterUtility_w_existing_subscr_other_component(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name1 = _u('name1')
-        _name2 = _u('name2')
+        _info = u'info'
+        _name1 = u'name1'
+        _name2 = u'name2'
         _other_reg = object()
         _to_reg = object()
         comp = self._makeOne()
@@ -545,14 +545,14 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registeredUtilities_notempty(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         from zope.interface.registry import UtilityRegistration
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name1 = _u('name1')
-        _name2 = _u('name2')
+        _info = u'info'
+        _name1 = u'name1'
+        _name2 = u'name2'
         _to_reg = object()
         comp = self._makeOne()
         comp.registerUtility(_to_reg, ifoo, _name1, _info)
@@ -630,12 +630,12 @@ class ComponentsTests(unittest.TestCase):
 
     def test_getUtilitiesFor_hit(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _name1 = _u('name1')
-        _name2 = _u('name2')
+        _name1 = u'name1'
+        _name2 = u'name2'
         _to_reg = object()
         comp = self._makeOne()
         comp.registerUtility(_to_reg, ifoo, name=_name1)
@@ -653,12 +653,12 @@ class ComponentsTests(unittest.TestCase):
 
     def test_getAllUtilitiesRegisteredFor_hit(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _name1 = _u('name1')
-        _name2 = _u('name2')
+        _name1 = u'name1'
+        _name2 = u'name2'
         _to_reg = object()
         comp = self._makeOne()
         comp.registerUtility(_to_reg, ifoo, name=_name1)
@@ -668,36 +668,36 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerAdapter_with_component_name(self):
         from zope.interface.declarations import named, InterfaceClass
-        from zope.interface._compat import _u
+        
 
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
 
-        @named(_u('foo'))
+        @named(u'foo')
         class Foo(object):
             pass
-        _info = _u('info')
+        _info = u'info'
 
         comp = self._makeOne()
         comp.registerAdapter(Foo, (ibar,), ifoo, info=_info)
 
         self.assertEqual(
-            comp._adapter_registrations[(ibar,), ifoo, _u('foo')],
+            comp._adapter_registrations[(ibar,), ifoo, u'foo'],
             (Foo, _info))
 
     def test_registerAdapter_w_explicit_provided_and_required(self):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Registered
         from zope.interface.registry import AdapterRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = object()
         def _factory(context):
             return _to_reg
@@ -724,13 +724,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerAdapter_no_provided_available(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = object()
         class _Factory(object):
             def __init__(self, context):
@@ -744,13 +744,13 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import implementer
         from zope.interface.interfaces import Registered
         from zope.interface.registry import AdapterRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = object()
         @implementer(ifoo)
         class _Factory(object):
@@ -779,13 +779,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerAdapter_no_required_available(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         class _Factory(object):
             def __init__(self, context):
                 self._context = context
@@ -795,13 +795,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerAdapter_w_invalid_required(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         class _Factory(object):
             def __init__(self, context):
                 self._context = context
@@ -814,12 +814,12 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.interface import Interface
         from zope.interface.interfaces import Registered
         from zope.interface.registry import AdapterRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         class _Factory(object):
             def __init__(self, context):
                 self._context = context
@@ -851,13 +851,13 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import implementedBy
         from zope.interface.interfaces import Registered
         from zope.interface.registry import AdapterRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         class _Factory(object):
             def __init__(self, context):
                 self._context = context
@@ -889,13 +889,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerAdapter_w_required_containing_junk(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         class _Factory(object):
             def __init__(self, context):
                 self._context = context
@@ -907,13 +907,13 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Registered
         from zope.interface.registry import AdapterRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         class _Factory(object):
             __component_adapts__ = (ibar,)
             def __init__(self, context):
@@ -942,13 +942,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerAdapter_wo_event(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _name = _u('name')
+        _info = u'info'
+        _name = u'name'
         _to_reg = object()
         def _factory(context):
             return _to_reg
@@ -1089,15 +1089,15 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registeredAdapters_notempty(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         from zope.interface.registry import AdapterRegistration
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IFoo')
-        _info = _u('info')
-        _name1 = _u('name1')
-        _name2 = _u('name2')
+        _info = u'info'
+        _name1 = u'name1'
+        _name2 = u'name2'
         class _Factory(object):
             def __init__(self, context):
                 pass
@@ -1359,7 +1359,7 @@ class ComponentsTests(unittest.TestCase):
     def test_getAdapters_non_empty(self):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.declarations import implementer
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
@@ -1379,8 +1379,8 @@ class ComponentsTests(unittest.TestCase):
         class _Factory2(object):
             def __init__(self, context1, context2):
                 self.context = context1, context2
-        _name1 = _u('name1')
-        _name2 = _u('name2')
+        _name1 = u'name1'
+        _name2 = u'name2'
         comp = self._makeOne()
         comp.registerAdapter(_Factory1, (ibar, ibaz), ifoo, name=_name1)
         comp.registerAdapter(_Factory2, (ibar, ibaz), ifoo, name=_name2)
@@ -1393,13 +1393,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerSubscriptionAdapter_w_nonblank_name(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _name = _u('name')
-        _info = _u('info')
+        _name = u'name'
+        _info = u'info'
         _to_reg = object()
         def _factory(context):
             return _to_reg
@@ -1411,13 +1411,13 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Registered
         from zope.interface.registry import SubscriptionRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _blank = _u('')
-        _info = _u('info')
+        _blank = u''
+        _info = u'info'
         _to_reg = object()
         def _factory(context):
             return _to_reg
@@ -1449,13 +1449,13 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import implementer
         from zope.interface.interfaces import Registered
         from zope.interface.registry import SubscriptionRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _blank = _u('')
+        _info = u'info'
+        _blank = u''
         _to_reg = object()
         @implementer(ifoo)
         class _Factory(object):
@@ -1487,13 +1487,13 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Registered
         from zope.interface.registry import SubscriptionRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _info = _u('info')
-        _blank = _u('')
+        _info = u'info'
+        _blank = u''
         class _Factory(object):
             __component_adapts__ = (ibar,)
             def __init__(self, context):
@@ -1523,13 +1523,13 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerSubscriptionAdapter_wo_event(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _blank = _u('')
-        _info = _u('info')
+        _blank = u''
+        _info = u'info'
         _to_reg = object()
         def _factory(context):
             return _to_reg
@@ -1546,14 +1546,14 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registeredSubscriptionAdapters_notempty(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         from zope.interface.registry import SubscriptionRegistration
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IFoo')
-        _info = _u('info')
-        _blank = _u('')
+        _info = u'info'
+        _blank = u''
         class _Factory(object):
             def __init__(self, context):
                 pass
@@ -1579,12 +1579,12 @@ class ComponentsTests(unittest.TestCase):
 
     def test_unregisterSubscriptionAdapter_w_nonblank_name(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
-        _nonblank = _u('nonblank')
+        _nonblank = u'nonblank'
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.unregisterSubscriptionAdapter,
                           required=ifoo, provided=ibar, name=_nonblank)
@@ -1790,11 +1790,11 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerHandler_w_nonblank_name(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _nonblank = _u('nonblank')
+        _nonblank = u'nonblank'
         comp = self._makeOne()
         def _factory(context):
             pass
@@ -1805,12 +1805,12 @@ class ComponentsTests(unittest.TestCase):
         from zope.interface.declarations import InterfaceClass
         from zope.interface.interfaces import Registered
         from zope.interface.registry import HandlerRegistration
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _blank = _u('')
-        _info = _u('info')
+        _blank = u''
+        _info = u'info'
         _to_reg = object()
         def _factory(context):
             return _to_reg
@@ -1837,12 +1837,12 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerHandler_wo_explicit_required_no_event(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _info = _u('info')
-        _blank = _u('')
+        _info = u'info'
+        _blank = u''
         class _Factory(object):
             __component_adapts__ = (ifoo,)
             def __init__(self, context):
@@ -1895,11 +1895,11 @@ class ComponentsTests(unittest.TestCase):
  
     def test_unregisterHandler_w_nonblank_name(self):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        _nonblank = _u('nonblank')
+        _nonblank = u'nonblank'
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.unregisterHandler,
                           required=(ifoo,), name=_nonblank)
@@ -2055,7 +2055,7 @@ class UtilityRegistrationTests(unittest.TestCase):
 
     def _makeOne(self, component=None, factory=None):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
@@ -2063,7 +2063,7 @@ class UtilityRegistrationTests(unittest.TestCase):
             def __repr__(self):
                 return '_REGISTRY'
         registry = _Registry()
-        name = _u('name')
+        name = u'name'
         doc = 'DOCSTRING'
         klass = self._getTargetClass()
         return (klass(registry, ifoo, name, component, doc, factory),
@@ -2240,7 +2240,7 @@ class AdapterRegistrationTests(unittest.TestCase):
 
     def _makeOne(self, component=None):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
@@ -2249,7 +2249,7 @@ class AdapterRegistrationTests(unittest.TestCase):
             def __repr__(self):
                 return '_REGISTRY'
         registry = _Registry()
-        name = _u('name')
+        name = u'name'
         doc = 'DOCSTRING'
         klass = self._getTargetClass()
         return (klass(registry, (ibar,), ifoo, name, component, doc),
@@ -2449,7 +2449,7 @@ class SubscriptionRegistrationTests(unittest.TestCase):
 
     def _makeOne(self, component=None):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
@@ -2458,7 +2458,7 @@ class SubscriptionRegistrationTests(unittest.TestCase):
             def __repr__(self):
                 return '_REGISTRY'
         registry = _Registry()
-        name = _u('name')
+        name = u'name'
         doc = 'DOCSTRING'
         klass = self._getTargetClass()
         return (klass(registry, (ibar,), ifoo, name, component, doc),
@@ -2486,7 +2486,7 @@ class HandlerRegistrationTests(unittest.TestCase):
 
     def _makeOne(self, component=None):
         from zope.interface.declarations import InterfaceClass
-        from zope.interface._compat import _u
+        
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
@@ -2494,7 +2494,7 @@ class HandlerRegistrationTests(unittest.TestCase):
             def __repr__(self):
                 return '_REGISTRY'
         registry = _Registry()
-        name = _u('name')
+        name = u'name'
         doc = 'DOCSTRING'
         klass = self._getTargetClass()
         return (klass(registry, (ifoo,), name, component, doc),


### PR DESCRIPTION
Since we no longer support 3.2 we can use the literal syntax.

This was done with a quick sed script.