### PR TITLE
fix catching ImportError exception

### DIFF
--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,7 +1,7 @@
 # this is a namespace package
 try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
+    from pkg_resources import declare_namespace
+    declare_namespace(__name__)
 except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__)


### PR DESCRIPTION
The change avoids error when imported pkg_resources module does not contain declare_namespace attribute.