### PR TITLE
Added Travis, appveyor, and tox for 3.6 branch.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    class I[A-Z]\w+\((Interface|I[A-Z].*)\):

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+*.egg-info
+*.pyc
+*.so
+__pycache__
+.coverage
+.installed.cfg
+nosetests.xml
+coverage.xml
+.eggs/
+.tox/
+bin/
+build/
+eggs/
+develop-eggs/
+docs/_build/
+parts/

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    if [[ "${PYBIN}" == *"cp27"* ]]; then
+        "${PYBIN}/pip" install -e /io/
+        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+    fi
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/zope.interface*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done

--- a/.manylinux.sh
+++ b/.manylinux.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+docker pull $DOCKER_IMAGE
+
+docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/.manylinux-install.sh
+
+pip install twine && twine upload -u zope.wheelbuilder -p $PYPIPASSWORD wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+language: python
+sudo: false
+matrix:
+    include:
+        - os: linux
+          python: 2.7
+        # It's important to use 'macpython' builds to get the least
+        # restrictive wheel tag. It's also important to avoid
+        # 'homebrew 3' because it floats instead of being a specific version.
+        - os: osx
+          language: generic
+          env: TERRYFY_PYTHON='macpython 2.7'
+        - services:
+            - docker
+          env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+          before_install:
+            - if [[ $TRAVIS_TAG ]]; then bash .manylinux.sh; fi
+            - exit 0
+        - services:
+            - docker
+          env:
+            - DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+            - PRE_CMD=linux32
+          before_install:
+            - if [[ $TRAVIS_TAG ]]; then bash .manylinux.sh; fi
+            - exit 0
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then get_python_environment $TERRYFY_PYTHON venv; fi
+install:
+    - pip install -e .
+script:
+    - python setup.py test -q
+notifications:
+    email: false
+after_success:
+    - echo [distutils]                                  > ~/.pypirc
+    - echo index-servers = pypi                        >> ~/.pypirc
+    - echo [pypi]                                      >> ~/.pypirc
+    - echo repository=https://pypi.python.org/pypi     >> ~/.pypirc
+    - echo username=zope.wheelbuilder                  >> ~/.pypirc
+    - echo password=$PYPIPASSWORD                      >> ~/.pypirc
+    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then pip install twine; fi
+    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then python setup.py bdist_wheel; fi
+    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then twine upload dist/*; fi
+
+env:
+    global:
+        secure: "CeOq8/6F8IlbRpKEk2z3RPD/q5cBCPXGOUgjYryG/c+7P6SCTxaTKfxiJPqT3sGgO8x/HcJVuvZghyqCPvysk3cbnq4SiMtI1S0hS/N3DFsGZHn25YQBipAYjA4YDUb6GqCpsSUIXdbGMEzG7DOSB6c+49+//wkjbBFHmPNWvMQ="

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,19 @@
+include *.rst
+include *.txt
+include *.py
+include .coveragerc
+include build.cmd
+include buildout.cfg
+include tox.ini
+
+recursive-include docs *
+recursive-include src *
+
+global-exclude *.dll
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude *.so
+global-exclude coverage.xml
+global-exclude appveyor.yml
+
+prune docs/_build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+environment:
+  global:
+    TWINE_USERNAME: zope.wheelbuilder
+    TWINE_PASSWORD:
+      secure: UcdTh6W78cRLVGfKRFoa5A==
+
+  matrix:
+    - python: 27
+    - python: 27-x64
+
+install:
+  - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
+  - pip install -e .
+
+build_script:
+  - pip install wheel
+  - python -W ignore setup.py -q bdist_wheel
+
+test_script:
+  - python setup.py test -q
+
+artifacts:
+  - path: 'dist\*.whl'
+    name: wheel
+
+deploy_script:
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { pip install twine; twine upload dist/* }
+
+deploy: on

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ try: # Zope setuptools versions
 
 except (ImportError, SyntaxError):
     from build_ext_2 import optional_build_ext
-    
+
 setup(name='zope.interface',
       version='3.6.8',
       url='http://pypi.python.org/pypi/zope.interface',
@@ -114,10 +114,12 @@ setup(name='zope.interface',
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Zope Public License",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.4",
         "Programming Language :: Python :: 2.5",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Libraries :: Python Modules",
       ],
 

--- a/src/zope/interface/tests/test_odd_declarations.py
+++ b/src/zope/interface/tests/test_odd_declarations.py
@@ -179,17 +179,6 @@ class Test(unittest.TestCase):
     def test_directlyProvides_fails_for_odd_class(self):
         self.assertRaises(TypeError, directlyProvides, C, I5)
 
-    # see above
-    def TODO_test_classProvides_fails_for_odd_class(self):
-        try:
-            class A(Odd):
-                classProvides(I1)
-        except TypeError:
-            pass # Sucess
-        self.assert_(False,
-                     "Shouldn't be able to use directlyProvides on odd class."
-                     )
-
     def test_implementedBy(self):
         class I2(I1): pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,31 @@
+[tox]
+envlist =
+    py27,py27-pure,coverage
+
+[testenv]
+commands =
+    python setup.py -q test -q
+deps =
+    zope.event
+
+[testenv:py27-pure]
+setenv =
+    PURE_PYTHON=1
+    PIP_CACHE_DIR = {envdir}/.cache
+
+[testenv:py]
+commands =
+    python --version
+    {[testenv]commands}
+
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python2.7
+commands =
+    nosetests --with-xunit --with-xcoverage
+deps =
+    {[testenv]deps}
+    nose
+    coverage
+    nosexcover


### PR DESCRIPTION
Copied from master branch, but removed the Python 3 stuff, which is unsupported on the 3.6 branch. Well, 3.1 seems supported, but that is very old, and on 3.3 I got errors locally.

Also removed 'docs' from the tox envs, as that proved tricky to get to work, and has changed much.

Removed `TODO_test_classProvides_fails_for_odd_class` test method, which would always fail but be ignored due to its name, except that the coverage tests would *not* ignore it, leading to a failure.