### PR TITLE
Test sanity cleanups

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+[run]
+source = zope.interface
+
 [report]
 show_missing = true
 exclude_lines =

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ eggs/
 develop-eggs/
 docs/_build/
 parts/
+htmlcov/

--- a/src/zope/interface/_compat.py
+++ b/src/zope/interface/_compat.py
@@ -31,7 +31,7 @@ if sys.version_info[0] < 3: #pragma NO COVER
     PYTHON3 = False
     PYTHON2 = True
 
-else: #pragma NO COVER
+else: # pragma: no cover
 
     def _normalize_name(name):
         if isinstance(name, bytes):
@@ -48,16 +48,11 @@ else: #pragma NO COVER
     PYTHON3 = True
     PYTHON2 = False
 
-def _skip_under_py3k(test_method): #pragma NO COVER
-    if sys.version_info[0] < 3:
-        return test_method
-    def _dummy(*args):
-        pass
-    return _dummy
+def _skip_under_py3k(test_method): # pragma: no cover
+    import unittest
+    return unittest.skipIf(sys.version_info[0] >= 3, "Only on Python 2")(test_method)
 
-def _skip_under_py2(test_method): #pragma NO COVER
-    if sys.version_info[0] > 2:
-        return test_method
-    def _dummy(*args):
-        pass
-    return _dummy
+
+def _skip_under_py2(test_method): # pragma: no cover
+    import unittest
+    return unittest.skipIf(sys.version_info[0] < 3, "Only on Python 3")(test_method)

--- a/src/zope/interface/common/tests/test_idatetime.py
+++ b/src/zope/interface/common/tests/test_idatetime.py
@@ -38,9 +38,7 @@ class TestDateTimeInterfaces(unittest.TestCase):
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestDateTimeInterfaces))
-    return suite
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
 
 
 if __name__ == '__main__':

--- a/src/zope/interface/common/tests/test_idatetime.py
+++ b/src/zope/interface/common/tests/test_idatetime.py
@@ -35,11 +35,3 @@ class TestDateTimeInterfaces(unittest.TestCase):
         verifyClass(IDateClass, date)
         verifyClass(IDateTimeClass, datetime)
         verifyClass(ITimeClass, time)
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/src/zope/interface/common/tests/test_import_interfaces.py
+++ b/src/zope/interface/common/tests/test_import_interfaces.py
@@ -11,19 +11,16 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-import doctest
 import unittest
 
-def test_interface_import():
-    """
-    >>> import zope.interface.common.interfaces
-    """
+class TestInterfaceImport(unittest.TestCase):
+
+    def test_import(self):
+        import zope.interface.common.interfaces as x
+        self.assertIsNotNone(x)
 
 def test_suite():
