### PR TITLE
100% coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ exclude_lines =
     class I[A-Z]\w+\((Interface|I[A-Z].*)\):
     raise NotImplementedError
     self\.fail
+    @_skip_under_py2

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,5 @@ show_missing = true
 exclude_lines =
     pragma: no cover
     class I[A-Z]\w+\((Interface|I[A-Z].*)\):
+    raise NotImplementedError
+    self\.fail

--- a/src/zope/interface/adapter.py
+++ b/src/zope/interface/adapter.py
@@ -252,7 +252,7 @@ class BaseAdapterRegistry(object):
         old = components.get(_BLANK)
         if not old:
             # this is belt-and-suspenders against the failure of cleanup below
-            return  #pragma NO COVERAGE 
+            return  # pragma: no cover
 
         if value is None:
             new = ()
@@ -291,7 +291,7 @@ class BaseAdapterRegistry(object):
 
     # XXX hack to fake out twisted's use of a private api.  We need to get them
     # to use the new registed method.
-    def get(self, _): #pragma NO COVER
+    def get(self, _): # pragma: no cover
         class XXXTwistedFakeOut:
             selfImplied = {}
         return XXXTwistedFakeOut
@@ -410,14 +410,14 @@ LookupBasePy = LookupBaseFallback # BBB
 
 try:
     from zope.interface._zope_interface_coptimizations import LookupBase
-except ImportError: #pragma NO COVER
+except ImportError: # pragma: no cover
     LookupBase = LookupBaseFallback
 
 
 class VerifyingBaseFallback(LookupBaseFallback):
     # Mixin for lookups against registries which "chain" upwards, and
     # whose lookups invalidate their own caches whenever a parent registry
-    # bumps its own '_generation' counter.  E.g., used by 
+    # bumps its own '_generation' counter.  E.g., used by
     # zope.component.persistentregistry
 
     def changed(self, originally_changed):
@@ -446,7 +446,7 @@ VerifyingBasePy = VerifyingBaseFallback #BBB
 
 try:
     from zope.interface._zope_interface_coptimizations import VerifyingBase
-except ImportError: #pragma NO COVER
+except ImportError: # pragma: no cover
     VerifyingBase = VerifyingBaseFallback
 
 

--- a/src/zope/interface/advice.py
+++ b/src/zope/interface/advice.py
@@ -28,11 +28,11 @@ Visit the PEAK home page at http://peak.telecommunity.com for more information.
 from types import FunctionType
 try:
     from types import ClassType
-except ImportError:  #pragma NO COVER Python > 3.x
+except ImportError:  # pragma: no cover Python > 3.x
     __python3 = True
-else: #pragma NO COVER Python < 3.x
+else: # pragma: no cover Python < 3.x
     __python3 = False
-    
+
 import sys
 
 def getFrameInfo(frame):
@@ -96,7 +96,7 @@ def addClassAdvisor(callback, depth=2):
     declare any '__metaclass__' *first*, to ensure all callbacks are run."""
     # This entire approach is invalid under Py3K.  Don't even try to fix
     # the coverage for this block there. :(
-    if __python3: #pragma NO COVER
+    if __python3: # pragma: no cover
         raise TypeError('Class advice impossible in Python3')
 
     frame = sys._getframe(depth)
@@ -172,7 +172,7 @@ def determineMetaclass(bases, explicit_mc=None):
 
     candidates = minimalBases(meta) # minimal set of metaclasses
 
-    if not candidates: #pragma NO COVER
+    if not candidates: # pragma: no cover
         # they're all "classic" classes
         assert(not __python3) # This should not happen under Python 3
         return ClassType
@@ -188,7 +188,7 @@ def determineMetaclass(bases, explicit_mc=None):
 def minimalBases(classes):
     """Reduce a list of base classes to its ordered minimum equivalent"""
 
-    if not __python3: #pragma NO COVER
+    if not __python3: # pragma: no cover
         classes = [c for c in classes if c is not ClassType]
     candidates = []
 
@@ -203,4 +203,3 @@ def minimalBases(classes):
             candidates.append(m)
 
     return candidates
-

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -436,7 +436,7 @@ class implementer_only:
 def _implements(name, interfaces, classImplements):
     # This entire approach is invalid under Py3K.  Don't even try to fix
     # the coverage for this block there. :(
-    if PYTHON3: #pragma NO COVER
+    if PYTHON3: # pragma: no cover
         raise TypeError('Class advice impossible in Python3')
     frame = sys._getframe(2)
     locals = frame.f_locals
@@ -481,7 +481,7 @@ def implements(*interfaces):
     """
     # This entire approach is invalid under Py3K.  Don't even try to fix
     # the coverage for this block there. :(
-    if PYTHON3: #pragma NO COVER
+    if PYTHON3: # pragma: no cover
         raise TypeError(_ADVICE_ERROR % 'implementer')
     _implements("implements", interfaces, classImplements)
 
