### PR TITLE
Don't redefine METH_KEYWORDS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.3.4 (unreleased)
 ------------------
 
-- TBD
+- Avoid a warning from the C compiler.
+  (https://github.com/zopefoundation/zope.interface/issues/71)
 
 4.3.3 (2016-12-13)
 ------------------

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -29,11 +29,6 @@
 #define PY3K
 #endif
 
-#ifdef PY3K
-/* See http://bugs.python.org/issue15657 */
-#define METH_KEYWORDS 0x0003
-#endif
-
 static PyObject *str__dict__, *str__implemented__, *strextends;
 static PyObject *BuiltinImplementationSpecifications, *str__provides__;
 static PyObject *str__class__, *str__providedBy__;
@@ -47,7 +42,7 @@ static PyTypeObject *Implements;
 
 static int imported_declarations = 0;
 
-static int 
+static int
 import_declarations(void)
 {
   PyObject *declarations, *i;
@@ -55,7 +50,7 @@ import_declarations(void)
   declarations = PyImport_ImportModule("zope.interface.declarations");
   if (declarations == NULL)
     return -1;
-  
+
   BuiltinImplementationSpecifications = PyObject_GetAttrString(
                     declarations, "BuiltinImplementationSpecifications");
   if (BuiltinImplementationSpecifications == NULL)
@@ -77,7 +72,7 @@ import_declarations(void)
 
   if (! PyType_Check(i))
     {
-      PyErr_SetString(PyExc_TypeError, 
+      PyErr_SetString(PyExc_TypeError,
                       "zope.interface.declarations.Implements is not a type");
       return -1;
     }
@@ -146,7 +141,7 @@ implementedBy(PyObject *ignored, PyObject *cls)
   /* Maybe we have a builtin */
   if (imported_declarations == 0 && import_declarations() < 0)
     return NULL;
-  
+
   spec = PyDict_GetItem(BuiltinImplementationSpecifications, cls);
   if (spec != NULL)
     {
@@ -190,13 +185,13 @@ static PyObject *
 providedBy(PyObject *ignored, PyObject *ob)
 {
   PyObject *result, *cls, *cp;
-  
+
   result = PyObject_GetAttr(ob, str__providedBy__);
   if (result == NULL)
     {
       PyErr_Clear();
       return getObjectSpecification(NULL, ob);
-    } 
+    }
 
 
   /* We want to make sure we have a spec. We can't do a type check
@@ -204,11 +199,11 @@ providedBy(PyObject *ignored, PyObject *ob)
      only attribute.
   */
   if (PyObject_TypeCheck(result, &SpecType)
-      || 
+      ||
       PyObject_HasAttr(result, strextends)
       )
     return result;
-    
+
   /*
     The object's class doesn't understand descriptors.
     Sigh. We need to get an object descriptor, but we have to be
@@ -223,13 +218,13 @@ providedBy(PyObject *ignored, PyObject *ob)
 
   result = PyObject_GetAttr(ob, str__provides__);
   if (result == NULL)
-    {      
+    {
       /* No __provides__, so just fall back to implementedBy */
       PyErr_Clear();
       result = implementedBy(NULL, cls);
       Py_DECREF(cls);
       return result;
-    } 
+    }
 
   cp = PyObject_GetAttr(cls, str__provides__);
   if (cp == NULL)
@@ -256,9 +251,9 @@ providedBy(PyObject *ignored, PyObject *ob)
   return result;
 }
 
-/* 
+/*
    Get an attribute from an inst dict. Return a borrowed reference.
-  
+
    This has a number of advantages:
 
    - It avoids layers of Python api
@@ -284,7 +279,7 @@ inst_attr(PyObject *self, PyObject *name)
 
 static PyObject *
 Spec_extends(PyObject *self, PyObject *other)
-{  
+{
   PyObject *implied;
 
   implied = inst_attr(self, str_implied);
@@ -304,11 +299,11 @@ Spec_extends(PyObject *self, PyObject *other)
 #endif
 }
 
-static char Spec_extends__doc__[] = 
+static char Spec_extends__doc__[] =
 "Test whether a specification is or extends another"
 ;
 
-static char Spec_providedBy__doc__[] = 
+static char Spec_providedBy__doc__[] =
 "Test whether an interface is implemented by the specification"
 ;
 
@@ -335,7 +330,7 @@ Spec_providedBy(PyObject *self, PyObject *ob)
     item = Spec_extends(decl, self);
   else
     /* decl is probably a security proxy.  We have to go the long way
-       around. 
+       around.
     */
     item = PyObject_CallFunctionObjArgs(decl, self, NULL);
 
@@ -344,7 +339,7 @@ Spec_providedBy(PyObject *self, PyObject *ob)
 }
 
 
