### PR TITLE
Don't cache lookup failures

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@
 3.6.8 (unreleased)
 ------------------
 
+- Don't cache lookup failures.
 
 3.6.7 (2011-08-20)
 ------------------
@@ -16,7 +17,7 @@
 
 - LP #570942:  Now correctly compare interfaces  from different modules but
   with the same names.
-  
+
   N.B.: This is a less intrusive / destabilizing fix than the one applied in
   3.6.3:  we only fix the underlying cmp-alike function, rather than adding
   the other "rich comparison" functions.
@@ -202,7 +203,7 @@ New Features
 ++++++++++++
 
 - The adapter-lookup algorithim was refactored to make it
-  much simpler and faster.  
+  much simpler and faster.
 
   Also, more of the adapter-lookup logic is implemented in C, making
   debugging of application code easier, since there is less

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -38,7 +38,7 @@ static PyTypeObject *Implements;
 
 static int imported_declarations = 0;
 
-static int 
+static int
 import_declarations(void)
 {
   PyObject *declarations, *i;
@@ -46,7 +46,7 @@ import_declarations(void)
   declarations = PyImport_ImportModule("zope.interface.declarations");
   if (declarations == NULL)
     return -1;
-  
+
   BuiltinImplementationSpecifications = PyObject_GetAttrString(
                     declarations, "BuiltinImplementationSpecifications");
   if (BuiltinImplementationSpecifications == NULL)
@@ -68,7 +68,7 @@ import_declarations(void)
 
   if (! PyType_Check(i))
     {
-      PyErr_SetString(PyExc_TypeError, 
+      PyErr_SetString(PyExc_TypeError,
                       "zope.interface.declarations.Implements is not a type");
       return -1;
     }
@@ -137,7 +137,7 @@ implementedBy(PyObject *ignored, PyObject *cls)
   /* Maybe we have a builtin */
   if (imported_declarations == 0 && import_declarations() < 0)
     return NULL;
-  
+
   spec = PyDict_GetItem(BuiltinImplementationSpecifications, cls);
   if (spec != NULL)
     {
@@ -181,13 +181,13 @@ static PyObject *
 providedBy(PyObject *ignored, PyObject *ob)
 {
   PyObject *result, *cls, *cp;
-  
+
   result = PyObject_GetAttr(ob, str__providedBy__);
   if (result == NULL)
     {
       PyErr_Clear();
       return getObjectSpecification(NULL, ob);
-    } 
+    }
 
 
   /* We want to make sure we have a spec. We can't do a type check
@@ -195,11 +195,11 @@ providedBy(PyObject *ignored, PyObject *ob)
      only attribute.
   */
   if (PyObject_TypeCheck(result, &SpecType)
-      || 
+      ||
       PyObject_HasAttr(result, strextends)
       )
     return result;
-    
+
   /*
     The object's class doesn't understand descriptors.
     Sigh. We need to get an object descriptor, but we have to be
@@ -214,13 +214,13 @@ providedBy(PyObject *ignored, PyObject *ob)
 
   result = PyObject_GetAttr(ob, str__provides__);
   if (result == NULL)
-    {      
+    {
       /* No __provides__, so just fall back to implementedBy */
       PyErr_Clear();
       result = implementedBy(NULL, cls);
       Py_DECREF(cls);
       return result;
-    } 
+    }
 
   cp = PyObject_GetAttr(cls, str__provides__);
   if (cp == NULL)
@@ -247,9 +247,9 @@ providedBy(PyObject *ignored, PyObject *ob)
   return result;
 }
 
-/* 
+/*
    Get an attribute from an inst dict. Return a borrowed reference.
-  
+
    This has a number of advantages:
 
    - It avoids layers of Python api
@@ -275,7 +275,7 @@ inst_attr(PyObject *self, PyObject *name)
 
 static PyObject *
 Spec_extends(PyObject *self, PyObject *other)
-{  
+{
   PyObject *implied;
 
   implied = inst_attr(self, str_implied);
@@ -295,11 +295,11 @@ Spec_extends(PyObject *self, PyObject *other)
 #endif
 }
 
-static char Spec_extends__doc__[] = 
+static char Spec_extends__doc__[] =
 "Test whether a specification is or extends another"
 ;
 
-static char Spec_providedBy__doc__[] = 
+static char Spec_providedBy__doc__[] =
 "Test whether an interface is implemented by the specification"
 ;
 
@@ -326,7 +326,7 @@ Spec_providedBy(PyObject *self, PyObject *ob)
     item = Spec_extends(decl, self);
   else
     /* decl is probably a security proxy.  We have to go the long way
-       around. 
+       around.
     */
     item = PyObject_CallFunctionObjArgs(decl, self, NULL);
 