@@ -509,7 +509,7 @@ def implementsOnly(*interfaces):
     """
     # This entire approach is invalid under Py3K.  Don't even try to fix
     # the coverage for this block there. :(
-    if PYTHON3: #pragma NO COVER
+    if PYTHON3: # pragma: no cover
         raise TypeError(_ADVICE_ERROR % 'implementer_only')
     _implements("implementsOnly", interfaces, classImplementsOnly)
 
@@ -581,7 +581,7 @@ def directlyProvides(object, *interfaces):
         # Note that we can't get here from Py3k tests:  there is no normal
         # class which isn't descriptor aware.
         if not isinstance(object,
-                          DescriptorAwareMetaClasses): #pragma NO COVER Py3k
+                          DescriptorAwareMetaClasses): # pragma: no cover Py3k
             raise TypeError("Attempt to make an interface declaration on a "
                             "non-descriptor-aware class")
 
@@ -641,9 +641,9 @@ ClassProvidesBase = ClassProvidesBaseFallback
 # Try to get C base:
 try:
     import zope.interface._zope_interface_coptimizations
-except ImportError:  #pragma NO COVERAGE
+except ImportError:  # pragma: no cover
     pass
-else:  #pragma NO COVERAGE
+else:  # pragma: no cover
     from zope.interface._zope_interface_coptimizations import ClassProvidesBase
 
 
@@ -715,7 +715,7 @@ def classProvides(*interfaces):
     # This entire approach is invalid under Py3K.  Don't even try to fix
     # the coverage for this block there. :(
 
-    if PYTHON3: #pragma NO COVER
+    if PYTHON3: # pragma: no cover
         raise TypeError(_ADVICE_ERROR % 'provider')
 
     frame = sys._getframe(1)
@@ -801,7 +801,7 @@ def ObjectSpecification(direct, cls):
 
     These combine information for the object and for it's classes.
     """
-    return Provides(cls, direct) #pragma NO COVER fossil
+    return Provides(cls, direct) # pragma: no cover fossil
 
 def getObjectSpecificationFallback(ob):
 
@@ -918,9 +918,9 @@ _empty = Declaration()
 
 try:
     import zope.interface._zope_interface_coptimizations
-except ImportError: #pragma NO COVER
+except ImportError: # pragma: no cover
     pass
-else: #pragma NO COVER PyPy
+else: # pragma: no cover PyPy
     from zope.interface._zope_interface_coptimizations import implementedBy
     from zope.interface._zope_interface_coptimizations import providedBy
     from zope.interface._zope_interface_coptimizations import (

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -115,7 +115,7 @@ class SpecificationBasePy(object):
 SpecificationBase = SpecificationBasePy
 try:
     from zope.interface._zope_interface_coptimizations import SpecificationBase
-except ImportError: #pragma NO COVER
+except ImportError: # pragma: no cover
     pass
 
 _marker = object()
@@ -156,14 +156,14 @@ class InterfaceBasePy(object):
 InterfaceBase = InterfaceBasePy
 try:
     from zope.interface._zope_interface_coptimizations import InterfaceBase
-except ImportError: #pragma NO COVER
+except ImportError: # pragma: no cover
     pass
 
 
 adapter_hooks = []
 try:
     from zope.interface._zope_interface_coptimizations import adapter_hooks
-except ImportError: #pragma NO COVER
+except ImportError: # pragma: no cover
     pass
 
 
@@ -321,7 +321,7 @@ class InterfaceClass(Element, InterfaceBase, Specification):
                     # This is how cPython figures out the module of
                     # a class, but of course it does it in C. :-/
                     __module__ = sys._getframe(1).f_globals['__name__']
-                except (AttributeError, KeyError): #pragma NO COVERAGE
+                except (AttributeError, KeyError): # pragma: no cover
                     pass
 
         self.__module__ = __module__
@@ -465,7 +465,7 @@ class InterfaceClass(Element, InterfaceBase, Specification):
     def _call_conform(self, conform):
         try:
             return conform(self)
-        except TypeError: #pragma NO COVER
+        except TypeError: # pragma: no cover
             # We got a TypeError. It might be an error raised by
             # the __conform__ implementation, or *we* may have
             # made the TypeError by calling an unbound method
@@ -479,7 +479,7 @@ class InterfaceClass(Element, InterfaceBase, Specification):
                 raise
             # This clever trick is from Phillip Eby
 
-        return None #pragma NO COVER
+        return None # pragma: no cover
 
     def __reduce__(self):
         return self.__name__
@@ -517,7 +517,7 @@ class InterfaceClass(Element, InterfaceBase, Specification):
 
     def __hash__(self):
         d = self.__dict__
-        if '__module__' not in d or '__name__' not in d: #pragma NO COVER
+        if '__module__' not in d or '__name__' not in d: # pragma: no cover
             warnings.warn('Hashing uninitialized InterfaceClass instance')
             return 1
         return hash((self.__name__, self.__module__))

--- a/src/zope/interface/tests/advisory_testing.py
+++ b/src/zope/interface/tests/advisory_testing.py
@@ -28,11 +28,11 @@ def ping(log, value):
 
 try:
     from types import ClassType
-    
+
     class ClassicClass:
         __metaclass__ = ClassType
         classLevelFrameInfo = getFrameInfo(sys._getframe())
-except ImportError:
+except ImportError: # pragma: no cover (Py3, this module may not even be imported)
     ClassicClass = None
 
 class NewStyleClass:

--- a/src/zope/interface/tests/dummy.py
+++ b/src/zope/interface/tests/dummy.py
@@ -20,4 +20,4 @@ moduleProvides(IDummyModule)
 
 def bar(baz):
     # Note:  no 'self', because the module provides the interface directly.
-    pass
+    raise NotImplementedError()

--- a/src/zope/interface/tests/odd.py
+++ b/src/zope/interface/tests/odd.py
@@ -68,10 +68,11 @@ This is used for testing support for ExtensionClass in new interfaces.
 
 class MetaMetaClass(type):
 
-    def __getattribute__(self, name):
+    def __getattribute__(cls, name):
         if name == '__class__':
-            return self
-        return type.__getattribute__(self, name)
+            return cls
+        # Under Python 3.6, __prepare__ gets requested
+        return type.__getattribute__(cls, name) # pragma: no cover
 
 
 class MetaClass(object):
@@ -93,7 +94,7 @@ class MetaClass(object):
                 return v
         raise AttributeError(name)
 
-    def __repr__(self):
+    def __repr__(self): # pragma: no cover
         return "<odd class %s at %s>" % (self.__name__, hex(id(self)))
 
 
@@ -120,15 +121,8 @@ class OddInstance(object):
         self.__dict__[name] = v
 
     def __delattr__(self, name):
-        del self.__dict__[name]
+        raise NotImplementedError()
 
-    def __repr__(self):
+    def __repr__(self): # pragma: no cover
         return "<odd %s instance at %s>" % (
             self.__class__.__name__, hex(id(self)))
-
-
-
-# DocTest:
-if __name__ == "__main__":
-    import doctest, __main__
-    doctest.testmod(__main__, isprivate=lambda *a: False)

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -1390,7 +1390,7 @@ class Test_utils(unittest.TestCase):
         STR = b'str'
         if sys.version_info[0] < 3:
             self.assertEqual(_normalize_name(STR), unicode(STR))
-        else:
+        else: # pragma: no cover (tox runs coverage on Python 2)
             self.assertEqual(_normalize_name(STR), str(STR, 'ascii'))
 
     def test__normalize_name_unicode(self):

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -249,10 +249,10 @@ class LookupBaseFallbackTests(unittest.TestCase):
                 pass
         if uc_lookupAll is None:
             def uc_lookupAll(self, required, provided):
-                pass
+                raise NotImplementedError()
         if uc_subscriptions is None:
             def uc_subscriptions(self, required, provided):
-                pass
+                raise NotImplementedError()
         class Derived(self._getTargetClass()):
             _uncached_lookup = uc_lookup
             _uncached_lookupAll = uc_lookupAll
@@ -260,14 +260,11 @@ class LookupBaseFallbackTests(unittest.TestCase):
         return Derived()
 
     def test_lookup_w_invalid_name(self):
-        _called_with = []
         def _lookup(self, required, provided, name):
-            _called_with.append((required, provided, name))
-            return None
+            self.fail("This should never be called")
         lb = self._makeOne(uc_lookup=_lookup)
         with self.assertRaises(ValueError):
             lb.lookup(('A',), 'B', object())
-        self.assertEqual(_called_with, [])
 
     def test_lookup_miss_no_default(self):
         _called_with = []
@@ -361,14 +358,12 @@ class LookupBaseFallbackTests(unittest.TestCase):
         self.assertEqual(_results, [c])
 
     def test_lookup1_w_invalid_name(self):
-        _called_with = []
         def _lookup(self, required, provided, name):
-            _called_with.append((required, provided, name))
-            return None
+            self.fail("This should never be called")
+
         lb = self._makeOne(uc_lookup=_lookup)
         with self.assertRaises(ValueError):
             lb.lookup1('A', 'B', object())
-        self.assertEqual(_called_with, [])
 
     def test_lookup1_miss_no_default(self):
         _called_with = []
@@ -563,7 +558,7 @@ class LookupBaseTests(LookupBaseFallbackTests):
         from zope.interface.adapter import LookupBaseFallback
         try:
             import zope.interface._zope_interface_coptimizations
-        except ImportError:
+        except ImportError: # pragma: no cover (pypy)
             self.assertIs(self._getTargetClass(), LookupBaseFallback)
         else:
             self.assertIsNot(self._getTargetClass(), LookupBaseFallback)
@@ -579,13 +574,13 @@ class VerifyingBaseFallbackTests(unittest.TestCase):
                  uc_subscriptions=None):
         if uc_lookup is None:
             def uc_lookup(self, required, provided, name):
