### PR TITLE
Support Components subclasses that are not hashable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changes
 =======
 
-4.4.0 (unreleased)
+4.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support Components subclasses that are not hashable.
+  (https://github.com/zopefoundation/zope.interface/issues/53)
 
 
 4.3.0 (2016-08-31)

--- a/src/zope/interface/tests/test_registry.py
+++ b/src/zope/interface/tests/test_registry.py
@@ -2655,9 +2655,10 @@ class _Monkey(object):
 
 def test_suite():
     return unittest.TestSuite((
-            unittest.makeSuite(ComponentsTests),
-            unittest.makeSuite(UtilityRegistrationTests),
-            unittest.makeSuite(AdapterRegistrationTests),
-            unittest.makeSuite(SubscriptionRegistrationTests),
-            unittest.makeSuite(AdapterRegistrationTests),
-        ))
+        unittest.makeSuite(ComponentsTests),
+        unittest.makeSuite(UnhashableComponentsTests),
+        unittest.makeSuite(UtilityRegistrationTests),
+        unittest.makeSuite(AdapterRegistrationTests),
+        unittest.makeSuite(SubscriptionRegistrationTests),
+        unittest.makeSuite(AdapterRegistrationTests),
+    ))

--- a/src/zope/interface/tests/test_registry.py
+++ b/src/zope/interface/tests/test_registry.py
@@ -2133,6 +2133,15 @@ class ComponentsTests(unittest.TestCase):
         self.assertEqual(_called_2, [bar])
 
 
+class UnhashableComponentsTests(ComponentsTests):
+
+    def _getTargetClass(self):
+        # Mimic what pyramid does to create an unhashable
+        # registry
+        class Components(super(UnhashableComponentsTests, self)._getTargetClass(), dict):
+            pass
+        return Components
+
 # Test _getUtilityProvided, _getAdapterProvided, _getAdapterRequired via their
 # callers (Component.registerUtility, Component.registerAdapter).
 


### PR DESCRIPTION
Fixes #53.

This depends on the `id` of the instance staying stable and not being reused while the instance is extant. It uses a manual weakref and cleanup function.