### PR TITLE
Ensure that LICENSE.txt is present in built wheels.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ where=src
 [aliases]
 dev = develop easy_install zope.interface[testing]
 docs = easy_install zope.interface[docs]
+
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
See #62.