-                pass
+                raise NotImplementedError()
         if uc_lookupAll is None:
             def uc_lookupAll(self, required, provided):
-                pass
+                raise NotImplementedError()
         if uc_subscriptions is None:
             def uc_subscriptions(self, required, provided):
-                pass
+                raise NotImplementedError()
         class Derived(self._getTargetClass()):
             _uncached_lookup = uc_lookup
             _uncached_lookupAll = uc_lookupAll
@@ -648,13 +643,13 @@ class VerifyingBaseFallbackTests(unittest.TestCase):
         self.assertEqual(_results, [c])
 
     def test_adapter_hook(self):
-        a, b, c = [object(), object(), object()]
+        a, b, _c = [object(), object(), object()]
         def _factory1(context):
             return a
         def _factory2(context):
             return b
         def _factory3(context):
-            return c
+            self.fail("This should never be called")
         _factories = [_factory1, _factory2, _factory3]
         def _lookup(self, required, provided, name):
             return _factories.pop(0)
@@ -670,13 +665,13 @@ class VerifyingBaseFallbackTests(unittest.TestCase):
         self.assertTrue(adapted is b)
 
     def test_queryAdapter(self):
-        a, b, c = [object(), object(), object()]
+        a, b, _c = [object(), object(), object()]
         def _factory1(context):
             return a
         def _factory2(context):
             return b
         def _factory3(context):
-            return c
+            self.fail("This should never be called")
         _factories = [_factory1, _factory2, _factory3]
         def _lookup(self, required, provided, name):
             return _factories.pop(0)
@@ -734,7 +729,7 @@ class VerifyingBaseTests(VerifyingBaseFallbackTests):
         from zope.interface.adapter import VerifyingBaseFallback
         try:
             import zope.interface._zope_interface_coptimizations
-        except ImportError:
+        except ImportError: # pragma: no cover (pypy)
             self.assertIs(self._getTargetClass(), VerifyingBaseFallback)
         else:
             self.assertIsNot(self._getTargetClass(), VerifyingBaseFallback)

--- a/src/zope/interface/tests/test_advice.py
+++ b/src/zope/interface/tests/test_advice.py
@@ -221,7 +221,7 @@ class Test_determineMetaclass(unittest.TestCase):
         self.assertEqual(self._callFUT((Meta, type)), Metameta)
 
     @_skip_under_py2
