### PR TITLE
Removed docstrings to avoid publishing in Zope2 environments.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 4.3.3 (unreleased)
 ------------------
 
+- Removed docstrings to avoid publishing in Zope2 environments.
+
 - Fix C optimizations broken on Py3k.  See the Python bug at:
   http://bugs.python.org/issue15657
   (https://github.com/zopefoundation/zope.interface/issues/60)

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -66,27 +66,27 @@ class Element(object):
         self.__tagged_values = {}
 
     def getName(self):
-        """ Returns the name of the object. """
+        # Returns the name of the object.
         return self.__name__
 
     def getDoc(self):
-        """ Returns the documentation for the object. """
+        # Returns the documentation for the object.
         return self.__doc__
 
     def getTaggedValue(self, tag):
-        """ Returns the value associated with 'tag'. """
+        # Returns the value associated with 'tag'.
         return self.__tagged_values[tag]
 
     def queryTaggedValue(self, tag, default=None):
-        """ Returns the value associated with 'tag'. """
+        # Returns the value associated with 'tag'.
         return self.__tagged_values.get(tag, default)
 
     def getTaggedValueTags(self):
-        """ Returns a list of all tags. """
+        # Returns a list of all tags.
         return self.__tagged_values.keys()
 
     def setTaggedValue(self, tag, value):
-        """ Associates 'value' with 'key'. """
+        # Associates 'value' with 'key'.
         self.__tagged_values[tag] = value
 
 class SpecificationBasePy(object):
@@ -220,8 +220,7 @@ class Specification(SpecificationBase):
         )
 
     def changed(self, originally_changed):
-        """We, or something we depend on, have changed
-        """
+        # We, or something we depend on, have changed.
         try:
             del self._v_attrs
         except AttributeError:
@@ -253,8 +252,7 @@ class Specification(SpecificationBase):
 
 
     def interfaces(self):
-        """Return an iterator for the interfaces in the specification.
-        """
+        # Return an iterator for the interfaces in the specification.
         seen = {}
         for base in self.__bases__:
             for interface in base.interfaces():
@@ -264,11 +262,9 @@ class Specification(SpecificationBase):
 
 
     def extends(self, interface, strict=True):
-        """Does the specification extend the given interface?
-
-        Test whether an interface in the specification extends the
-        given interface
-        """
+        # Does the specification extend the given interface?
+        # Test whether an interface in the specification extends the
+        # given interface
         return ((interface in self._implied)
                 and
                 ((not strict) or (self != interface))
@@ -278,8 +274,7 @@ class Specification(SpecificationBase):
         return weakref.ref(self, callback)
 
     def get(self, name, default=None):
-        """Query for an attribute description
-        """
+        # Query for an attribute description.
         try:
             attrs = self._v_attrs
         except AttributeError:
@@ -373,19 +368,18 @@ class InterfaceClass(Element, InterfaceBase, Specification):
         self.__identifier__ = "%s.%s" % (self.__module__, self.__name__)
 
     def interfaces(self):
-        """Return an iterator for the interfaces in the specification.
-        """
+        # Return an iterator for the interfaces in the specification.
         yield self
 
     def getBases(self):
         return self.__bases__
 
     def isEqualOrExtendedBy(self, other):
-        """Same interface or extends?"""
+        # Same interface or extends?
         return self == other or other.extends(self)
 
     def names(self, all=False):
-        """Return the attribute names defined by the interface."""
+        # Return the attribute names defined by the interface.
         if not all:
             return self.__attrs.keys()
 
@@ -400,7 +394,7 @@ class InterfaceClass(Element, InterfaceBase, Specification):
         return iter(self.names(all=True))
 
     def namesAndDescriptions(self, all=False):
-        """Return attribute names and descriptions defined by interface."""
+        # Return attribute names and descriptions defined by interface.
         if not all:
             return self.__attrs.items()
 
@@ -413,7 +407,7 @@ class InterfaceClass(Element, InterfaceBase, Specification):
         return r.items()
 
     def getDescriptionFor(self, name):
-        """Return the attribute description for the given name."""
+        # Return the attribute description for the given name.
         r = self.get(name)
         if r is not None:
             return r
@@ -432,7 +426,7 @@ class InterfaceClass(Element, InterfaceBase, Specification):
         return self.get(name, default)
 
     def validateInvariants(self, obj, errors=None):
-        """validate object to defined invariants."""
+        # validate object to defined invariants.
         for call in self.queryTaggedValue('invariants', []):
             try:
                 call(obj)


### PR DESCRIPTION
This is part of [PloneHotfix20161129](https://plone.org/security/hotfix/20161129/unauthorized-disclosure-of-site-configuration).

This is a very minor part of it: strangely this was only needed on Plone 4.1. For the current releases 4.3 and 5.0 a different patch, targeting z3c.form widgets, was used, which somehow was not enough on 4.1.

A possible line of 'attack' (information disclosure) would be:

- You have a z3c.form on `localhost/plone/@@discussion-settings`
- That form has a widget at `/++widget++captcha`
- You can get at the Interface of this widget using `/terms/field/interface`
- And then you can access various methods, like `/setTaggedValue?tag=cake&value=lovely` and `/namesAndDescriptions`.

Core Plone has a [test](https://github.com/plone/Products.CMFPlone/blob/5.0.6/Products/CMFPlone/tests/testSecurity.py#L71-L76) for this situation. The z3c.form patch that I mentioned actually results in a 302 redirect to the login form in the above scenario. Without that, you would get a 200. With the changes of this pull request you would get a 404 NotFound.

Like I said, this pull request is not strictly needed on current Plone releases. But there may be other ways, also outside of Plone in core Zope2 or CMF, to get at the Interface through a url, which would give an attacker lots of information about the Interface.

If this pull request is accepted, I should probably port this to branches 3.6 and 3.7.