### PR TITLE
Fix process of reference count during GC

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,12 @@ Changes
 4.4.3 (unreleased)
 ------------------
 
-- Avoid exceptions when the ``__annotations__`` attribute is added to interface definitions with Python 3.x type hints.
-  See `issue 98 <https://github.com/zopefoundation/zope.interface/issues/98>`_.
+- Avoid exceptions when the ``__annotations__`` attribute is added to
+  interface definitions with Python 3.x type hints. See `issue 98
+  <https://github.com/zopefoundation/zope.interface/issues/98>`_.
+- Fix the possibility of a rare crash in the C extension when
+  deallocating items. See `issue 100
+  <https://github.com/zopefoundation/zope.interface/issues/100>`_.
 
 
 4.4.2 (2017-06-14)

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -759,7 +759,7 @@ lookup_traverse(lookup *self, visitproc visit, void *arg)
 
 static int
 lookup_clear(lookup *self)
-{	
+{
   Py_CLEAR(self->_cache);
   Py_CLEAR(self->_mcache);
   Py_CLEAR(self->_scache);

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -759,7 +759,7 @@ lookup_traverse(lookup *self, visitproc visit, void *arg)
 
 static int
 lookup_clear(lookup *self)
-{
+{	
   Py_CLEAR(self->_cache);
   Py_CLEAR(self->_mcache);
   Py_CLEAR(self->_scache);
@@ -769,6 +769,7 @@ lookup_clear(lookup *self)
 static void
 lookup_dealloc(lookup *self)
 {
+  PyObject_GC_UnTrack((PyObject *)self);
   lookup_clear(self);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
@@ -1335,6 +1336,7 @@ verifying_clear(verify *self)
 static void
 verifying_dealloc(verify *self)
 {
+  PyObject_GC_UnTrack((PyObject *)self);   	
   verifying_clear(self);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }


### PR DESCRIPTION
call PyObject_GC_UnTrack() in tp_dealloc()
see the following sites for details:
 * https://bugs.python.org/issue31095
 * https://github.com/python/cpython/pull/2974