-    def test_meta_of_class_py3k(self):
+    def test_meta_of_class_py3k(self): # pragma: no cover (tox runs coverage on Python 2)
         # Work around SyntaxError under Python2.
         EXEC = '\n'.join([
         'class Metameta(type):',
@@ -249,7 +249,7 @@ class Test_determineMetaclass(unittest.TestCase):
         self.assertEqual(self._callFUT((A, B,)), Meta_B)
 
     @_skip_under_py2
-    def test_multiple_in_hierarchy_py3k(self):
+    def test_multiple_in_hierarchy_py3k(self): # pragma: no cover (tox runs coverage on Python 2)
         # Work around SyntaxError under Python2.
         EXEC = '\n'.join([
         'class Meta_A(type):',
@@ -282,7 +282,7 @@ class Test_determineMetaclass(unittest.TestCase):
         self.assertRaises(TypeError, self._callFUT, (A, B,))
 
     @_skip_under_py2
-    def test_multiple_not_in_hierarchy_py3k(self):
+    def test_multiple_not_in_hierarchy_py3k(self): # pragma: no cover (tox runs coverage on Python 2)
         # Work around SyntaxError under Python2.
         EXEC = '\n'.join([
         'class Meta_A(type):',

--- a/src/zope/interface/tests/test_advice.py
+++ b/src/zope/interface/tests/test_advice.py
@@ -221,7 +221,7 @@ class Test_determineMetaclass(unittest.TestCase):
         self.assertEqual(self._callFUT((Meta, type)), Metameta)
 
     @_skip_under_py2
-    def test_meta_of_class_py3k(self): # pragma: no cover (tox runs coverage on Python 2)
+    def test_meta_of_class_py3k(self):
         # Work around SyntaxError under Python2.
         EXEC = '\n'.join([
         'class Metameta(type):',
@@ -249,7 +249,7 @@ class Test_determineMetaclass(unittest.TestCase):
         self.assertEqual(self._callFUT((A, B,)), Meta_B)
 
     @_skip_under_py2
-    def test_multiple_in_hierarchy_py3k(self): # pragma: no cover (tox runs coverage on Python 2)
+    def test_multiple_in_hierarchy_py3k(self):
         # Work around SyntaxError under Python2.
         EXEC = '\n'.join([
         'class Meta_A(type):',
@@ -282,7 +282,7 @@ class Test_determineMetaclass(unittest.TestCase):
         self.assertRaises(TypeError, self._callFUT, (A, B,))
 
     @_skip_under_py2
-    def test_multiple_not_in_hierarchy_py3k(self): # pragma: no cover (tox runs coverage on Python 2)
+    def test_multiple_not_in_hierarchy_py3k(self):
         # Work around SyntaxError under Python2.
         EXEC = '\n'.join([
         'class Meta_A(type):',

--- a/src/zope/interface/tests/test_advice.py
+++ b/src/zope/interface/tests/test_advice.py
@@ -45,8 +45,6 @@ class FrameInfoTest(unittest.TestCase):
     @_skip_under_py3k
     def test_w_ClassicClass(self):
         from zope.interface.tests import advisory_testing
-        if advisory_testing.ClassicClass is None:
-            return
         (kind,
          module,
          f_locals,
@@ -111,18 +109,6 @@ class AdviceTests(unittest.TestCase):
 
         self.assertEqual(log, [(1, Foo), (2, [Foo]), (3, [[Foo]])])
 
-    def TODOtest_outside(self):
-        from zope.interface.tests.advisory_testing import ping
-        # Disabled because the check does not work with doctest tests.
-        try:
-            ping([], 1)
-        except SyntaxError:
-            pass
-        else:
-            raise AssertionError(
-                "Should have detected advice outside class body"
-            )
-
     @_skip_under_py3k
     def test_single_explicit_meta(self):
         from zope.interface.tests.advisory_testing import ping
@@ -157,11 +143,9 @@ class AdviceTests(unittest.TestCase):
         try:
             class Derived(Base1, Base2):
                 ping([], 1)
-
+            self.fail("Should have gotten incompatibility error")
         except TypeError:
             pass
-        else:
-            raise AssertionError("Should have gotten incompatibility error")
 
         class Metaclass3(Metaclass1, Metaclass2):
             pass
@@ -177,10 +161,7 @@ class AdviceTests(unittest.TestCase):
     @_skip_under_py3k
     def test_meta_no_bases(self):
         from zope.interface.tests.advisory_testing import ping
-        try:
-            from types import ClassType
-        except ImportError:
-            return
+        from types import ClassType
         class Thing:
             ping([], 1)
         klass, = Thing # unpack list created by pong
@@ -198,12 +179,12 @@ class Test_isClassAdvisor(unittest.TestCase):
 
     def test_w_normal_function(self):
         def foo():
-            pass
+            raise NotImplementedError()
         self.assertEqual(self._callFUT(foo), False)
 
     def test_w_advisor_function(self):
         def bar():
-            pass
+            raise NotImplementedError()
         bar.previousMetaclass = object()
         self.assertEqual(self._callFUT(bar), True)
 

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -31,7 +31,7 @@ class _Py3ClassAdvice(object):
                 exec(code, globs, locs)
                 self.assertEqual(len(log), 0) # no longer warn
                 return True
-            else:
+            else: # pragma: no cover (tox runs coverage on Python 2)
                 try:
                     exec(code, globs, locs)
                 except TypeError:
@@ -752,7 +752,7 @@ class Test_implementsOnly(unittest.TestCase, _Py3ClassAdvice):
             warnings.resetwarnings()
             try:
                 exec(CODE, globs, locs)
-            except TypeError:
+            except TypeError: # pragma: no cover (tox runs coverage on Python 2)
                 if not PYTHON3:
                     raise
             else:

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -964,10 +964,10 @@ class Test_directlyProvides(unittest.TestCase):
             def __getattribute__(cls, name):
                 # Emulate metaclass whose base is not the type object.
                 if name == '__class__':
-                    return self
+                    return cls
                 # Under certain circumstances, the implementedByFallback
                 # can get here for __dict__
-                return type.__getattribute__(self, name) # pragma: no cover
+                return type.__getattribute__(cls, name) # pragma: no cover
 
         class Foo(object):
             __metaclass__ = MetaClass

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """Test Interface implementation
 """
+# pylint:disable=protected-access
 import unittest
 
 _marker = object()
@@ -25,7 +26,7 @@ class Test_invariant(unittest.TestCase):
         from zope.interface.interface import TAGGED_DATA
 
         def _check(*args, **kw):
-            pass
+            raise NotImplementedError()
 
         class Foo(object):
             invariant(_check)
@@ -38,10 +39,10 @@ class Test_invariant(unittest.TestCase):
         from zope.interface.interface import TAGGED_DATA
 
         def _check(*args, **kw):
-            pass
+            raise NotImplementedError()
 
         def _another_check(*args, **kw):
-            pass
+            raise NotImplementedError()
 
         class Foo(object):
             invariant(_check)
@@ -95,12 +96,10 @@ class ElementTests(unittest.TestCase):
         from zope.interface.interface import Element
         return Element
 
-    def _makeOne(self,  name=None, __doc__=_marker):
+    def _makeOne(self,  name=None):
         if name is None:
             name = self.DEFAULT_NAME
-        if __doc__ is _marker:
-            return self._getTargetClass()(name)
-        return self._getTargetClass()(name, __doc__)
+        return self._getTargetClass()(name)
 
     def test_ctor_defaults(self):
         element = self._makeOne()
@@ -215,7 +214,7 @@ class SpecificationBaseTests(unittest.TestCase):
         from zope.interface.interface import SpecificationBasePy
         try:
             import zope.interface._zope_interface_coptimizations
-        except ImportError:
+        except ImportError: # pragma: no cover (pypy)
             self.assertIs(self._getTargetClass(), SpecificationBasePy)
         else:
             self.assertIsNot(self._getTargetClass(), SpecificationBasePy)
@@ -292,7 +291,7 @@ class InterfaceBaseTests(unittest.TestCase):
         from zope.interface.interface import InterfaceBasePy
         try:
             import zope.interface._zope_interface_coptimizations
-        except ImportError:
+        except ImportError: # pragma: no cover (pypy)
             self.assertIs(self._getTargetClass(), InterfaceBasePy)
         else:
             self.assertIsNot(self._getTargetClass(), InterfaceBasePy)
@@ -827,10 +826,8 @@ class InterfaceClassTests(unittest.TestCase):
 
     def test___hash___missing_required_attrs(self):
         import warnings
-        try:
-            from warnings import catch_warnings
-        except ImportError:  # Python 2.5
-            return
+        from warnings import catch_warnings
+
         class Derived(self._getTargetClass()):
             def __init__(self):
                 pass # Don't call base class.
@@ -905,7 +902,7 @@ class InterfaceTests(unittest.TestCase):
         class I1(Interface):
 
             def method(foo, bar, bingo):
-                pass
+                "A method"
 
         self.assertTrue(I1['method'].interface is I1)
 
@@ -926,9 +923,9 @@ class InterfaceTests(unittest.TestCase):
         class Current(object):
             __implemented__ = ICurrent
             def method1(self, a, b):
-                return 1
+                raise NotImplementedError()
             def method2(self, a, b):
-                return 2
+                raise NotImplementedError()
 
         current = Current()
 
@@ -951,7 +948,7 @@ class InterfaceTests(unittest.TestCase):
         class Current():
             __implemented__ = IBase
             def method(self):
-                pass
+                raise NotImplementedError()
         current = Current()
 
         self.assertTrue(IBase.implementedBy(Current))
@@ -976,7 +973,7 @@ class InterfaceTests(unittest.TestCase):
         class Current(object):
             __implemented__ = IDerived
             def method(self):
-                pass
+                raise NotImplementedError()
 
         current = Current()
 
@@ -1005,7 +1002,7 @@ class InterfaceTests(unittest.TestCase):
             __implemented__ = ILeft
 
             def method(self):
-                pass
+                raise NotImplementedError()
 
         class Right(object):
             __implemented__ = IRight
@@ -1042,7 +1039,7 @@ class InterfaceTests(unittest.TestCase):
             __implemented__ = ILeft
 
             def method(self):
-                pass
+                raise NotImplementedError()
 
         class Right(object):
             __implemented__ = IRight
@@ -1092,14 +1089,14 @@ class InterfaceTests(unittest.TestCase):
             attr = Attribute(u'My attr')
 
             def method():
-                pass
+                "A method"
 
         class CheckMe(object):
             __implemented__ = ICheckMe
             attr = 'value'
 
             def method(self):
-                pass
+                raise NotImplementedError()
 
         self.assertTrue(verifyClass(ICheckMe, CheckMe))
 
@@ -1113,14 +1110,14 @@ class InterfaceTests(unittest.TestCase):
             attr = Attribute(u'My attr')
 
             def method():
-                pass
+                "A method"
 
         class CheckMe(object):
             __implemented__ = ICheckMe
             attr = 'value'
 
             def method(self):
-                pass
+                raise NotImplementedError()
 
         check_me = CheckMe()
 
@@ -1523,11 +1520,10 @@ class InterfaceTests(unittest.TestCase):
         e = []
         try:
             iface.validateInvariants(has_invariant, e)
+            self.fail("validateInvariants should always rais")
         except Invalid as error:
             self.assertEqual(error.args[0], e)
-        else:
-            self._assert(0) # validateInvariants should always raise
-            # Invalid
+
         self.assertEqual(len(e), error_len)
         msgs = [error.args[0] for error in e]
         msgs.sort()

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -1520,7 +1520,7 @@ class InterfaceTests(unittest.TestCase):
         e = []
         try:
             iface.validateInvariants(has_invariant, e)
-            self.fail("validateInvariants should always rais")
+            self.fail("validateInvariants should always raise")
         except Invalid as error:
             self.assertEqual(error.args[0], e)
 

--- a/src/zope/interface/tests/test_registry.py
+++ b/src/zope/interface/tests/test_registry.py
@@ -12,6 +12,7 @@
 #
 ##############################################################################
 """Component Registry Tests"""
+# pylint:disable=protected-access
 import unittest
 
 
@@ -93,7 +94,7 @@ class ComponentsTests(unittest.TestCase):
 
     def test_registerUtility_both_factory_and_component(self):
         def _factory():
-            pass
+            raise NotImplementedError()
         _to_reg = object()
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.registerUtility,
@@ -162,13 +163,9 @@ class ComponentsTests(unittest.TestCase):
         self.assertTrue(event.object.factory is _factory)
 
     def test_registerUtility_no_provided_available(self):
-        from zope.interface.declarations import InterfaceClass
-
-        class IFoo(InterfaceClass):
-            pass
         class Foo(object):
             pass
-        ifoo = IFoo('IFoo')
+
         _info = u'info'
         _name = u'name'
         _to_reg = Foo()
@@ -349,7 +346,7 @@ class ComponentsTests(unittest.TestCase):
 
     def test_unregisterUtility_both_factory_and_component(self):
         def _factory():
-            pass
+            raise NotImplementedError()
         _to_reg = object()
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.unregisterUtility,
@@ -786,9 +783,9 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         _info = u'info'
         _name = u'name'
-        _to_reg = object()
+
         def _factory(context):
-            return _to_reg
+            raise NotImplementedError()
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -815,14 +812,14 @@ class ComponentsTests(unittest.TestCase):
 
         class IFoo(InterfaceClass):
             pass
-        ifoo = IFoo('IFoo')
+
         ibar = IFoo('IBar')
         _info = u'info'
         _name = u'name'
         _to_reg = object()
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.registerAdapter, _Factory, (ibar,),
                           name=_name, info=_info)
@@ -840,10 +837,11 @@ class ComponentsTests(unittest.TestCase):
         _info = u'info'
         _name = u'name'
         _to_reg = object()
+
         @implementer(ifoo)
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -871,12 +869,12 @@ class ComponentsTests(unittest.TestCase):
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        ibar = IFoo('IBar')
+
         _info = u'info'
         _name = u'name'
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+           pass
+
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.registerAdapter, _Factory,
                           provided=ifoo, name=_name, info=_info)
@@ -891,8 +889,7 @@ class ComponentsTests(unittest.TestCase):
         _info = u'info'
         _name = u'name'
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.registerAdapter, _Factory,
                           ibar, provided=ifoo, name=_name, info=_info)
@@ -909,8 +906,7 @@ class ComponentsTests(unittest.TestCase):
         _info = u'info'
         _name = u'name'
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -947,8 +943,8 @@ class ComponentsTests(unittest.TestCase):
         _info = u'info'
         _name = u'name'
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         @implementer(ibar)
         class _Context(object):
             pass
@@ -981,12 +977,11 @@ class ComponentsTests(unittest.TestCase):
         class IFoo(InterfaceClass):
             pass
         ifoo = IFoo('IFoo')
-        ibar = IFoo('IBar')
+
         _info = u'info'
         _name = u'name'
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.registerAdapter, _Factory, [object()],
                           provided=ifoo, name=_name, info=_info)
@@ -1004,8 +999,7 @@ class ComponentsTests(unittest.TestCase):
         _name = u'name'
         class _Factory(object):
             __component_adapts__ = (ibar,)
-            def __init__(self, context):
-                self._context = context
+
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1037,9 +1031,9 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         _info = u'info'
         _name = u'name'
-        _to_reg = object()
+
         def _factory(context):
-            return _to_reg
+            raise NotImplementedError()
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1068,8 +1062,8 @@ class ComponentsTests(unittest.TestCase):
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1085,8 +1079,8 @@ class ComponentsTests(unittest.TestCase):
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         comp.registerAdapter(_Factory, (ibar,), ifoo)
         _monkey, _events = self._wrapEvents()
@@ -1119,8 +1113,8 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         @implementer(ifoo)
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         comp.registerAdapter(_Factory, (ibar,), ifoo)
         _monkey, _events = self._wrapEvents()
@@ -1150,8 +1144,7 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         class _Factory(object):
             __component_adapts__ = (ibar,)
-            def __init__(self, context):
-                self._context = context
+
         comp = self._makeOne()
         comp.registerAdapter(_Factory, (ibar,), ifoo)
         _monkey, _events = self._wrapEvents()
@@ -1187,8 +1180,8 @@ class ComponentsTests(unittest.TestCase):
         _name1 = u'name1'
         _name2 = u'name2'
         class _Factory(object):
-            def __init__(self, context):
-                pass
+            pass
+
         comp = self._makeOne()
         comp.registerAdapter(_Factory, (ibar,), ifoo, _name1, _info)
         comp.registerAdapter(_Factory, (ibar,), ifoo, _name2, _info)
@@ -1488,9 +1481,9 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         _name = u'name'
         _info = u'info'
-        _to_reg = object()
         def _factory(context):
-            return _to_reg
+            raise NotImplementedError()
+
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.registerSubscriptionAdapter,
                           _factory, (ibar,), ifoo, _name, _info)
@@ -1506,9 +1499,8 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         _blank = u''
         _info = u'info'
-        _to_reg = object()
         def _factory(context):
-            return _to_reg
+            raise NotImplementedError()
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1544,11 +1536,11 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         _info = u'info'
         _blank = u''
-        _to_reg = object()
+
         @implementer(ifoo)
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1584,8 +1576,7 @@ class ComponentsTests(unittest.TestCase):
         _blank = u''
         class _Factory(object):
             __component_adapts__ = (ibar,)
-            def __init__(self, context):
-                self._context = context
+
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1618,9 +1609,10 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         _blank = u''
         _info = u'info'
-        _to_reg = object()
+
         def _factory(context):
-            return _to_reg
+            raise NotImplementedError()
+
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1643,8 +1635,8 @@ class ComponentsTests(unittest.TestCase):
         _info = u'info'
         _blank = u''
         class _Factory(object):
-            def __init__(self, context):
-                pass
+            pass
+
         comp = self._makeOne()
         comp.registerSubscriptionAdapter(_Factory, (ibar,), ifoo, info=_info)
         comp.registerSubscriptionAdapter(_Factory, (ibar,), ifoo, info=_info)
@@ -1698,8 +1690,8 @@ class ComponentsTests(unittest.TestCase):
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1716,8 +1708,8 @@ class ComponentsTests(unittest.TestCase):
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         comp.registerSubscriptionAdapter(_Factory, (ibar,), ifoo)
         _monkey, _events = self._wrapEvents()
@@ -1748,8 +1740,8 @@ class ComponentsTests(unittest.TestCase):
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         comp.registerSubscriptionAdapter(_Factory, (ibar,), ifoo)
         _monkey, _events = self._wrapEvents()
@@ -1782,8 +1774,8 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         @implementer(ifoo)
         class _Factory(object):
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         comp.registerSubscriptionAdapter(_Factory, (ibar,), ifoo)
         _monkey, _events = self._wrapEvents()
@@ -1813,8 +1805,7 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         class _Factory(object):
             __component_adapts__ = (ibar,)
-            def __init__(self, context):
-                self._context = context
+
         comp = self._makeOne()
         comp.registerSubscriptionAdapter(_Factory, (ibar,), ifoo)
         _monkey, _events = self._wrapEvents()
@@ -1885,7 +1876,8 @@ class ComponentsTests(unittest.TestCase):
         _nonblank = u'nonblank'
         comp = self._makeOne()
         def _factory(context):
-            pass
+            raise NotImplementedError()
+
         self.assertRaises(TypeError, comp.registerHandler, _factory,
                           required=ifoo, name=_nonblank)
 
@@ -1899,9 +1891,9 @@ class ComponentsTests(unittest.TestCase):
         ifoo = IFoo('IFoo')
         _blank = u''
         _info = u'info'
-        _to_reg = object()
         def _factory(context):
-            return _to_reg
+            raise NotImplementedError()
+
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1933,8 +1925,8 @@ class ComponentsTests(unittest.TestCase):
         _blank = u''
         class _Factory(object):
             __component_adapts__ = (ifoo,)
-            def __init__(self, context):
-                self._context = context
+            pass
+
         comp = self._makeOne()
         _monkey, _events = self._wrapEvents()
         with _monkey:
@@ -1947,9 +1939,6 @@ class ComponentsTests(unittest.TestCase):
         self.assertEqual(len(_events), 0)
 
     def test_registeredHandlers_empty(self):
-        from zope.interface.declarations import InterfaceClass
-        class IFoo(InterfaceClass):
-            pass
         comp = self._makeOne()
         self.assertFalse(list(comp.registeredHandlers()))
 
@@ -1960,9 +1949,9 @@ class ComponentsTests(unittest.TestCase):
             pass
         ifoo = IFoo('IFoo')
         def _factory1(context):
-            pass
+            raise NotImplementedError()
         def _factory2(context):
-            pass
+            raise NotImplementedError()
         comp = self._makeOne()
         comp.registerHandler(_factory1, (ifoo,))
         comp.registerHandler(_factory2, (ifoo,))
@@ -1993,10 +1982,6 @@ class ComponentsTests(unittest.TestCase):
                           required=(ifoo,), name=_nonblank)
 
     def test_unregisterHandler_neither_factory_nor_required(self):
-        from zope.interface.declarations import InterfaceClass
-        class IFoo(InterfaceClass):
-            pass
-        ifoo = IFoo('IFoo')
         comp = self._makeOne()
         self.assertRaises(TypeError, comp.unregisterHandler)
 
@@ -2017,9 +2002,8 @@ class ComponentsTests(unittest.TestCase):
             pass
         ifoo = IFoo('IFoo')
         comp = self._makeOne()
-        _to_reg = object()
         def _factory(context):
-            return _to_reg
+            raise NotImplementedError()
         comp = self._makeOne()
         comp.registerHandler(_factory, (ifoo,))
         _monkey, _events = self._wrapEvents()
@@ -2045,9 +2029,8 @@ class ComponentsTests(unittest.TestCase):
             pass
         ifoo = IFoo('IFoo')
         comp = self._makeOne()
-        _to_reg = object()
         def _factory(context):
-            return _to_reg
+            raise NotImplementedError()
         comp = self._makeOne()
         comp.registerHandler(_factory, (ifoo,))
         _monkey, _events = self._wrapEvents()
@@ -2074,8 +2057,7 @@ class ComponentsTests(unittest.TestCase):
         ifoo = IFoo('IFoo')
         class _Factory(object):
             __component_adapts__ = (ifoo,)
-            def __init__(self, context):
-                self._context = context
+
         comp = self._makeOne()
         comp.registerHandler(_Factory)
         _monkey, _events = self._wrapEvents()
@@ -2552,7 +2534,7 @@ class SubscriptionRegistrationTests(unittest.TestCase):
         ifoo = IFoo('IFoo')
         ibar = IFoo('IBar')
         class _Registry(object):
-            def __repr__(self):
+            def __repr__(self): # pragma: no cover
                 return '_REGISTRY'
         registry = _Registry()
         name = u'name'
@@ -2612,7 +2594,7 @@ class HandlerRegistrationTests(unittest.TestCase):
 
     def test_properties(self):
         def _factory(context):
-            pass
+            raise NotImplementedError()
         hr, _, _ =  self._makeOne(_factory)
         self.assertTrue(hr.handler is _factory)
         self.assertTrue(hr.factory is hr.handler)

--- a/src/zope/interface/tests/test_verify.py
+++ b/src/zope/interface/tests/test_verify.py
@@ -74,7 +74,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -112,7 +112,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(IDerived, Current)
 
@@ -130,7 +130,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, b):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -148,7 +148,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self):
-                pass
+                raise NotImplementedError()
 
         self.assertRaises(BrokenMethodImplementation,
                           self._callFUT, ICurrent, Current)
@@ -167,7 +167,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self):
-                pass
+                raise NotImplementedError()
 
         self.assertRaises(BrokenMethodImplementation,
                           self._callFUT, ICurrent, Current)
@@ -186,7 +186,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self):
-                pass
+                raise NotImplementedError()
 
         self.assertRaises(BrokenMethodImplementation,
                           self._callFUT, ICurrent, Current)
@@ -205,7 +205,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, a, b):
-                pass
+                raise NotImplementedError()
 
         self.assertRaises(BrokenMethodImplementation,
                           self._callFUT, ICurrent, Current)
@@ -223,7 +223,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, a, b=None):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -240,7 +240,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, *args):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -258,7 +258,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, **kw):
-                pass
+                raise NotImplementedError()
 
         self.assertRaises(BrokenMethodImplementation,
                           self._callFUT, ICurrent, Current)
