### PR TITLE
Use the canonical URL.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,4 +23,4 @@ the `Design By Contract`_ methodology support in Python.
 
 .. _Design By Contract: http://en.wikipedia.org/wiki/Design_by_contract
 
-For detailed documentation, please see http://docs.zope.org/zope.interface
+For detailed documentation, please see https://zopeinterface.readthedocs.io/en/latest/


### PR DESCRIPTION
docs.zope.org has now a redirect.