-    return unittest.TestSuite((
-        doctest.DocTestSuite(),
-        ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')
-

--- a/src/zope/interface/common/tests/test_import_interfaces.py
+++ b/src/zope/interface/common/tests/test_import_interfaces.py
@@ -18,9 +18,3 @@ class TestInterfaceImport(unittest.TestCase):
     def test_import(self):
         import zope.interface.common.interfaces as x
         self.assertIsNotNone(x)
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')

--- a/src/zope/interface/tests/__init__.py
+++ b/src/zope/interface/tests/__init__.py
@@ -1,13 +1,1 @@
-import os
-import unittest
-
-def additional_tests():
-    suites = unittest.TestSuite()
-    for file in os.listdir(os.path.dirname(__file__)):
-        if file.endswith('.py') and file!='__init__.py':
-            name = os.path.splitext(file)[0]
-            module = __import__('.'.join((__name__, name)), globals(), 
-                                locals(), [name])
-            if hasattr(module, 'test_suite'):
-                suites.addTests(module.test_suite())
-    return suites
+# Make this directory a package.

--- a/src/zope/interface/tests/odd.py
+++ b/src/zope/interface/tests/odd.py
@@ -77,7 +77,6 @@ class MetaMetaClass(type):
 class MetaClass(object):
     """Odd classes
     """
-    __metaclass__ = MetaMetaClass
 
     def __init__(self, name, bases, dict):
         self.__name__ = name
@@ -96,6 +95,12 @@ class MetaClass(object):
 
     def __repr__(self):
         return "<odd class %s at %s>" % (self.__name__, hex(id(self)))
+
+
+MetaClass = MetaMetaClass('MetaClass',
+                          MetaClass.__bases__,
+                          {k: v for k, v in MetaClass.__dict__.items()
+                          if k not in ('__dict__',)})
 
 class OddInstance(object):
 

--- a/src/zope/interface/tests/odd.py
+++ b/src/zope/interface/tests/odd.py
@@ -59,7 +59,7 @@ This is used for testing support for ExtensionClass in new interfaces.
   >>> if sys.version[0] == '2': # This test only makes sense under Python 2.x
   ...     from types import ClassType
   ...     assert not isinstance(C, (type, ClassType))
-  
+
   >>> int(C.__class__.__class__ is C.__class__)
   1
 """
@@ -72,7 +72,7 @@ class MetaMetaClass(type):
         if name == '__class__':
             return self
         return type.__getattribute__(self, name)
-    
+
 
 class MetaClass(object):
     """Odd classes
@@ -120,7 +120,7 @@ class OddInstance(object):
     def __repr__(self):
         return "<odd %s instance at %s>" % (
             self.__class__.__name__, hex(id(self)))
-        
+
 
 
 # DocTest:

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -1411,7 +1411,3 @@ class Test_utils(unittest.TestCase):
 
     # _lookup, _lookupAll, and _subscriptions tested via their callers
     # (AdapterLookupBase.{lookup,lookupAll,subscriptions}).
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -1400,7 +1400,7 @@ class Test_utils(unittest.TestCase):
 
     def test__normalize_name_unicode(self):
         from zope.interface.adapter import _normalize_name
-        
+
         USTR = u'ustr'
         self.assertEqual(_normalize_name(USTR), USTR)
 
@@ -1414,13 +1414,4 @@ class Test_utils(unittest.TestCase):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(BaseAdapterRegistryTests),
-        unittest.makeSuite(LookupBaseFallbackTests),
-        unittest.makeSuite(LookupBaseTests),
-        unittest.makeSuite(VerifyingBaseFallbackTests),
-        unittest.makeSuite(VerifyingBaseTests),
-        unittest.makeSuite(AdapterLookupBaseTests),
-        unittest.makeSuite(AdapterRegistryTests),
-        unittest.makeSuite(Test_utils),
-        ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_advice.py
+++ b/src/zope/interface/tests/test_advice.py
@@ -376,10 +376,4 @@ class Test_minimalBases(unittest.TestCase):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(FrameInfoTest),
-        unittest.makeSuite(AdviceTests),
-        unittest.makeSuite(Test_isClassAdvisor),
-        unittest.makeSuite(Test_determineMetaclass),
-        unittest.makeSuite(Test_minimalBases),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_advice.py
+++ b/src/zope/interface/tests/test_advice.py
@@ -372,8 +372,3 @@ class Test_minimalBases(unittest.TestCase):
         class B(object):
             pass
         self.assertEqual(self._callFUT([A, B, A]), [B, A])
-
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -1677,33 +1677,4 @@ class _MonkeyDict(object):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(DeclarationTests),
-        unittest.makeSuite(TestImplements),
-        unittest.makeSuite(Test_implementedByFallback),
-        unittest.makeSuite(Test_implementedBy),
-        unittest.makeSuite(Test_classImplementsOnly),
-        unittest.makeSuite(Test_classImplements),
-        unittest.makeSuite(Test__implements_advice),
-        unittest.makeSuite(Test_implementer),
-        unittest.makeSuite(Test_implementer_only),
-        unittest.makeSuite(Test_implements),
-        unittest.makeSuite(Test_implementsOnly),
-        unittest.makeSuite(ProvidesClassTests),
-        unittest.makeSuite(Test_Provides),
-        unittest.makeSuite(Test_directlyProvides),
-        unittest.makeSuite(Test_alsoProvides),
-        unittest.makeSuite(Test_noLongerProvides),
-        unittest.makeSuite(ClassProvidesBaseFallbackTests),
-        unittest.makeSuite(ClassProvidesTests),
-        unittest.makeSuite(Test_directlyProvidedBy),
-        unittest.makeSuite(Test_classProvides),
-        unittest.makeSuite(Test_provider),
-        unittest.makeSuite(Test_moduleProvides),
-        unittest.makeSuite(Test_getObjectSpecificationFallback),
-        unittest.makeSuite(Test_getObjectSpecification),
-        unittest.makeSuite(Test_providedByFallback),
-        unittest.makeSuite(Test_providedBy),
-        unittest.makeSuite(ObjectSpecificationDescriptorFallbackTests),
-        unittest.makeSuite(ObjectSpecificationDescriptorTests),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -1674,7 +1674,3 @@ class _MonkeyDict(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.target.clear()
         self.target.update(self.to_restore)
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_document.py
+++ b/src/zope/interface/tests/test_document.py
@@ -505,8 +505,4 @@ class Test__justify_and_indent(unittest.TestCase):
         self.assertEqual(self._callFUT(TEXT, 1, munge=1, width=15), EXPECTED)
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(Test_asStructuredText),
-        unittest.makeSuite(Test_asReStructuredText),
-        unittest.makeSuite(Test__justify_and_indent),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_document.py
+++ b/src/zope/interface/tests/test_document.py
@@ -503,6 +503,3 @@ class Test__justify_and_indent(unittest.TestCase):
                     "  multiple lines.\n"
                     " ")
         self.assertEqual(self._callFUT(TEXT, 1, munge=1, width=15), EXPECTED)
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_element.py
+++ b/src/zope/interface/tests/test_element.py
@@ -29,11 +29,3 @@ class TestElement(unittest.TestCase):
         e2.setTaggedValue("x", 2)
         self.assertEqual(e1.getTaggedValue("x"), 1)
         self.assertEqual(e2.getTaggedValue("x"), 2)
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')

--- a/src/zope/interface/tests/test_element.py
+++ b/src/zope/interface/tests/test_element.py
@@ -22,7 +22,7 @@ class TestElement(unittest.TestCase):
     def test_taggedValues(self):
         """Test that we can update tagged values of more than one element
         """
-        
+
         e1 = Element("foo")
         e2 = Element("bar")
         e1.setTaggedValue("x", 1)
@@ -32,9 +32,7 @@ class TestElement(unittest.TestCase):
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestElement))
-    return suite
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
 
 
 if __name__ == '__main__':

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -13,7 +13,6 @@
 ##############################################################################
 """Test Interface implementation
 """