-static char Spec_implementedBy__doc__[] = 
+static char Spec_implementedBy__doc__[] =
 "Test whether the specification is implemented by a class or factory.\n"
 "Raise TypeError if argument is neither a class nor a callable."
 ;
@@ -357,7 +352,7 @@ Spec_implementedBy(PyObject *self, PyObject *cls)
   decl = implementedBy(NULL, cls);
   if (decl == NULL)
     return NULL;
-  
+
   if (PyObject_TypeCheck(decl, &SpecType))
     item = Spec_extends(decl, self);
   else
@@ -368,10 +363,10 @@ Spec_implementedBy(PyObject *self, PyObject *cls)
 }
 
 static struct PyMethodDef Spec_methods[] = {
-	{"providedBy",  
+	{"providedBy",
          (PyCFunction)Spec_providedBy,		METH_O,
 	 Spec_providedBy__doc__},
-	{"implementedBy", 
+	{"implementedBy",
          (PyCFunction)Spec_implementedBy,	METH_O,
 	 Spec_implementedBy__doc__},
 	{"isOrExtends",	(PyCFunction)Spec_extends,	METH_O,
@@ -486,7 +481,7 @@ CPB_descr_get(PyObject *self, PyObject *inst, PyObject *cls)
       Py_XINCREF(implements);
       return implements;
     }
-  
+
   PyErr_SetObject(PyExc_AttributeError, str__provides__);
   return NULL;
 }
@@ -543,7 +538,7 @@ static PyTypeObject CPBType = {
             if adapter is not None:
                 return adapter
 
-  
+
 */
 static PyObject *
 __adapt__(PyObject *self, PyObject *obj)
@@ -572,7 +567,7 @@ __adapt__(PyObject *self, PyObject *obj)
   else
     {
       /* decl is probably a security proxy.  We have to go the long way
-         around. 
+         around.
       */
       PyObject *r;
       r = PyObject_CallFunctionObjArgs(decl, self, NULL);
@@ -620,7 +615,7 @@ static struct PyMethodDef ib_methods[] = {
   {NULL,		NULL}		/* sentinel */
 };
 
-/* 
+/*
         def __call__(self, obj, alternate=_marker):
             conform = getattr(obj, '__conform__', None)
             if conform is not None:
@@ -641,7 +636,7 @@ static PyObject *
 ib_call(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   PyObject *conform, *obj, *alternate=NULL, *adapter;
-  
+
   static char *kwlist[] = {"obj", "alternate", NULL};
 
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O", kwlist,
@@ -660,7 +655,7 @@ ib_call(PyObject *self, PyObject *args, PyObject *kwargs)
     }
   else
     PyErr_Clear();
- 
+
   adapter = __adapt__(self, obj);
   if (adapter == NULL || adapter != Py_None)
     return adapter;
@@ -758,7 +753,7 @@ lookup_traverse(lookup *self, visitproc visit, void *arg)
     if (vret != 0)
       return vret;
   }
-  
+
   return 0;
 }
 
@@ -796,7 +791,7 @@ lookup_changed(lookup *self, PyObject *ignored)
                                         if (N == NULL) return NULL; \
                                        }
 
-/*  
+/*
     def _getcache(self, provided, name):
         cache = self._cache.get(provided)
         if cache is None:
@@ -819,7 +814,7 @@ _subcache(PyObject *cache, PyObject *key)
   if (subcache == NULL)
     {
       int status;
- 
+
       subcache = PyDict_New();
       if (subcache == NULL)
         return NULL;
@@ -848,7 +843,7 @@ _getcache(lookup *self, PyObject *provided, PyObject *name)
 }
 
 
-/*  
+/*
     def lookup(self, required, provided, name=u'', default=None):
         cache = self._getcache(provided, name)
         if len(required) == 1:
@@ -879,12 +874,12 @@ tuplefy(PyObject *v)
     }
   else
     Py_INCREF(v);
-  
+
   return v;
 }
 static PyObject *
-_lookup(lookup *self, 
-        PyObject *required, PyObject *provided, PyObject *name, 
+_lookup(lookup *self,
+        PyObject *required, PyObject *provided, PyObject *name,
         PyObject *default_)
 {
   PyObject *result, *key, *cache;
@@ -945,13 +940,13 @@ lookup_lookup(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &required, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   return _lookup(self, required, provided, name, default_);
 }
 
 
-/*  
+/*
     def lookup1(self, required, provided, name=u'', default=None):
         cache = self._getcache(provided, name)
         result = cache.get(required, _not_in_mapping)
@@ -964,8 +959,8 @@ lookup_lookup(lookup *self, PyObject *args, PyObject *kwds)
         return result
 */
 static PyObject *
-_lookup1(lookup *self, 
-        PyObject *required, PyObject *provided, PyObject *name, 
+_lookup1(lookup *self,
+        PyObject *required, PyObject *provided, PyObject *name,
         PyObject *default_)
 {
   PyObject *result, *cache;
@@ -1006,12 +1001,12 @@ lookup_lookup1(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &required, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   return _lookup1(self, required, provided, name, default_);
 }
 
-/*  
+/*
     def adapter_hook(self, provided, object, name=u'', default=None):
         required = providedBy(object)
         cache = self._getcache(provided, name)
@@ -1027,8 +1022,8 @@ lookup_lookup1(lookup *self, PyObject *args, PyObject *kwds)
         return default
 */
 static PyObject *
-_adapter_hook(lookup *self, 
-              PyObject *provided, PyObject *object,  PyObject *name, 
+_adapter_hook(lookup *self,
+              PyObject *provided, PyObject *object,  PyObject *name,
               PyObject *default_)
 {
   PyObject *required, *factory, *result;
@@ -1036,12 +1031,12 @@ _adapter_hook(lookup *self,
   required = providedBy(NULL, object);
   if (required == NULL)
     return NULL;
-  
+
   factory = _lookup1(self, required, provided, name, Py_None);
   Py_DECREF(required);
   if (factory == NULL)
     return NULL;
-  
+
   if (factory != Py_None)
     {
       result = PyObject_CallFunctionObjArgs(factory, object, NULL);
@@ -1068,7 +1063,7 @@ lookup_adapter_hook(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &provided, &object, &name, &default_))
-    return NULL; 
+    return NULL;
 
   return _adapter_hook(self, provided, object, name, default_);
 }
@@ -1081,12 +1076,12 @@ lookup_queryAdapter(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &object, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   return _adapter_hook(self, provided, object, name, default_);
 }
 
-/*  
+/*
     def lookupAll(self, required, provided):
         cache = self._mcache.get(provided)
         if cache is None:
@@ -1141,7 +1136,7 @@ _lookupAll(lookup *self, PyObject *required, PyObject *provided)
       Py_DECREF(required);
     }
 
-  return result;  
+  return result;
 }
 static PyObject *
 lookup_lookupAll(lookup *self, PyObject *args, PyObject *kwds)
@@ -1151,12 +1146,12 @@ lookup_lookupAll(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist,
                                     &required, &provided))
-    return NULL; 
+    return NULL;
 
   return _lookupAll(self, required, provided);
 }
 
-/*  
+/*
     def subscriptions(self, required, provided):
         cache = self._scache.get(provided)
         if cache is None:
@@ -1212,7 +1207,7 @@ _subscriptions(lookup *self, PyObject *required, PyObject *provided)
       Py_DECREF(required);
     }
 
-  return result;  
+  return result;
 }
 static PyObject *
 lookup_subscriptions(lookup *self, PyObject *args, PyObject *kwds)
@@ -1222,19 +1217,19 @@ lookup_subscriptions(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist,
                                     &required, &provided))
-    return NULL; 
+    return NULL;
 
   return _subscriptions(self, required, provided);
 }
 
 static struct PyMethodDef lookup_methods[] = {
   {"changed",	    (PyCFunction)lookup_changed,       METH_O,        ""},
-  {"lookup",	    (PyCFunction)lookup_lookup,	       METH_KEYWORDS, ""},
-  {"lookup1",	    (PyCFunction)lookup_lookup1,       METH_KEYWORDS, ""},
-  {"queryAdapter",  (PyCFunction)lookup_queryAdapter,  METH_KEYWORDS, ""},
-  {"adapter_hook",  (PyCFunction)lookup_adapter_hook,  METH_KEYWORDS, ""},
-  {"lookupAll",	    (PyCFunction)lookup_lookupAll,     METH_KEYWORDS, ""},
-  {"subscriptions", (PyCFunction)lookup_subscriptions, METH_KEYWORDS, ""},
+  {"lookup",	    (PyCFunction)lookup_lookup,	       METH_KEYWORDS | METH_VARARGS, ""},
+  {"lookup1",	    (PyCFunction)lookup_lookup1,       METH_KEYWORDS | METH_VARARGS, ""},
+  {"queryAdapter",  (PyCFunction)lookup_queryAdapter,  METH_KEYWORDS | METH_VARARGS, ""},
+  {"adapter_hook",  (PyCFunction)lookup_adapter_hook,  METH_KEYWORDS | METH_VARARGS, ""},
+  {"lookupAll",	    (PyCFunction)lookup_lookupAll,     METH_KEYWORDS | METH_VARARGS, ""},
+  {"subscriptions", (PyCFunction)lookup_subscriptions, METH_KEYWORDS | METH_VARARGS, ""},
   {NULL,	    NULL}		/* sentinel */
 };
 
@@ -1260,7 +1255,7 @@ static PyTypeObject LookupBase = {
         /* tp_setattro       */ (setattrofunc)0,
         /* tp_as_buffer      */ 0,
         /* tp_flags          */ Py_TPFLAGS_DEFAULT
-				| Py_TPFLAGS_BASETYPE 
+				| Py_TPFLAGS_BASETYPE
                           	| Py_TPFLAGS_HAVE_GC,
 	/* tp_doc            */ "",
         /* tp_traverse       */ (traverseproc)lookup_traverse,
@@ -1291,7 +1286,7 @@ verifying_traverse(verify *self, visitproc visit, void *arg)
     if (vret != 0)
       return vret;
   }
-  
+
   return 0;
 }
 
@@ -1312,7 +1307,7 @@ verifying_dealloc(verify *self)
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
-/*  
+/*
     def changed(self, originally_changed):
         super(VerifyingBasePy, self).changed(originally_changed)
         self._verify_ro = self._registry.ro[1:]
@@ -1323,13 +1318,13 @@ _generations_tuple(PyObject *ro)
 {
   int i, l;
   PyObject *generations;
-  
+
   l = PyTuple_GET_SIZE(ro);
   generations = PyTuple_New(l);
   for (i=0; i < l; i++)
     {
       PyObject *generation;
-      
+
       generation = PyObject_GetAttr(PyTuple_GET_ITEM(ro, i), str_generation);
       if (generation == NULL)
         {
@@ -1365,7 +1360,7 @@ verifying_changed(verify *self, PyObject *ignored)
   Py_DECREF(t);
   if (ro == NULL)
     return NULL;
-  
+
   self->_verify_generations = _generations_tuple(ro);
   if (self->_verify_generations == NULL)
     {
@@ -1379,7 +1374,7 @@ verifying_changed(verify *self, PyObject *ignored)
   return Py_None;
 }
 
-/*  
+/*
     def _verify(self):
         if ([r._generation for r in self._verify_ro]
             != self._verify_generations):
@@ -1399,17 +1394,17 @@ _verify(verify *self)
       if (generations == NULL)
         return -1;
 
-      changed = PyObject_RichCompareBool(self->_verify_generations, 
+      changed = PyObject_RichCompareBool(self->_verify_generations,
 					 generations, Py_NE);
       Py_DECREF(generations);
       if (changed == -1)
         return -1;
-      
+
       if (changed == 0)
         return 0;
     }
 
-  changed_result = PyObject_CallMethodObjArgs(OBJECT(self), strchanged, 
+  changed_result = PyObject_CallMethodObjArgs(OBJECT(self), strchanged,
                                               Py_None, NULL);
   if (changed_result == NULL)
     return -1;
@@ -1426,7 +1421,7 @@ verifying_lookup(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &required, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1442,7 +1437,7 @@ verifying_lookup1(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &required, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1458,7 +1453,7 @@ verifying_adapter_hook(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &provided, &object, &name, &default_))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1474,7 +1469,7 @@ verifying_queryAdapter(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &object, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1490,7 +1485,7 @@ verifying_lookupAll(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist,
                                     &required, &provided))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1506,7 +1501,7 @@ verifying_subscriptions(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist,
                                     &required, &provided))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1516,12 +1511,12 @@ verifying_subscriptions(verify *self, PyObject *args, PyObject *kwds)
 
 static struct PyMethodDef verifying_methods[] = {
   {"changed",	   (PyCFunction)verifying_changed,	  METH_O,        ""},
-  {"lookup",	   (PyCFunction)verifying_lookup,	  METH_KEYWORDS, ""},
-  {"lookup1",	   (PyCFunction)verifying_lookup1,	  METH_KEYWORDS, ""},
-  {"queryAdapter",  (PyCFunction)verifying_queryAdapter,  METH_KEYWORDS, ""},
-  {"adapter_hook",  (PyCFunction)verifying_adapter_hook,  METH_KEYWORDS, ""},
-  {"lookupAll",	   (PyCFunction)verifying_lookupAll,	  METH_KEYWORDS, ""},
-  {"subscriptions", (PyCFunction)verifying_subscriptions, METH_KEYWORDS, ""},
+  {"lookup",	   (PyCFunction)verifying_lookup,	  METH_KEYWORDS | METH_VARARGS, ""},
+  {"lookup1",	   (PyCFunction)verifying_lookup1,	  METH_KEYWORDS | METH_VARARGS, ""},
+  {"queryAdapter",  (PyCFunction)verifying_queryAdapter,  METH_KEYWORDS | METH_VARARGS, ""},
+  {"adapter_hook",  (PyCFunction)verifying_adapter_hook,  METH_KEYWORDS | METH_VARARGS, ""},
+  {"lookupAll",	   (PyCFunction)verifying_lookupAll,	  METH_KEYWORDS | METH_VARARGS, ""},
+  {"subscriptions", (PyCFunction)verifying_subscriptions, METH_KEYWORDS | METH_VARARGS, ""},
   {NULL,	    NULL}		/* sentinel */
 };
 
@@ -1547,7 +1542,7 @@ static PyTypeObject VerifyingBase = {
         /* tp_setattro       */ (setattrofunc)0,
         /* tp_as_buffer      */ 0,
         /* tp_flags          */ Py_TPFLAGS_DEFAULT
-				| Py_TPFLAGS_BASETYPE 
+				| Py_TPFLAGS_BASETYPE
                           	| Py_TPFLAGS_HAVE_GC,
 	/* tp_doc            */ "",
         /* tp_traverse       */ (traverseproc)verifying_traverse,
@@ -1575,7 +1570,7 @@ static struct PyMethodDef m_methods[] = {
    "Get an object's interfaces (internal api)"},
   {"providedBy", (PyCFunction)providedBy, METH_O,
    "Get an object's interfaces"},
-  
+
   {NULL,	 (PyCFunction)NULL, 0, NULL}		/* sentinel */
 };
 
@@ -1630,7 +1625,7 @@ init(void)
   adapter_hooks = PyList_New(0);
   if (adapter_hooks == NULL)
     return NULL;
-        
+
   /* Initialize types: */
   SpecType.tp_new = PyBaseObject_Type.tp_new;
   if (PyType_Ready(&SpecType) < 0)
@@ -1667,7 +1662,7 @@ init(void)
   /* Add types: */
   if (PyModule_AddObject(m, "SpecificationBase", OBJECT(&SpecType)) < 0)
     return NULL;
-  if (PyModule_AddObject(m, "ObjectSpecificationDescriptor", 
+  if (PyModule_AddObject(m, "ObjectSpecificationDescriptor",
                          (PyObject *)&OSDType) < 0)
     return NULL;
   if (PyModule_AddObject(m, "ClassProvidesBase", OBJECT(&CPBType)) < 0)


### PR DESCRIPTION
Instead, use the intended METH_KEYWORDS | METH_VARARGS spelling.

Fixes #71  and avoids a complier warning on 3.6 and below.

(There are some automatic trailing whitespace removals; `?w=0` might be helpful when viewing.)