### PR TITLE
Allow Registering and unregistering instance methods as listeners

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes
 4.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow registering and unregistering instance methods as listeners.
+  See `issue 12 <https://github.com/zopefoundation/zope.interface/issues/12>`_
+  and `PR 102 <https://github.com/zopefoundation/zope.interface/pull/102>`_.
 
 
 4.4.3 (2017-09-22)

--- a/src/zope/interface/adapter.py
+++ b/src/zope/interface/adapter.py
@@ -257,7 +257,7 @@ class BaseAdapterRegistry(object):
         if value is None:
             new = ()
         else:
-            new = tuple([v for v in old if v is not value])
+            new = tuple([v for v in old if v != value])
 
         if new == old:
             return

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -236,7 +236,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(len(registry._subscribers), 2)
     
     def _instance_method_notify_target(self):
-        pass
+        self.fail("Example method, not intended to be called.")
     
     def test_unsubscribe_instance_method(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -234,6 +234,17 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         registry.subscribe([IB1], None, orig)
         registry.unsubscribe([IB1], None, nomatch) #doesn't raise
         self.assertEqual(len(registry._subscribers), 2)
+    
+    def _instance_method_notify_target(self):
+        pass
+    
+    def test_unsubscribe_instance_method(self):
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        registry = self._makeOne()
+        self.assertEqual(len(registry._subscribers), 0)
+        registry.subscribe([IB1], None, self._instance_method_notify_target)
+        registry.unsubscribe([IB1], None, self._instance_method_notify_target)
+        self.assertEqual(len(registry._subscribers), 0)
 
 
 class LookupBaseFallbackTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #12 - registering instance methods as listeners doesn’t allow to easily unregister them as the registry tries to find the handler with 'is' but it should use '==' to allow the python BoundMethod wrapper (which is a new instance every time instance.$methodname is accessed).