-import doctest
 import unittest
 
 _marker = object()
@@ -2114,10 +2113,3 @@ class _Monkey(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         for key, value in self.to_restore.items():
             setattr(self.module, key, value)
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.defaultTestLoader.loadTestsFromName(__name__),
-        doctest.DocTestSuite("zope.interface.interface"),
-    ))

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """Test Interface implementation
 """
+import doctest
 import unittest
 
 _marker = object()
@@ -184,24 +185,24 @@ class SpecificationBasePyTests(unittest.TestCase):
 
     def test_isOrExtends_miss(self):
         sb = self._makeOne()
-        sb._implied = {}  # not defined by SpecificationBasePy 
+        sb._implied = {}  # not defined by SpecificationBasePy
         self.assertFalse(sb.isOrExtends(object()))
 
     def test_isOrExtends_hit(self):
         sb = self._makeOne()
         testing = object()
-        sb._implied = {testing: {}}  # not defined by SpecificationBasePy 
+        sb._implied = {testing: {}}  # not defined by SpecificationBasePy
         self.assertTrue(sb(testing))
 
     def test___call___miss(self):
         sb = self._makeOne()
-        sb._implied = {}  # not defined by SpecificationBasePy 
+        sb._implied = {}  # not defined by SpecificationBasePy
         self.assertFalse(sb.isOrExtends(object()))
 
     def test___call___hit(self):
         sb = self._makeOne()
         testing = object()
-        sb._implied = {testing: {}}  # not defined by SpecificationBasePy 
+        sb._implied = {testing: {}}  # not defined by SpecificationBasePy
         self.assertTrue(sb(testing))
 
 
@@ -836,7 +837,7 @@ class InterfaceClassTests(unittest.TestCase):
                 pass # Don't call base class.
         derived = Derived()
         with catch_warnings(record=True) as warned:
