### PR TITLE
Simply the caching of utility-registration data. In addition to

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changes
 4.4.1 (unreleased)
 ------------------
 
+- Simply the caching of utility-registration data. In addition to
+  simplification, avoids spurious test failures when checking for
+  leaks in tests with persistent registries.
+
 - Raise ``ValueError`` when non-text names are passed to adapter registry
   methods:  prevents corruption of lookup caches.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.4.1 (unreleased)
 ------------------
 
-- Simply the caching of utility-registration data. In addition to
+- Simplify the caching of utility-registration data. In addition to
   simplification, avoids spurious test failures when checking for
   leaks in tests with persistent registries.
 

--- a/src/zope/interface/registry.py
+++ b/src/zope/interface/registry.py
@@ -145,6 +145,9 @@ class Components(object):
         self._init_registrations()
         self.__bases__ = tuple(bases)
 
+        # __init__ is used for test cleanup as well as initialization.
+        # XXX add a separate API for test cleanup.
+        # See _utility_registrations below.
         if hasattr(self, '_v_utility_registrations_cache'):
             del self._v_utility_registrations_cache
 
@@ -163,6 +166,10 @@ class Components(object):
 
     @property
     def _utility_registrations_cache(self):
+        # We use a _v_ attribute internally so that data aren't saved in ZODB.
+        # If data are pickled in other contexts, the data will be carried along.
+        # There's no harm in pickling the extra data othr than that it would
+        # be somewhat wasteful. It's doubtful that that's an issue anyway.
         try:
             return self._v_utility_registrations_cache
         except AttributeError:

--- a/src/zope/interface/tests/test_registry.py
+++ b/src/zope/interface/tests/test_registry.py
@@ -554,8 +554,6 @@ class ComponentsTests(unittest.TestCase):
         comp.registerUtility(_to_reg, ifoo, _name1, _info)
         comp.registerUtility(_to_reg, ifoo, _name2, _info)
 
-        _UtilityRegistrations.clear_cache()
-
         _monkey, _events = self._wrapEvents()
         with _monkey:
             comp.unregisterUtility(_to_reg, ifoo, _name2)


### PR DESCRIPTION
simplification, avoids spurious test failures when checking for
leaks in tests with persistent registries.

This fixes #83 