### PR TITLE
Synchronize and simplify zope/__init__.py

### DIFF
--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,7 +1,1 @@
-# this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
We *do* have a dependency on setuptools, so the try/except block should be unnecessary. At worst it might hide installation errors.

Fixes #114.