-            warnings.simplefilter('always') # see LP #825249 
+            warnings.simplefilter('always') # see LP #825249
             self.assertEqual(hash(derived), 1)
             self.assertEqual(len(warned), 1)
             self.assertTrue(warned[0].category is UserWarning)
@@ -1086,7 +1087,7 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface import Interface
         from zope.interface.verify import verifyClass
-        
+
 
         class ICheckMe(Interface):
             attr = Attribute(u'My attr')
@@ -1107,7 +1108,7 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface import Interface
         from zope.interface.verify import verifyObject
-        
+
 
         class ICheckMe(Interface):
             attr = Attribute(u'My attr')
@@ -1137,7 +1138,7 @@ class InterfaceTests(unittest.TestCase):
     def test_names_simple(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        
+
 
         class ISimple(Interface):
             attr = Attribute(u'My attr')
@@ -1150,7 +1151,7 @@ class InterfaceTests(unittest.TestCase):
     def test_names_derived(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        
+
 
         class IBase(Interface):
             attr = Attribute(u'My attr')
@@ -1176,7 +1177,7 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        
+
 
         class ISimple(Interface):
             attr = Attribute(u'My attr')
@@ -1200,7 +1201,7 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface import Interface
         from zope.interface.interface import Method
-        
+
 
         class IBase(Interface):
             attr = Attribute(u'My attr')
@@ -1265,7 +1266,7 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        
+
 
         class ISimple(Interface):
             attr = Attribute(u'My attr')
@@ -1287,7 +1288,7 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        
+
 
         class IBase(Interface):
             attr = Attribute(u'My attr')
@@ -1336,7 +1337,7 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        
+
 
         class ISimple(Interface):
             attr = Attribute(u'My attr')
@@ -1358,7 +1359,7 @@ class InterfaceTests(unittest.TestCase):
         from zope.interface import Attribute
         from zope.interface.interface import Method
         from zope.interface import Interface
-        
+
 
         class IBase(Interface):
             attr = Attribute(u'My attr')
@@ -1406,7 +1407,7 @@ class InterfaceTests(unittest.TestCase):
     def test___contains__simple(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        
+
 
         class ISimple(Interface):
             attr = Attribute(u'My attr')
@@ -1420,7 +1421,7 @@ class InterfaceTests(unittest.TestCase):
     def test___contains__derived(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        
+
 
         class IBase(Interface):
             attr = Attribute(u'My attr')
@@ -1453,7 +1454,7 @@ class InterfaceTests(unittest.TestCase):
     def test___iter__simple(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        
+
 
         class ISimple(Interface):
             attr = Attribute(u'My attr')
@@ -1466,7 +1467,7 @@ class InterfaceTests(unittest.TestCase):
     def test___iter__derived(self):
         from zope.interface import Attribute
         from zope.interface import Interface
-        
+
 
         class IBase(Interface):
             attr = Attribute(u'My attr')
@@ -1707,7 +1708,7 @@ class InterfaceTests(unittest.TestCase):
         class IRange(Interface):
             min = Attribute("Lower bound")
             max = Attribute("Upper bound")
-            
+
             @invariant
             def range_invariant(ob):
                 if ob.max < ob.min:
@@ -2086,8 +2087,8 @@ def _barGreaterThanFoo(obj):
     foo = getattr(obj, 'foo', None)
     bar = getattr(obj, 'bar', None)
     if foo is not None and isinstance(foo, type(bar)):
-        # type checking should be handled elsewhere (like, say, 
-        # schema); these invariants should be intra-interface 
+        # type checking should be handled elsewhere (like, say,
+        # schema); these invariants should be intra-interface
         # constraints.  This is a hacky way to do it, maybe, but you
         # get the idea
         if not bar > foo:
@@ -2116,17 +2117,7 @@ class _Monkey(object):
 
 
 def test_suite():
-    import doctest
     return unittest.TestSuite((
-        unittest.makeSuite(ElementTests),
-        unittest.makeSuite(SpecificationBasePyTests),
-        unittest.makeSuite(InterfaceBasePyTests),
-        unittest.makeSuite(SpecificationTests),
-        unittest.makeSuite(InterfaceTests),
-        unittest.makeSuite(AttributeTests),
-        unittest.makeSuite(MethodTests),
-        unittest.makeSuite(Test_fromFunction),
-        #unittest.makeSuite(Test_fromMethod),
-        doctest.DocTestSuite(),
+        unittest.defaultTestLoader.loadTestsFromName(__name__),
         doctest.DocTestSuite("zope.interface.interface"),
     ))

--- a/src/zope/interface/tests/test_interfaces.py
+++ b/src/zope/interface/tests/test_interfaces.py
@@ -93,7 +93,3 @@ class UnregisteredTests(unittest.TestCase,
         from zope.interface.interfaces import IUnregistered
         from zope.interface.verify import verifyObject
         verifyObject(IUnregistered, self._makeOne())
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_interfaces.py
+++ b/src/zope/interface/tests/test_interfaces.py
@@ -96,9 +96,4 @@ class UnregisteredTests(unittest.TestCase,
 
 
 def test_suite():
-    return unittest.TestSuite((
-            unittest.makeSuite(ObjectEventTests),
-            unittest.makeSuite(RegistrationEventTests),
-            unittest.makeSuite(RegisteredTests),
-            unittest.makeSuite(UnregisteredTests),
-        ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_odd_declarations.py
+++ b/src/zope/interface/tests/test_odd_declarations.py
@@ -214,7 +214,7 @@ class Test(unittest.TestCase):
 
 def test_suite():
     import doctest
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(Test))
-    suite.addTest(doctest.DocTestSuite(odd))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromName(__name__),
+        doctest.DocTestSuite(odd),
+    ))

--- a/src/zope/interface/tests/test_odd_declarations.py
+++ b/src/zope/interface/tests/test_odd_declarations.py
@@ -212,9 +212,51 @@ class Test(unittest.TestCase):
         self.assertEqual([i.getName() for i in implementedBy(C2)],
                          ['I3', 'I2'])
 
-def test_suite():
-    import doctest
-    return unittest.TestSuite((
-        unittest.defaultTestLoader.loadTestsFromName(__name__),
-        doctest.DocTestSuite(odd),
-    ))
+    def test_odd_metaclass_that_doesnt_subclass_type(self):
+        # This was originally a doctest in odd.py.
+        # It verifies that the metaclass the rest of these tests use
+        # works as expected.
+
+        # This is used for testing support for ExtensionClass in new interfaces.
+
+        class A(object):
+            a = 1
+
+        A = odd.MetaClass('A', A.__bases__, A.__dict__)
+
+        class B(object):
+            b = 1
+
+        B = odd.MetaClass('B', B.__bases__, B.__dict__)
+
+        class C(A, B):
+            pass
+
+        self.assertEqual(C.__bases__, (A, B))
+
+        a = A()
+        aa = A()
+        self.assertEqual(a.a, 1)
+        self.assertEqual(aa.a, 1)
+
+        aa.a = 2
+        self.assertEqual(a.a, 1)
+        self.assertEqual(aa.a, 2)
+
+        c = C()
+        self.assertEqual(c.a, 1)
+        self.assertEqual(c.b, 1)
+
+        c.b = 2
+        self.assertEqual(c.b, 2)
+
+        C.c = 1
+        self.assertEqual(c.c, 1)
+        c.c
+
+        import sys
+        if sys.version[0] == '2': # This test only makes sense under Python 2.x
+            from types import ClassType
+            assert not isinstance(C, (type, ClassType))
+
+        self.assertIs(C.__class__.__class__, C.__class__)

--- a/src/zope/interface/tests/test_odd_declarations.py
+++ b/src/zope/interface/tests/test_odd_declarations.py
@@ -36,7 +36,10 @@ class I31(I3): pass
 class I4(Interface): pass
 class I5(Interface): pass
 
-class Odd(object): __metaclass__ = odd.MetaClass
+class Odd(object):
+    pass
+Odd = odd.MetaClass('Odd', Odd.__bases__, {})
+
 
 class B(Odd): __implemented__ = I2
 

--- a/src/zope/interface/tests/test_registry.py
+++ b/src/zope/interface/tests/test_registry.py
@@ -2652,11 +2652,4 @@ class _Monkey(object):
             setattr(self.module, key, value)
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(ComponentsTests),
-        unittest.makeSuite(UnhashableComponentsTests),
-        unittest.makeSuite(UtilityRegistrationTests),
-        unittest.makeSuite(AdapterRegistrationTests),
-        unittest.makeSuite(SubscriptionRegistrationTests),
-        unittest.makeSuite(AdapterRegistrationTests),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_registry.py
+++ b/src/zope/interface/tests/test_registry.py
@@ -2650,6 +2650,3 @@ class _Monkey(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         for key, value in self.to_restore.items():
             setattr(self.module, key, value)
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_sorting.py
+++ b/src/zope/interface/tests/test_sorting.py
@@ -14,7 +14,7 @@
 """Test interface sorting
 """
 
-from unittest import TestCase, TestSuite, main, makeSuite
+import unittest
 
 from zope.interface import Interface
 
@@ -26,7 +26,7 @@ class I5(I4): pass
 class I6(I2): pass
 
 
-class Test(TestCase):
+class Test(unittest.TestCase):
 
     def test(self):
         l = [I1, I3, I5, I6, I4, I2]
@@ -37,7 +37,7 @@ class Test(TestCase):
         l = [I1, None, I3, I5, I6, I4, I2]
         l.sort()
         self.assertEqual(l, [I1, I2, I3, I4, I5, I6, None])
-    
+
     def test_w_equal_names(self):
         # interfaces with equal names but different modules should sort by
         # module name
@@ -47,9 +47,8 @@ class Test(TestCase):
         self.assertEqual(l, [m1_I1, I1])
 
 def test_suite():
-    return TestSuite((
-        makeSuite(Test),
-        ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
 
 if __name__=='__main__':
-    main(defaultTest='test_suite')
+    unittest.main(defaultTest='test_suite')

--- a/src/zope/interface/tests/test_sorting.py
+++ b/src/zope/interface/tests/test_sorting.py
@@ -45,10 +45,3 @@ class Test(unittest.TestCase):
         l = [I1, m1_I1]
         l.sort()
         self.assertEqual(l, [m1_I1, I1])
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-
-if __name__=='__main__':
-    unittest.main(defaultTest='test_suite')

--- a/src/zope/interface/tests/test_verify.py
+++ b/src/zope/interface/tests/test_verify.py
@@ -563,8 +563,7 @@ class OldSkool:
 def test_suite():
     #import doctest
     return unittest.TestSuite((
-        unittest.makeSuite(Test_verifyClass),
-        unittest.makeSuite(Test_verifyObject),
+        unittest.defaultTestLoader.loadTestsFromName(__name__),
     #   This one needs to turn into just docs.
     #doctest.DocFileSuite('../verify.txt',
     #                     optionflags=doctest.NORMALIZE_WHITESPACE),

--- a/src/zope/interface/tests/test_verify.py
+++ b/src/zope/interface/tests/test_verify.py
@@ -559,12 +559,3 @@ class Test_verifyObject(Test_verifyClass):
 
 class OldSkool:
     pass
-
-def test_suite():
-    #import doctest
-    return unittest.TestSuite((
-        unittest.defaultTestLoader.loadTestsFromName(__name__),
-    #   This one needs to turn into just docs.
-    #doctest.DocFileSuite('../verify.txt',
-    #                     optionflags=doctest.NORMALIZE_WHITESPACE),
-    ))

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
 
 [testenv]
 commands =
-    python setup.py -q test -q
+    python setup.py -q test -q []
 deps =
     zope.event
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
 
 [testenv]
 commands =
-    python setup.py -q test -q []
+    python setup.py -q test -q {posargs}
 deps =
     zope.event
 
@@ -28,7 +28,7 @@ usedevelop = true
 basepython =
     python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage
+    nosetests --with-xunit --with-xcoverage {posargs}
 deps =
     {[testenv]deps}
     nose


### PR DESCRIPTION
Partially addresses #87

- Remove manual lists of tests in favor of loadTestsFromName. This mostly gets all test runners running the same number of tests.
- Remove `additional_tests`, which was just duplicating the discovered tests. No modern test runner seems to need it.
- Change the two compatibility skip decorators to actually use unitetest skips, which helps with the reporting.
- Pull in the .gitignore and .coveragerc changes from #86.