### PR TITLE
Disallow non-text name passed to adapter registry methods.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@
 3.6.8 (unreleased)
 ------------------
 
+- Raise ``ValueError`` when non-text names are passed to adapter registry
+  methods:  prevents corruption of lookup caches.
 
 3.6.7 (2011-08-20)
 ------------------

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -880,6 +880,12 @@ _lookup(lookup *self,
 {
   PyObject *result, *key, *cache;
 
+  if ( name && !PyString_Check(name) && !PyUnicode_Check(name) )
+  {
+    PyErr_SetString(PyExc_ValueError,
+                    "name is not a string or unicode");
+    return NULL;
+  }
   cache = _getcache(self, provided, name);
   if (cache == NULL)
     return NULL;
@@ -961,6 +967,13 @@ _lookup1(lookup *self,
 {
   PyObject *result, *cache;
 
+  if ( name && !PyString_Check(name) && !PyUnicode_Check(name) )
+  {
+    PyErr_SetString(PyExc_ValueError,
+                    "name is not a string or unicode");
+    return NULL;
+  }
+
   cache = _getcache(self, provided, name);
   if (cache == NULL)
     return NULL;
@@ -1017,6 +1030,13 @@ _adapter_hook(lookup *self,
               PyObject *default_)
 {
   PyObject *required, *factory, *result;
+
+  if ( name && !PyString_Check(name) && !PyUnicode_Check(name) )
+  {
+    PyErr_SetString(PyExc_ValueError,
+                    "name is not a string or unicode");
+    return NULL;
+  }
 
   required = providedBy(NULL, object);
   if (required == NULL)

--- a/src/zope/interface/adapter.py
+++ b/src/zope/interface/adapter.py
@@ -97,6 +97,8 @@ class BaseAdapterRegistry(object):
         self._v_lookup.changed(originally_changed)
 
     def register(self, required, provided, name, value):
+        if not isinstance(name, basestring):
+            raise ValueError('name is not text')
         if value is None:
             self.unregister(required, provided, name, value)
             return
@@ -320,6 +322,8 @@ class LookupBasePy(object):
         return cache
 
     def lookup(self, required, provided, name=u'', default=None):
+        if not isinstance(name, basestring):
+            raise ValueError('name is not text')
         cache = self._getcache(provided, name)
         if len(required) == 1:
             result = cache.get(required[0], _not_in_mapping)
@@ -339,6 +343,8 @@ class LookupBasePy(object):
         return result
 
     def lookup1(self, required, provided, name=u'', default=None):
+        if not isinstance(name, basestring):
+            raise ValueError('name is not text')
         cache = self._getcache(provided, name)
         result = cache.get(required, _not_in_mapping)
         if result is _not_in_mapping:
@@ -353,6 +359,8 @@ class LookupBasePy(object):
         return self.adapter_hook(provided, object, name, default)
 
     def adapter_hook(self, provided, object, name=u'', default=None):
+        if not isinstance(name, basestring):
+            raise ValueError('name is not text')
         required = providedBy(object)
         cache = self._getcache(provided, name)
         factory = cache.get(required, _not_in_mapping)

--- a/src/zope/interface/interfaces.py
+++ b/src/zope/interface/interfaces.py
@@ -675,11 +675,13 @@ class IAdapterRegistry(Interface):
         """Register a value
 
         A value is registered for a *sequence* of required specifications, a
-        provided interface, and a name.
+        provided interface, and a name, which must be text.
         """
 
     def registered(required, provided, name=u''):
         """Return the component registered for the given interfaces and name
+
+        name must be text.
 
         Unlike the lookup method, this methods won't retrieve
         components registered for more specific required interfaces or
@@ -694,7 +696,8 @@ class IAdapterRegistry(Interface):
         """Lookup a value
 
         A value is looked up based on a *sequence* of required
-        specifications, a provided interface, and a name.
+        specifications, a provided interface, and a name, which must be
+        text.
         """
 
     def queryMultiAdapter(objects, provided, name=u'', default=None):
@@ -705,7 +708,8 @@ class IAdapterRegistry(Interface):
         """Lookup a value using a single required interface
 
         A value is looked up based on a single required
-        specifications, a provided interface, and a name.
+        specifications, a provided interface, and a name, which must be
+        text.
         """
 
     def queryAdapter(object, provided, name=u'', default=None):
@@ -714,6 +718,8 @@ class IAdapterRegistry(Interface):
 
     def adapter_hook(provided, object, name=u'', default=None):
         """Adapt an object using a registered adapter factory.
+
+        name must be text.
         """
 
     def lookupAll(required, provided):

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -134,6 +134,11 @@ def test_named_adapter_with_default():
     If we ask for a named adapter, we won't get a result unless there
     is a named adapter, even if the object implements the interface:
 
+    >>> registry.lookup([IF1], IF0, None) #doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    ValueError: name...
+
     >>> registry.lookup([IF1], IF0, 'bob')
 
     >>> registry.register([None], IB1, 'bob', 'A1')


### PR DESCRIPTION
Prevents corruption of lookup cache.

Alternative to fix proposed in #75 (3.6 branch).