### PR TITLE
Make setuptools a hard dependency of setup.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changes
   be used together in ordered containers like BTrees.
   (https://github.com/zopefoundation/zope.interface/issues/42)
 
+- Make ``setuptools`` a hard dependency of ``setup.py``.
+  (https://github.com/zopefoundation/zope.interface/issues/13)
+
 4.2.0 (2016-06-10)
 ------------------
 


### PR DESCRIPTION
Uses `find_packages` instead of a manual list.

Fixes #13.
Fixes #14.