### PR TITLE
Fix C optimizations broken on Py3k.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes
 4.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix C optimizations broken on Py3k.  See the Python bug at:
+  http://bugs.python.org/issue15657
+  (https://github.com/zopefoundation/zope.interface/issues/60)
 
 
 4.3.2 (2016-09-05)

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -25,6 +25,15 @@
 #define Py_TYPE(o) ((o)->ob_type)
 #endif
 
+#if PY_MAJOR_VERSION >= 3
+#define PY3K
+#endif
+
+#ifdef PY3K
+/* See http://bugs.python.org/issue15657 */
+#define METH_KEYWORDS 0x0003
+#endif
+
 static PyObject *str__dict__, *str__implemented__, *strextends;
 static PyObject *BuiltinImplementationSpecifications, *str__provides__;
 static PyObject *str__class__, *str__providedBy__;

--- a/src/zope/interface/adapter.py
+++ b/src/zope/interface/adapter.py
@@ -398,7 +398,7 @@ class LookupBaseFallback(object):
 LookupBasePy = LookupBaseFallback # BBB
 
 try:
-    from _zope_interface_coptimizations import LookupBase
+    from zope.interface._zope_interface_coptimizations import LookupBase
 except ImportError: #pragma NO COVER
     LookupBase = LookupBaseFallback
 
@@ -434,7 +434,7 @@ class VerifyingBaseFallback(LookupBaseFallback):
 VerifyingBasePy = VerifyingBaseFallback #BBB
 
 try:
-    from _zope_interface_coptimizations import VerifyingBase
+    from zope.interface._zope_interface_coptimizations import VerifyingBase
 except ImportError: #pragma NO COVER
     VerifyingBase = VerifyingBaseFallback
 

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -640,11 +640,11 @@ ClassProvidesBase = ClassProvidesBaseFallback
 
 # Try to get C base:
 try:
-    import _zope_interface_coptimizations
+    import zope.interface._zope_interface_coptimizations
 except ImportError:  #pragma NO COVERAGE
     pass
 else:  #pragma NO COVERAGE
-    from _zope_interface_coptimizations import ClassProvidesBase
+    from zope.interface._zope_interface_coptimizations import ClassProvidesBase
 
 
 class ClassProvides(Declaration, ClassProvidesBase):
@@ -917,13 +917,15 @@ def _normalizeargs(sequence, output = None):
 _empty = Declaration()
 
 try:
-    import _zope_interface_coptimizations
+    import zope.interface._zope_interface_coptimizations
 except ImportError: #pragma NO COVER
     pass
 else: #pragma NO COVER PyPy
-    from _zope_interface_coptimizations import implementedBy
-    from _zope_interface_coptimizations import providedBy
-    from _zope_interface_coptimizations import getObjectSpecification
-    from _zope_interface_coptimizations import ObjectSpecificationDescriptor
+    from zope.interface._zope_interface_coptimizations import implementedBy
+    from zope.interface._zope_interface_coptimizations import providedBy
+    from zope.interface._zope_interface_coptimizations import (
+        getObjectSpecification)
+    from zope.interface._zope_interface_coptimizations import (
+        ObjectSpecificationDescriptor)
 
 objectSpecificationDescriptor = ObjectSpecificationDescriptor()

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -114,7 +114,7 @@ class SpecificationBasePy(object):
 
 SpecificationBase = SpecificationBasePy
 try:
-    from _zope_interface_coptimizations import SpecificationBase
+    from zope.interface._zope_interface_coptimizations import SpecificationBase
 except ImportError: #pragma NO COVER
     pass
 
@@ -155,14 +155,14 @@ class InterfaceBasePy(object):
 
 InterfaceBase = InterfaceBasePy
 try:
-    from _zope_interface_coptimizations import InterfaceBase
+    from zope.interface._zope_interface_coptimizations import InterfaceBase
 except ImportError: #pragma NO COVER
     pass
 
 
 adapter_hooks = []
 try:
-    from _zope_interface_coptimizations import adapter_hooks
+    from zope.interface._zope_interface_coptimizations import adapter_hooks
 except ImportError: #pragma NO COVER
     pass
 

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -527,6 +527,15 @@ class LookupBaseTests(LookupBaseFallbackTests):
         from zope.interface.adapter import LookupBase
         return LookupBase
 
+    def test_optimizations(self):
+        from zope.interface.adapter import LookupBaseFallback
+        try:
+            import zope.interface._zope_interface_coptimizations
+        except ImportError:
+            self.assertIs(self._getTargetClass(), LookupBaseFallback)
+        else:
+            self.assertIsNot(self._getTargetClass(), LookupBaseFallback)
+
 
 class VerifyingBaseFallbackTests(unittest.TestCase):
 
@@ -688,6 +697,15 @@ class VerifyingBaseTests(VerifyingBaseFallbackTests):
     def _getTargetClass(self):
         from zope.interface.adapter import VerifyingBase
         return VerifyingBase
+
+    def test_optimizations(self):
+        from zope.interface.adapter import VerifyingBaseFallback
+        try:
+            import zope.interface._zope_interface_coptimizations
+        except ImportError:
+            self.assertIs(self._getTargetClass(), VerifyingBaseFallback)
+        else:
+            self.assertIsNot(self._getTargetClass(), VerifyingBaseFallback)
 
 
 class AdapterLookupBaseTests(unittest.TestCase):

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -473,6 +473,16 @@ class Test_implementedBy(Test_implementedByFallback):
         from zope.interface.declarations import implementedBy
         return implementedBy(*args, **kw)
 
+    def test_optimizations(self):
+        from zope.interface.declarations import implementedByFallback
+        from zope.interface.declarations import implementedBy
+        try:
+            import zope.interface._zope_interface_coptimizations
+        except ImportError:
+            self.assertIs(implementedBy, implementedByFallback)
+        else:
+            self.assertIsNot(implementedBy, implementedByFallback)
+
 
 class Test_classImplementsOnly(unittest.TestCase):
 
@@ -1123,6 +1133,15 @@ class ClassProvidesBaseTests(ClassProvidesBaseFallbackTests):
         from zope.interface.declarations import ClassProvidesBase
         return ClassProvidesBase
 
+    def test_optimizations(self):
+        from zope.interface.declarations import ClassProvidesBaseFallback
+        try:
+            import zope.interface._zope_interface_coptimizations
+        except ImportError:
+            self.assertIs(self._getTargetClass(), ClassProvidesBaseFallback)
+        else:
+            self.assertIsNot(self._getTargetClass(), ClassProvidesBaseFallback)
+
 
 class ClassProvidesTests(unittest.TestCase):
 
@@ -1440,6 +1459,18 @@ class Test_getObjectSpecification(Test_getObjectSpecificationFallback):
         from zope.interface.declarations import getObjectSpecification
         return getObjectSpecification(*args, **kw)
 
+    def test_optimizations(self):
+        from zope.interface.declarations import getObjectSpecificationFallback
+        from zope.interface.declarations import getObjectSpecification
+        try:
+            import zope.interface._zope_interface_coptimizations
+        except ImportError:
+            self.assertIs(getObjectSpecification,
+                          getObjectSpecificationFallback)
+        else:
+            self.assertIsNot(getObjectSpecification,
+                             getObjectSpecificationFallback)
+
 
 class Test_providedByFallback(unittest.TestCase):
 
@@ -1525,6 +1556,16 @@ class Test_providedBy(Test_providedByFallback):
         from zope.interface.declarations import providedBy
         return providedBy(*args, **kw)
 
+    def test_optimizations(self):
+        from zope.interface.declarations import providedByFallback
+        from zope.interface.declarations import providedBy
+        try:
+            import zope.interface._zope_interface_coptimizations
+        except ImportError:
+            self.assertIs(providedBy, providedByFallback)
+        else:
+            self.assertIsNot(providedBy, providedByFallback)
+
 
 class ObjectSpecificationDescriptorFallbackTests(unittest.TestCase):
 
@@ -1585,6 +1626,18 @@ class ObjectSpecificationDescriptorTests(
     def _getTargetClass(self):
         from zope.interface.declarations import ObjectSpecificationDescriptor
         return ObjectSpecificationDescriptor
+
+    def test_optimizations(self):
+        from zope.interface.declarations import (
+            ObjectSpecificationDescriptorFallback)
+        try:
+            import zope.interface._zope_interface_coptimizations
+        except ImportError:
+            self.assertIs(self._getTargetClass(),
+                          ObjectSpecificationDescriptorFallback)
+        else:
+            self.assertIsNot(self._getTargetClass(),
+                             ObjectSpecificationDescriptorFallback)
 
 
 # Test _normalizeargs through its callers.

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -205,6 +205,22 @@ class SpecificationBasePyTests(unittest.TestCase):
         self.assertTrue(sb(testing))
 
 
+class SpecificationBaseTests(unittest.TestCase):
+
+    def _getTargetClass(self):
+        from zope.interface.interface import SpecificationBase
+        return SpecificationBase
+
+    def test_optimizations(self):
+        from zope.interface.interface import SpecificationBasePy
+        try:
+            import zope.interface._zope_interface_coptimizations
+        except ImportError:
+            self.assertIs(self._getTargetClass(), SpecificationBasePy)
+        else:
+            self.assertIsNot(self._getTargetClass(), SpecificationBasePy)
+
+
 class InterfaceBasePyTests(unittest.TestCase):
 
     def _getTargetClass(self):
@@ -264,6 +280,22 @@ class InterfaceBasePyTests(unittest.TestCase):
         with _Monkey(interface, adapter_hooks=[_hook_miss, _hook_hit]):
             self.assertTrue(ib.__adapt__(adapted) is adapted)
             self.assertEqual(_missed, [(ib, adapted)])
+
+
+class InterfaceBaseTests(unittest.TestCase):
+
+    def _getTargetClass(self):
+        from zope.interface.interface import InterfaceBase
+        return InterfaceBase
+
+    def test_optimizations(self):
+        from zope.interface.interface import InterfaceBasePy
+        try:
+            import zope.interface._zope_interface_coptimizations
+        except ImportError:
+            self.assertIs(self._getTargetClass(), InterfaceBasePy)
+        else:
+            self.assertIsNot(self._getTargetClass(), InterfaceBasePy)
 
 
 class SpecificationTests(unittest.TestCase):


### PR DESCRIPTION
- The bare import of `_zope_c_optimizations` prevented them from being   used.

- After enabling them via absolute imports, they would fail due to http://bugs.python.org/issue15657.

Fixes #60.