@@ -276,7 +276,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, a, *args):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -293,7 +293,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, a, *args, **kw):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -311,7 +311,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, a):
-                pass
+                raise NotImplementedError()
 
         self.assertRaises(BrokenMethodImplementation,
                           self._callFUT, ICurrent, Current)
@@ -329,7 +329,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, a, *args):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -346,7 +346,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, *args):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -363,7 +363,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, **kw):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -381,7 +381,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, a, *args):
-                pass
+                raise NotImplementedError()
 
         self.assertRaises(BrokenMethodImplementation,
                           self._callFUT, ICurrent, Current)
@@ -401,7 +401,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current(object):
 
             def method(self, a):
-                pass
+                raise NotImplementedError()
 
         self.assertRaises(BrokenMethodImplementation,
                           self._callFUT, ICurrent, Current)
@@ -419,7 +419,7 @@ class Test_verifyClass(unittest.TestCase):
         class Current:
 
             def attr(self):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 
@@ -476,11 +476,11 @@ class Test_verifyClass(unittest.TestCase):
 
         class QuasiMethod(Method):
             def __call__(self, *args, **kw):
-                pass
+                raise NotImplementedError()
 
         class QuasiCallable(object):
             def __call__(self, *args, **kw):
-                pass
+                raise NotImplementedError()
 
         class ICurrent(Interface):
             attr = QuasiMethod('This is callable')
