### PR TITLE
Fix sentence in README

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -218,7 +218,7 @@ Of course, ``Foo`` doesn't *provide* ``IFoo``, it *implements* it:
   >>> IFoo.providedBy(Foo)
   False
 
-We can also ask what interfaces are implemented by an object:
+We can also ask what interfaces are implemented by a class:
 
 .. doctest::
 


### PR DESCRIPTION
Classes (factories) _implement_, objects _provide_. After first carefully explaining the difference, the docs mix them up.