### PR TITLE
Let pypy and pypy3 float on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
         - os: linux
           python: 3.6
         - os: linux
-          python: pypy-5.6.0
+          python: pypy
         - os: linux
-          python: pypy3.3-5.5-alpha
+          python: pypy3
         # It's important to use 'macpython' builds to get the least
         # restrictive wheel tag. It's also important to avoid
         # 'homebrew 3' because it floats instead of being a specific version.


### PR DESCRIPTION
Now that Travis has again upped its PyPy game, these should not be pinned to specific versions, but rather float with the PyPy releases.