@@ -510,7 +510,7 @@ class Test_verifyClass(unittest.TestCase):
 
             @decorator
             def method(self, a):
-                pass
+                raise NotImplementedError()
 
         self._callFUT(ICurrent, Current)
 

--- a/src/zope/interface/verify.py
+++ b/src/zope/interface/verify.py
@@ -69,7 +69,7 @@ def _verify(iface, candidate, tentative=0, vtype=None):
             if sys.version[0] == '3' and isinstance(candidate, type):
                 # This is an "unbound method" in Python 3.
                 meth = fromFunction(attr, iface, name=name,
-                                    imlevel=1) #pragma NO COVERAGE
+                                    imlevel=1) # pragma: no cover
             else:
                 # Nope, just a normal function
                 meth = fromFunction(attr, iface, name=name)
@@ -85,7 +85,7 @@ def _verify(iface, candidate, tentative=0, vtype=None):
                 raise BrokenMethodImplementation(name, "Not a method")
             # sigh, it's callable, but we don't know how to introspect it, so
             # we have to give it a pass.
-            continue #pragma NO COVERAGE
+            continue # pragma: no cover
 
         # Make sure that the required and implemented method signatures are
         # the same.

--- a/tox.ini
+++ b/tox.ini
@@ -28,12 +28,11 @@ usedevelop = true
 basepython =
     python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage {posargs}
+    coverage run setup.py -q test -q {posargs}
+    coverage report --skip-covered
 deps =
     {[testenv]deps}
-    nose
     coverage
-    nosexcover
 
 [testenv:docs]
 basepython =


### PR DESCRIPTION
Well, as close as possible without conflicting with #86.

This is almost entirely trivial changes:

- Make dummy methods that should never be called either raise NotImplementedError or call self.fail() in tests.
- Standardize the no-coverage pragma
- Add a few pragmas where coverage varies across versions/implementations, mostly for the sake of tox (travis should hit them all).

Also convert the tox command to use the `coverage` command and drop use of `nosetests`. This also drops generating the .xml coverage reports by default.