@@ -335,7 +335,7 @@ Spec_providedBy(PyObject *self, PyObject *ob)
 }
 
 
-static char Spec_implementedBy__doc__[] = 
+static char Spec_implementedBy__doc__[] =
 "Test whether the specification is implemented by a class or factory.\n"
 "Raise TypeError if argument is neither a class nor a callable."
 ;
@@ -348,7 +348,7 @@ Spec_implementedBy(PyObject *self, PyObject *cls)
   decl = implementedBy(NULL, cls);
   if (decl == NULL)
     return NULL;
-  
+
   if (PyObject_TypeCheck(decl, &SpecType))
     item = Spec_extends(decl, self);
   else
@@ -359,10 +359,10 @@ Spec_implementedBy(PyObject *self, PyObject *cls)
 }
 
 static struct PyMethodDef Spec_methods[] = {
-	{"providedBy",  
+	{"providedBy",
          (PyCFunction)Spec_providedBy,		METH_O,
 	 Spec_providedBy__doc__},
-	{"implementedBy", 
+	{"implementedBy",
          (PyCFunction)Spec_implementedBy,	METH_O,
 	 Spec_implementedBy__doc__},
 	{"isOrExtends",	(PyCFunction)Spec_extends,	METH_O,
@@ -477,7 +477,7 @@ CPB_descr_get(PyObject *self, PyObject *inst, PyObject *cls)
       Py_XINCREF(implements);
       return implements;
     }
-  
+
   PyErr_SetObject(PyExc_AttributeError, str__provides__);
   return NULL;
 }
@@ -534,7 +534,7 @@ static PyTypeObject CPBType = {
             if adapter is not None:
                 return adapter
 
-  
+
 */
 static PyObject *
 __adapt__(PyObject *self, PyObject *obj)
@@ -563,7 +563,7 @@ __adapt__(PyObject *self, PyObject *obj)
   else
     {
       /* decl is probably a security proxy.  We have to go the long way
-         around. 
+         around.
       */
       PyObject *r;
       r = PyObject_CallFunctionObjArgs(decl, self, NULL);
@@ -611,7 +611,7 @@ static struct PyMethodDef ib_methods[] = {
   {NULL,		NULL}		/* sentinel */
 };
 
-/* 
+/*
         def __call__(self, obj, alternate=_marker):
             conform = getattr(obj, '__conform__', None)
             if conform is not None:
@@ -632,7 +632,7 @@ static PyObject *
 ib_call(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   PyObject *conform, *obj, *alternate=NULL, *adapter;
-  
+
   static char *kwlist[] = {"obj", "alternate", NULL};
 
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O", kwlist,
@@ -651,7 +651,7 @@ ib_call(PyObject *self, PyObject *args, PyObject *kwargs)
     }
   else
     PyErr_Clear();
- 
+
   adapter = __adapt__(self, obj);
   if (adapter == NULL || adapter != Py_None)
     return adapter;
@@ -749,7 +749,7 @@ lookup_traverse(lookup *self, visitproc visit, void *arg)
     if (vret != 0)
       return vret;
   }
-  
+
   return 0;
 }
 
@@ -787,7 +787,7 @@ lookup_changed(lookup *self, PyObject *ignored)
                                         if (N == NULL) return NULL; \
                                        }
 
-/*  
+/*
     def _getcache(self, provided, name):
         cache = self._cache.get(provided)
         if cache is None:
@@ -810,7 +810,7 @@ _subcache(PyObject *cache, PyObject *key)
   if (subcache == NULL)
     {
       int status;
- 
+
       subcache = PyDict_New();
       if (subcache == NULL)
         return NULL;
@@ -839,7 +839,7 @@ _getcache(lookup *self, PyObject *provided, PyObject *name)
 }
 
 
-/*  
+/*
     def lookup(self, required, provided, name=u'', default=None):
         cache = self._getcache(provided, name)
         if len(required) == 1:
@@ -870,12 +870,12 @@ tuplefy(PyObject *v)
     }
   else
     Py_INCREF(v);
-  
+
   return v;
 }
 static PyObject *
-_lookup(lookup *self, 
-        PyObject *required, PyObject *provided, PyObject *name, 
+_lookup(lookup *self,
+        PyObject *required, PyObject *provided, PyObject *name,
         PyObject *default_)
 {
   PyObject *result, *key, *cache;
@@ -904,6 +904,14 @@ _lookup(lookup *self,
         {
           Py_DECREF(required);
           return NULL;
+        }
+
+      if (result == Py_None && default_ != NULL)
+        {
+          /* do not cache misses because the name is not included in the cache key */
+          Py_DECREF(Py_None);
+          Py_INCREF(default_);
+          return default_;
         }
       status = PyDict_SetItem(cache, key, result);
       Py_DECREF(required);
@@ -936,13 +944,13 @@ lookup_lookup(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &required, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   return _lookup(self, required, provided, name, default_);
 }
 
 
-/*  
+/*
     def lookup1(self, required, provided, name=u'', default=None):
         cache = self._getcache(provided, name)
         result = cache.get(required, _not_in_mapping)
@@ -955,8 +963,8 @@ lookup_lookup(lookup *self, PyObject *args, PyObject *kwds)
         return result
 */
 static PyObject *
-_lookup1(lookup *self, 
-        PyObject *required, PyObject *provided, PyObject *name, 
+_lookup1(lookup *self,
+        PyObject *required, PyObject *provided, PyObject *name,
         PyObject *default_)
 {
   PyObject *result, *cache;
@@ -991,12 +999,12 @@ lookup_lookup1(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &required, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   return _lookup1(self, required, provided, name, default_);
 }
 
-/*  
+/*
     def adapter_hook(self, provided, object, name=u'', default=None):
         required = providedBy(object)
         cache = self._getcache(provided, name)
@@ -1012,8 +1020,8 @@ lookup_lookup1(lookup *self, PyObject *args, PyObject *kwds)
         return default
 */
 static PyObject *
-_adapter_hook(lookup *self, 
-              PyObject *provided, PyObject *object,  PyObject *name, 
+_adapter_hook(lookup *self,
+              PyObject *provided, PyObject *object,  PyObject *name,
               PyObject *default_)
 {
   PyObject *required, *factory, *result;
@@ -1021,12 +1029,12 @@ _adapter_hook(lookup *self,
   required = providedBy(NULL, object);
   if (required == NULL)
     return NULL;
-  
+
   factory = _lookup1(self, required, provided, name, Py_None);
   Py_DECREF(required);
   if (factory == NULL)
     return NULL;
-  
+
   if (factory != Py_None)
     {
       result = PyObject_CallFunctionObjArgs(factory, object, NULL);
@@ -1053,7 +1061,7 @@ lookup_adapter_hook(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &provided, &object, &name, &default_))
-    return NULL; 
+    return NULL;
 
   return _adapter_hook(self, provided, object, name, default_);
 }
@@ -1066,12 +1074,12 @@ lookup_queryAdapter(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &object, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   return _adapter_hook(self, provided, object, name, default_);
 }
 
-/*  
+/*
     def lookupAll(self, required, provided):
         cache = self._mcache.get(provided)
         if cache is None:
@@ -1126,7 +1134,7 @@ _lookupAll(lookup *self, PyObject *required, PyObject *provided)
       Py_DECREF(required);
     }
 
-  return result;  
+  return result;
 }
 static PyObject *
 lookup_lookupAll(lookup *self, PyObject *args, PyObject *kwds)
@@ -1136,12 +1144,12 @@ lookup_lookupAll(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist,
                                     &required, &provided))
-    return NULL; 
+    return NULL;
 
   return _lookupAll(self, required, provided);
 }
 
-/*  
+/*
     def subscriptions(self, required, provided):
         cache = self._scache.get(provided)
         if cache is None:
@@ -1197,7 +1205,7 @@ _subscriptions(lookup *self, PyObject *required, PyObject *provided)
       Py_DECREF(required);
     }
 
-  return result;  
+  return result;
 }
 static PyObject *
 lookup_subscriptions(lookup *self, PyObject *args, PyObject *kwds)
@@ -1207,7 +1215,7 @@ lookup_subscriptions(lookup *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist,
                                     &required, &provided))
-    return NULL; 
+    return NULL;
 
   return _subscriptions(self, required, provided);
 }
@@ -1245,7 +1253,7 @@ static PyTypeObject LookupBase = {
         /* tp_setattro       */ (setattrofunc)0,
         /* tp_as_buffer      */ 0,
         /* tp_flags          */ Py_TPFLAGS_DEFAULT
-				| Py_TPFLAGS_BASETYPE 
+				| Py_TPFLAGS_BASETYPE
                           	| Py_TPFLAGS_HAVE_GC,
 	/* tp_doc            */ "",
         /* tp_traverse       */ (traverseproc)lookup_traverse,
@@ -1276,7 +1284,7 @@ verifying_traverse(verify *self, visitproc visit, void *arg)
     if (vret != 0)
       return vret;
   }
-  
+
   return 0;
 }
 
@@ -1297,7 +1305,7 @@ verifying_dealloc(verify *self)
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
-/*  
+/*
     def changed(self, originally_changed):
         super(VerifyingBasePy, self).changed(originally_changed)
         self._verify_ro = self._registry.ro[1:]
@@ -1308,13 +1316,13 @@ _generations_tuple(PyObject *ro)
 {
   int i, l;
   PyObject *generations;
-  
+
   l = PyTuple_GET_SIZE(ro);
   generations = PyTuple_New(l);
   for (i=0; i < l; i++)
     {
       PyObject *generation;
-      
+
       generation = PyObject_GetAttr(PyTuple_GET_ITEM(ro, i), str_generation);
       if (generation == NULL)
         {
@@ -1350,7 +1358,7 @@ verifying_changed(verify *self, PyObject *ignored)
   Py_DECREF(t);
   if (ro == NULL)
     return NULL;
-  
+
   self->_verify_generations = _generations_tuple(ro);
   if (self->_verify_generations == NULL)
     {
@@ -1364,7 +1372,7 @@ verifying_changed(verify *self, PyObject *ignored)
   return Py_None;
 }
 
-/*  
+/*
     def _verify(self):
         if ([r._generation for r in self._verify_ro]
             != self._verify_generations):
@@ -1384,17 +1392,17 @@ _verify(verify *self)
       if (generations == NULL)
         return -1;
 
-      changed = PyObject_RichCompareBool(self->_verify_generations, 
+      changed = PyObject_RichCompareBool(self->_verify_generations,
 					 generations, Py_NE);
       Py_DECREF(generations);
       if (changed == -1)
         return -1;
-      
+
       if (changed == 0)
         return 0;
     }
 
-  changed_result = PyObject_CallMethodObjArgs(OBJECT(self), strchanged, 
+  changed_result = PyObject_CallMethodObjArgs(OBJECT(self), strchanged,
                                               Py_None, NULL);
   if (changed_result == NULL)
     return -1;
@@ -1411,7 +1419,7 @@ verifying_lookup(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &required, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1427,7 +1435,7 @@ verifying_lookup1(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &required, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1443,7 +1451,7 @@ verifying_adapter_hook(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &provided, &object, &name, &default_))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1459,7 +1467,7 @@ verifying_queryAdapter(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
                                     &object, &provided, &name, &default_))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1475,7 +1483,7 @@ verifying_lookupAll(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist,
                                     &required, &provided))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1491,7 +1499,7 @@ verifying_subscriptions(verify *self, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist,
                                     &required, &provided))
-    return NULL; 
+    return NULL;
 
   if (_verify(self) < 0)
     return NULL;
@@ -1532,7 +1540,7 @@ static PyTypeObject VerifyingBase = {
         /* tp_setattro       */ (setattrofunc)0,
         /* tp_as_buffer      */ 0,
         /* tp_flags          */ Py_TPFLAGS_DEFAULT
-				| Py_TPFLAGS_BASETYPE 
+				| Py_TPFLAGS_BASETYPE
                           	| Py_TPFLAGS_HAVE_GC,
 	/* tp_doc            */ "",
         /* tp_traverse       */ (traverseproc)verifying_traverse,
@@ -1560,7 +1568,7 @@ static struct PyMethodDef m_methods[] = {
    "Get an object's interfaces (internal api)"},
   {"providedBy", (PyCFunction)providedBy, METH_O,
    "Get an object's interfaces"},
-  
+
   {NULL,	 (PyCFunction)NULL, 0, NULL}		/* sentinel */
 };
 
@@ -1619,7 +1627,7 @@ init(void)
   adapter_hooks = PyList_New(0);
   if (adapter_hooks == NULL)
     return NULL;
-        
+
   /* Initialize types: */
   SpecType.tp_new = PyBaseObject_Type.tp_new;
   if (PyType_Ready(&SpecType) < 0)
@@ -1657,7 +1665,7 @@ init(void)
   /* Add types: */
   if (PyModule_AddObject(m, "SpecificationBase", OBJECT(&SpecType)) < 0)
     return NULL;
-  if (PyModule_AddObject(m, "ObjectSpecificationDescriptor", 
+  if (PyModule_AddObject(m, "ObjectSpecificationDescriptor",
                          (PyObject *)&OSDType) < 0)
     return NULL;
   if (PyModule_AddObject(m, "ClassProvidesBase", OBJECT(&CPBType)) < 0)

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -906,12 +906,16 @@ _lookup(lookup *self,
           return NULL;
         }
 
-      if (result == Py_None && default_ != NULL)
+      if (result == Py_None)
         {
           /* do not cache misses because the name is not included in the cache key */
+          if (default_ != NULL)
+            {
+              Py_INCREF(default_);
+              return default_;
+            }
           Py_DECREF(Py_None);
-          Py_INCREF(default_);
-          return default_;
+          return result;
         }
       status = PyDict_SetItem(cache, key, result);
       Py_DECREF(required);

--- a/src/zope/interface/adapter.py
+++ b/src/zope/interface/adapter.py
@@ -328,13 +328,12 @@ class LookupBasePy(object):
 
         if result is _not_in_mapping:
             result = self._uncached_lookup(required, provided, name)
+            if result is None:
+                return default
             if len(required) == 1:
                 cache[required[0]] = result
             else:
                 cache[tuple(required)] = result
-
-        if result is None:
-            return default
 
         return result
 

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -94,17 +94,17 @@ def test_multi_adapter_lookupAll_get_best_matches():
 def test_multi_adapter_w_default():
     """
     >>> registry = AdapterRegistry()
-    
+
     >>> registry.register([None, None], IB1, 'bob', 'A0')
 
     >>> registry.lookup((IF1, IR1), IB0, 'bob')
     'A0'
-    
+
     >>> registry.register([None, IR0], IB1, 'bob', 'A1')
 
     >>> registry.lookup((IF1, IR1), IB0, 'bob')
     'A1'
-    
+
     >>> registry.lookup((IF1, IR1), IB0, 'bruce')
 
     >>> registry.register([None, IR1], IB1, 'bob', 'A2')
@@ -192,7 +192,7 @@ def test_adapter_hook_with_factory_producing_None():
     """
     >>> registry = AdapterRegistry()
     >>> default = object()
-    
+
     >>> class Object1(object):
     ...     zope.interface.implements(IF0)
     >>> class Object2(object):
@@ -290,6 +290,18 @@ def test_changing_declarations():
     >>> zope.interface.classImplements(C, I1)
 
     >>> registry.lookup([zope.interface.implementedBy(C)], I2, '')
+    42
+    """
+
+def test_lookup_failure():
+    """
+    >>> registry = AdapterRegistry()
+    >>> registry.register((), IF0, '', 42)
+    >>> def subsequent_lookup():
+    ...     print registry.lookup((), IF0, None)
+    ...     print registry.lookup((), IF0)
+    >>> subsequent_lookup()
+    None
     42
     """
 


### PR DESCRIPTION
`z.i.adapter.LookupBase._getcache` will only use the `name` argument as a cache key if `name` evaluates to True (https://github.com/zopefoundation/zope.interface/blob/3.6/src/zope/interface/adapter.py#L314). If a client uses a name that evaluates to False (in addition to the correct interface) to lookup an unnamed utility, the utility is not found, but the default marker ends up in the cache and calls to `lookup` will subsequently return it even as a result of correct queries (i.e. queries with no name provided, `name` then evaluates to the default u'') even though the utility exists and could be found using `_uncached_lookup()`.

Example:
https://github.com/eea/eea.facetednavigation/commit/92390c6a9b0f1d3bf748a565d9c4a1f743c02694#diff-baadd81b5599e2f44501742288141f51L247

Here, `queryUtility(ISolrSearch, name=None)` is used to lookup collective.solr's (unnamed) Search utility. The lookup fails, but the result of the query nevertheless gets cached. As a consequence subsequent (correct) queries using `queryUtility(ISolrSearch)` (without the name) will return the default marker.

Suggestion: Do not cache lookup failures. An alternative would be to fix the condition to use a broader range of names as cache key in LookupBase._getcache().