### PR TITLE
Publish the documentation for zope.interface.common

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,12 +1,13 @@
-:mod:`zope.interface` API Documentation
-=======================================
+=========================================
+ :mod:`zope.interface` API Documentation
+=========================================
 
 
 :class:`zope.interface.interface.Specification`
------------------------------------------------
+===============================================
 
 API
-+++
+---
 
 Specification objects implement the API defined by
 :class:`zope.interface.interfaces.ISpecification`:
@@ -17,7 +18,7 @@ Specification objects implement the API defined by
 
 
 Usage
-+++++
+-----
 
 For example:
 
@@ -156,10 +157,10 @@ Exmples for :meth:`Specification.extends`:
 
 
 :class:`zope.interface.interface.InterfaceClass`
-------------------------------------------------
+================================================
 
 API
-+++
+---
 
 Specification objects implement the API defined by
 :class:`zope.interface.interfaces.IInterface`:
@@ -170,7 +171,7 @@ Specification objects implement the API defined by
 
 
 Usage
-+++++
+-----
 
 Exmples for :meth:`InterfaceClass.extends`:
 
@@ -188,10 +189,10 @@ Exmples for :meth:`InterfaceClass.extends`:
 
 
 :class:`zope.interface.declarations.Declaration`
-------------------------------------------------
+================================================
 
 API
-+++
+---
 
 Specification objects implement the API defined by
 :class:`zope.interface.interfaces.IDeclaration`:
@@ -202,7 +203,7 @@ Specification objects implement the API defined by
 
 
 Usage
-+++++
+-----
 
 Exmples for :meth:`Declaration.__contains__`:
 
@@ -339,16 +340,16 @@ Exmples for :meth:`Declaration.__add__`:
 
 
 :func:`zope.interface.declarations.implementedBy`
--------------------------------------------------
+=================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.implementedByFallback
 
 
 Usage
-+++++
+-----
 
 Consider the following example:
 
@@ -414,16 +415,16 @@ This also manages storage of implementation specifications.
 
 
 :func:`zope.interface.declarations.classImplementsOnly`
--------------------------------------------------------
+=======================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.classImplementsOnly
 
 
 Usage
-+++++
+-----
 
 Consider the following example:
 
@@ -453,16 +454,16 @@ whatever interfaces instances of ``A`` and ``B`` implement.
 
 
 :func:`zope.interface.declarations.classImplements`
----------------------------------------------------
+===================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.classImplements
 
 
 Usage
-+++++
+-----
 
 Consider the following example:
 
@@ -497,10 +498,10 @@ interfaces instances of ``A`` and ``B`` provide.
 
 
 :class:`zope.interface.declarations.implementer`
-------------------------------------------------
+================================================
 
 API
-+++
+---
 
 .. autoclass:: zope.interface.declarations.implementer
    :members:
@@ -508,10 +509,10 @@ API
 
 
 :class:`zope.interface.declarations.implementer_only`
------------------------------------------------------
+=====================================================
 
 API
-+++
+---
 
 .. autoclass:: zope.interface.declarations.implementer_only
    :members:
@@ -519,30 +520,30 @@ API
 
 
 :func:`zope.interface.declarations.implements`
-----------------------------------------------
+==============================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.implements
 
 
 
 :func:`zope.interface.declarations.implementsOnly`
---------------------------------------------------
+==================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.implementsOnly
 
 
 
 :class:`zope.interface.declarations.ProvidesClass`
---------------------------------------------------
+==================================================
 
 API
-+++
+---
 
 .. autoclass:: zope.interface.declarations.ProvidesClass
    :members:
@@ -550,7 +551,7 @@ API
 
 
 Usage
-+++++
+-----
 
 Descriptor semantics (via ``Provides.__get__``):
 
@@ -571,16 +572,16 @@ Descriptor semantics (via ``Provides.__get__``):
 
 
 :func:`zope.interface.declarations.Provides`
---------------------------------------------------
+============================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.Provides
 
 
 Usage
-+++++
+-----
 
 In the examples below, we are going to make assertions about
 the size of the weakvalue dictionary.  For the assertions to be
@@ -624,16 +625,16 @@ collect function to help with this:
 
 
 :func:`zope.interface.declarations.directlyProvides`
-----------------------------------------------------
+====================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.directlyProvides
 
 
 Usage
-+++++
+-----
 
 Consider the following example:
 
@@ -714,16 +715,16 @@ We can do away with this check when we get rid of the old EC
 
 
 :func:`zope.interface.declarations.alsoProvides`
-------------------------------------------------
+================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.alsoProvides
 
 
 Usage
-+++++
+-----
 
 Consider the following example:
 
@@ -782,16 +783,16 @@ instances have been declared for instances of ``C``. Notice that the
 
 
 :func:`zope.interface.declarations.noLongerProvides`
-----------------------------------------------------
+====================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.noLongerProvides
 
 
 Usage
-+++++
+-----
 
 Consider the following two interfaces:
 
@@ -834,25 +835,25 @@ Removing an interface that is provided through the class is not possible:
 
 
 :func:`zope.interface.declarations.directlyProvidedBy`
-------------------------------------------------------
+======================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.directlyProvidedBy
 
 
 :func:`zope.interface.declarations.classProvides`
--------------------------------------------------
+=================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.classProvides
 
 
 Usage
-+++++
+-----
 
 For example:
 
@@ -892,10 +893,10 @@ Which is equivalent to:
 
 
 :class:`zope.interface.declarations.provider`
----------------------------------------------
+=============================================
 
 API
-+++
+---
 
 .. autoclass:: zope.interface.declarations.provider
    :members:
@@ -903,26 +904,26 @@ API
 
 
 :func:`zope.interface.declarations.moduleProvides`
---------------------------------------------------
+==================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.moduleProvides
 
 
 
 :func:`zope.interface.declarations.ObjectSpecification`
--------------------------------------------------------
+=======================================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.ObjectSpecification
 
 
 Usage
-+++++
+-----
 
 For example:
 
@@ -988,26 +989,26 @@ For example:
 
 
 :func:`zope.interface.declarations.providedBy`
-----------------------------------------------
+==============================================
 
 API
-+++
+---
 
 .. autofunction:: zope.interface.declarations.providedBy
 
 
 :class:`zope.interface.declarations.ObjectSpecificationDescriptor`
-------------------------------------------------------------------
+==================================================================
 
 API
-+++
+---
 
 .. autoclass:: zope.interface.declarations.ObjectSpecificationDescriptor
    :members:
    :member-order: bysource
 
 Usage
-+++++
+-----
 
 For example:
 
@@ -1031,17 +1032,17 @@ depending on how we were accessed.
 
 
 :class:`zope.interface.declarations.named`
----------------------------------------------
+==========================================
 
 API
-+++
+---
 
 .. autoclass:: zope.interface.declarations.named
    :members:
    :member-order: bysource
 
 Usage
-+++++
+-----
 
 For example:
 
@@ -1062,10 +1063,10 @@ provided.
 
 
 :class:`zope.interface.adapter.AdapterRegistry`
------------------------------------------------
+===============================================
 
 API
-+++
+---
 
 The adapter registry's API is defined by
 :class:`zope.interface.interfaces.IAdapterRegistry`:
@@ -1075,15 +1076,15 @@ The adapter registry's API is defined by
    :member-order: bysource
 
 Usage
-+++++
+-----
 
 See :ref:`adapter-registry`.
 
 ``zope.interface.registry.Components``
---------------------------------------
+======================================
 
 API
-+++
+---
 
 The component registry's API is defined by
 ``zope.interface.interfaces.IComponents``:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1102,3 +1102,31 @@ The component registry's API is defined by
 .. autointerface:: zope.interface.interfaces.IComponentRegistry
    :members:
    :member-order: bysource
+
+Python Standard Library Interfaces
+==================================
+
+The ``zope.interface.common`` package provides interfaces for objects
+distributed as part of the Python standard library. Importing these
+modules has the effect of making the standard library objects
+implement the correct interface.
+
+``zope.interface.common.interfaces``
+------------------------------------
+
+.. automodule:: zope.interface.common.interfaces
+
+``zope.interface.common.idatetime``
+-----------------------------------
+
+.. automodule:: zope.interface.common.idatetime
+
+``zope.interface.common.mapping``
+---------------------------------
+
+.. automodule:: zope.interface.common.mapping
+
+``zope.interface.common.sequence``
+----------------------------------
+
+.. automodule:: zope.interface.common.sequence

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,3 +261,6 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
+
+autodoc_default_flags = ['members', 'show-inheritance']
+autoclass_content = 'both'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ release = rqmt.version
 exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+default_role = 'obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True
@@ -264,3 +264,4 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 autodoc_default_flags = ['members', 'show-inheritance']
 autoclass_content = 'both'
+autodoc_member_order = 'bysource'

--- a/src/zope/interface/common/idatetime.py
+++ b/src/zope/interface/common/idatetime.py
@@ -1,7 +1,7 @@
 ##############################################################################
 # Copyright (c) 2002 Zope Foundation and Contributors.
 # All Rights Reserved.
-# 
+#
 # This software is subject to the provisions of the Zope Public License,
 # Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
 # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
@@ -14,15 +14,18 @@
 This module is called idatetime because if it were called datetime the import
 of the real datetime would fail.
 """
+from datetime import timedelta, date, datetime, time, tzinfo
 
 from zope.interface import Interface, Attribute
 from zope.interface import classImplements
 
-from datetime import timedelta, date, datetime, time, tzinfo
-
 
 class ITimeDeltaClass(Interface):
-    """This is the timedelta class interface."""
+    """This is the timedelta class interface.
+
+    This is symbolic; this module does **not** make
+    `datetime.timedelta` provide this interface.
+    """
 
     min = Attribute("The most negative timedelta object")
 
@@ -35,6 +38,8 @@ class ITimeDeltaClass(Interface):
 class ITimeDelta(ITimeDeltaClass):
     """Represent the difference between two datetime objects.
 
+    Implemented by `datetime.timedelta`.
+
     Supported operators:
 
     - add, subtract timedelta
@@ -42,9 +47,9 @@ class ITimeDelta(ITimeDeltaClass):
     - compare to timedelta
     - multiply, divide by int/long
 
-    In addition, datetime supports subtraction of two datetime objects
-    returning a timedelta, and addition or subtraction of a datetime
-    and a timedelta giving a datetime.
+    In addition, `.datetime` supports subtraction of two `.datetime` objects
+    returning a `.timedelta`, and addition or subtraction of a `.datetime`
+    and a `.timedelta` giving a `.datetime`.
 
     Representation: (days, seconds, microseconds).
     """
@@ -57,7 +62,11 @@ class ITimeDelta(ITimeDeltaClass):
 
 
 class IDateClass(Interface):
-    """This is the date class interface."""
+    """This is the date class interface.
+
+    This is symbolic; this module does **not** make
+    `datetime.date` provide this interface.
+    """
 
     min = Attribute("The earliest representable date")
 
@@ -69,29 +78,32 @@ class IDateClass(Interface):
     def today():
         """Return the current local time.
 
-        This is equivalent to date.fromtimestamp(time.time())"""
+        This is equivalent to ``date.fromtimestamp(time.time())``"""
 
     def fromtimestamp(timestamp):
         """Return the local date from a POSIX timestamp (like time.time())
 
-        This may raise ValueError, if the timestamp is out of the range of
-        values supported by the platform C localtime() function. It's common
+        This may raise `ValueError`, if the timestamp is out of the range of
+        values supported by the platform C ``localtime()`` function. It's common
         for this to be restricted to years from 1970 through 2038. Note that
         on non-POSIX systems that include leap seconds in their notion of a
-        timestamp, leap seconds are ignored by fromtimestamp().
+        timestamp, leap seconds are ignored by `fromtimestamp`.
         """
 
     def fromordinal(ordinal):
         """Return the date corresponding to the proleptic Gregorian ordinal.
 
-         January 1 of year 1 has ordinal 1. ValueError is raised unless
+         January 1 of year 1 has ordinal 1. `ValueError` is raised unless
          1 <= ordinal <= date.max.toordinal().
-         For any date d, date.fromordinal(d.toordinal()) == d.
+
+         For any date *d*, ``date.fromordinal(d.toordinal()) == d``.
          """
 
 
 class IDate(IDateClass):
     """Represents a date (year, month and day) in an idealized calendar.
+
+    Implemented by `datetime.date`.
 
     Operators:
 
@@ -111,33 +123,33 @@ class IDate(IDateClass):
         """Return a date with the same value.
 
         Except for those members given new values by whichever keyword
-        arguments are specified. For example, if d == date(2002, 12, 31), then
-        d.replace(day=26) == date(2000, 12, 26). 
+        arguments are specified. For example, if ``d == date(2002, 12, 31)``, then
+        ``d.replace(day=26) == date(2000, 12, 26)``.
         """
 
     def timetuple():
-        """Return a 9-element tuple of the form returned by time.localtime().
+        """Return a 9-element tuple of the form returned by `time.localtime`.
 
         The hours, minutes and seconds are 0, and the DST flag is -1.
-        d.timetuple() is equivalent to
-        (d.year, d.month, d.day, 0, 0, 0, d.weekday(), d.toordinal() -
-        date(d.year, 1, 1).toordinal() + 1, -1)
+        ``d.timetuple()`` is equivalent to
+        ``(d.year, d.month, d.day, 0, 0, 0, d.weekday(), d.toordinal() -
+        date(d.year, 1, 1).toordinal() + 1, -1)``
         """
 
     def toordinal():
         """Return the proleptic Gregorian ordinal of the date
 
-        January 1 of year 1 has ordinal 1. For any date object d,
-        date.fromordinal(d.toordinal()) == d.
+        January 1 of year 1 has ordinal 1. For any date object *d*,
+        ``date.fromordinal(d.toordinal()) == d``.
         """
 
     def weekday():
         """Return the day of the week as an integer.
 
         Monday is 0 and Sunday is 6. For example,
-        date(2002, 12, 4).weekday() == 2, a Wednesday.
+        ``date(2002, 12, 4).weekday() == 2``, a Wednesday.
 
-        See also isoweekday().
+        .. seealso:: `isoweekday`.
         """
 
     def isoweekday():
@@ -146,7 +158,7 @@ class IDate(IDateClass):
         Monday is 1 and Sunday is 7. For example,
         date(2002, 12, 4).isoweekday() == 3, a Wednesday.
 
-        See also weekday(), isocalendar().
+        .. seealso:: `weekday`, `isocalendar`.
         """
 
     def isocalendar():
@@ -164,19 +176,19 @@ class IDate(IDateClass):
 
         For example, 2004 begins on a Thursday, so the first week of ISO year
         2004 begins on Monday, 29 Dec 2003 and ends on Sunday, 4 Jan 2004, so
-        that date(2003, 12, 29).isocalendar() == (2004, 1, 1) and
-        date(2004, 1, 4).isocalendar() == (2004, 1, 7).
+        that ``date(2003, 12, 29).isocalendar() == (2004, 1, 1)`` and
+        ``date(2004, 1, 4).isocalendar() == (2004, 1, 7)``.
         """
 
     def isoformat():
         """Return a string representing the date in ISO 8601 format.
 
         This is 'YYYY-MM-DD'.
-        For example, date(2002, 12, 4).isoformat() == '2002-12-04'.
+        For example, ``date(2002, 12, 4).isoformat() == '2002-12-04'``.
         """
 
     def __str__():
-        """For a date d, str(d) is equivalent to d.isoformat()."""
+        """For a date *d*, ``str(d)`` is equivalent to ``d.isoformat()``."""
 
     def ctime():
         """Return a string representing the date.
@@ -184,7 +196,7 @@ class IDate(IDateClass):
         For example date(2002, 12, 4).ctime() == 'Wed Dec 4 00:00:00 2002'.
         d.ctime() is equivalent to time.ctime(time.mktime(d.timetuple()))
         on platforms where the native C ctime() function
-        (which time.ctime() invokes, but which date.ctime() does not invoke)
+        (which `time.ctime` invokes, but which date.ctime() does not invoke)
         conforms to the C standard.
         """
 
@@ -197,7 +209,11 @@ class IDate(IDateClass):
 
 
 class IDateTimeClass(Interface):
-    """This is the datetime class interface."""
+    """This is the datetime class interface.
+
+    This is symbolic; this module does **not** make
+    `datetime.datetime` provide this interface.
+    """
 
     min = Attribute("The earliest representable datetime")
 
@@ -209,32 +225,33 @@ class IDateTimeClass(Interface):
     def today():
         """Return the current local datetime, with tzinfo None.
 
-        This is equivalent to datetime.fromtimestamp(time.time()).
-        See also now(), fromtimestamp().
+        This is equivalent to ``datetime.fromtimestamp(time.time())``.
+
+        .. seealso:: `now`, `fromtimestamp`.
         """
 
     def now(tz=None):
         """Return the current local date and time.
 
-        If optional argument tz is None or not specified, this is like today(),
+        If optional argument *tz* is None or not specified, this is like `today`,
         but, if possible, supplies more precision than can be gotten from going
-        through a time.time() timestamp (for example, this may be possible on
-        platforms supplying the C gettimeofday() function).
+        through a `time.time` timestamp (for example, this may be possible on
+        platforms supplying the C ``gettimeofday()`` function).
 
         Else tz must be an instance of a class tzinfo subclass, and the current
         date and time are converted to tz's time zone. In this case the result
         is equivalent to tz.fromutc(datetime.utcnow().replace(tzinfo=tz)).
 
-        See also today(), utcnow().
+        .. seealso:: `today`, `utcnow`.
         """
 
     def utcnow():
         """Return the current UTC date and time, with tzinfo None.
 
-        This is like now(), but returns the current UTC date and time, as a
-        naive datetime object. 
+        This is like `now`, but returns the current UTC date and time, as a
+        naive datetime object.
 
-        See also now().
+        .. seealso:: `now`.
         """
 
     def fromtimestamp(timestamp, tz=None):
@@ -247,9 +264,9 @@ class IDateTimeClass(Interface):
         Else tz must be an instance of a class tzinfo subclass, and the
         timestamp is converted to tz's time zone. In this case the result is
         equivalent to
-        tz.fromutc(datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz)).
+        ``tz.fromutc(datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz))``.
 
-        fromtimestamp() may raise ValueError, if the timestamp is out of the
+        fromtimestamp() may raise `ValueError`, if the timestamp is out of the
         range of values supported by the platform C localtime() or gmtime()
         functions. It's common for this to be restricted to years in 1970
         through 2038. Note that on non-POSIX systems that include leap seconds
@@ -257,23 +274,23 @@ class IDateTimeClass(Interface):
         fromtimestamp(), and then it's possible to have two timestamps
         differing by a second that yield identical datetime objects.
 
-        See also utcfromtimestamp().
+        .. seealso:: `utcfromtimestamp`.
         """
 
     def utcfromtimestamp(timestamp):
         """Return the UTC datetime from the POSIX timestamp with tzinfo None.
 
-        This may raise ValueError, if the timestamp is out of the range of
-        values supported by the platform C gmtime() function. It's common for
+        This may raise `ValueError`, if the timestamp is out of the range of
+        values supported by the platform C ``gmtime()`` function. It's common for
         this to be restricted to years in 1970 through 2038.
 
-        See also fromtimestamp().
+        .. seealso:: `fromtimestamp`.
         """
 
     def fromordinal(ordinal):
         """Return the datetime from the proleptic Gregorian ordinal.
 
-        January 1 of year 1 has ordinal 1. ValueError is raised unless
+        January 1 of year 1 has ordinal 1. `ValueError` is raised unless
         1 <= ordinal <= datetime.max.toordinal().
         The hour, minute, second and microsecond of the result are all 0, and
         tzinfo is None.
@@ -284,13 +301,15 @@ class IDateTimeClass(Interface):
 
         Its date members are equal to the given date object's, and whose time
         and tzinfo members are equal to the given time object's. For any
-        datetime object d, d == datetime.combine(d.date(), d.timetz()).
+        datetime object *d*, ``d == datetime.combine(d.date(), d.timetz())``.
         If date is a datetime object, its time and tzinfo members are ignored.
         """
 
 
 class IDateTime(IDate, IDateTimeClass):
     """Object contains all the information from a date object and a time object.
+
+    Implemented by `datetime.datetime`.
     """
 
     year = Attribute("Year between MINYEAR and MAXYEAR inclusive")
@@ -318,21 +337,23 @@ class IDateTime(IDate, IDateTimeClass):
     def time():
         """Return time object with same hour, minute, second, microsecond.
 
-        tzinfo is None. See also method timetz().
+        tzinfo is None.
+
+        .. seealso:: Method :meth:`timetz`.
         """
 
     def timetz():
         """Return time object with same hour, minute, second, microsecond,
         and tzinfo.
 
-        See also method time().
+        .. seealso:: Method :meth:`time`.
         """
 
     def replace(year, month, day, hour, minute, second, microsecond, tzinfo):
         """Return a datetime with the same members, except for those members
         given new values by whichever keyword arguments are specified.
 
-        Note that tzinfo=None can be specified to create a naive datetime from
+        Note that ``tzinfo=None`` can be specified to create a naive datetime from
         an aware datetime with no conversion of date and time members.
         """
 
@@ -348,20 +369,22 @@ class IDateTime(IDate, IDateTimeClass):
         If self.tzinfo is tz, self.astimezone(tz) is equal to self: no
         adjustment of date or time members is performed. Else the result is
         local time in time zone tz, representing the same UTC time as self:
+
             after astz = dt.astimezone(tz), astz - astz.utcoffset()
+
         will usually have the same date and time members as dt - dt.utcoffset().
-        The discussion of class tzinfo explains the cases at Daylight Saving
+        The discussion of class `datetime.tzinfo` explains the cases at Daylight Saving
         Time transition boundaries where this cannot be achieved (an issue only
         if tz models both standard and daylight time).
 
-        If you merely want to attach a time zone object tz to a datetime dt
-        without adjustment of date and time members, use dt.replace(tzinfo=tz).
+        If you merely want to attach a time zone object *tz* to a datetime *dt*
+        without adjustment of date and time members, use ``dt.replace(tzinfo=tz)``.
         If you merely want to remove the time zone object from an aware
-        datetime dt without conversion of date and time members, use 
-        dt.replace(tzinfo=None).
+        datetime dt without conversion of date and time members, use
+        ``dt.replace(tzinfo=None)``.
 
-        Note that the default tzinfo.fromutc() method can be overridden in a
-        tzinfo subclass to effect the result returned by astimezone().
+        Note that the default `tzinfo.fromutc` method can be overridden in a
+        tzinfo subclass to effect the result returned by `astimezone`.
         """
 
     def utcoffset():
@@ -377,10 +400,10 @@ class IDateTime(IDate, IDateTimeClass):
         """Return the timezone name."""
 
     def timetuple():
-        """Return a 9-element tuple of the form returned by time.localtime()."""
+        """Return a 9-element tuple of the form returned by `time.localtime`."""
 
     def utctimetuple():
-        """Return UTC time tuple compatilble with time.gmtimr()."""
+        """Return UTC time tuple compatilble with `time.gmtime`."""
 
     def toordinal():
         """Return the proleptic Gregorian ordinal of the date.
@@ -399,7 +422,8 @@ class IDateTime(IDate, IDateTimeClass):
         """Return the day of the week as an integer.
 
         Monday is 1 and Sunday is 7. The same as self.date().isoweekday.
-        See also weekday(), isocalendar().
+
+        .. seealso:: `weekday`, `isocalendar`.
         """
 
     def isocalendar():
@@ -413,7 +437,7 @@ class IDateTime(IDate, IDateTimeClass):
 
         YYYY-MM-DDTHH:MM:SS.mmmmmm or YYYY-MM-DDTHH:MM:SS if microsecond is 0
 
-        If utcoffset() does not return None, a 6-character string is appended,
+        If `utcoffset` does not return None, a 6-character string is appended,
         giving the UTC offset in (signed) hours and minutes:
 
         YYYY-MM-DDTHH:MM:SS.mmmmmm+HH:MM or YYYY-MM-DDTHH:MM:SS+HH:MM
@@ -424,16 +448,16 @@ class IDateTime(IDate, IDateTimeClass):
         """
 
     def __str__():
-        """For a datetime instance d, str(d) is equivalent to d.isoformat(' ').
+        """For a datetime instance *d*, ``str(d)`` is equivalent to ``d.isoformat(' ')``.
         """
 
     def ctime():
         """Return a string representing the date and time.
 
-        datetime(2002, 12, 4, 20, 30, 40).ctime() == 'Wed Dec 4 20:30:40 2002'.
-        d.ctime() is equivalent to time.ctime(time.mktime(d.timetuple())) on
-        platforms where the native C ctime() function (which time.ctime()
-        invokes, but which datetime.ctime() does not invoke) conforms to the
+        ``datetime(2002, 12, 4, 20, 30, 40).ctime() == 'Wed Dec 4 20:30:40 2002'``.
+        ``d.ctime()`` is equivalent to ``time.ctime(time.mktime(d.timetuple()))`` on
+        platforms where the native C ``ctime()`` function (which `time.ctime`
+        invokes, but which `datetime.ctime` does not invoke) conforms to the
         C standard.
         """
 
@@ -445,7 +469,12 @@ class IDateTime(IDate, IDateTimeClass):
 
 
 class ITimeClass(Interface):
-    """This is the time class interface."""
+    """This is the time class interface.
+
+    This is symbolic; this module does **not** make
+    `datetime.time` provide this interface.
+
+    """
 
     min = Attribute("The earliest representable time")
 
@@ -457,6 +486,8 @@ class ITimeClass(Interface):
 
 class ITime(ITimeClass):
     """Represent time with time zone.
+
+    Implemented by `datetime.time`.
 
     Operators:
 

--- a/src/zope/interface/common/interfaces.py
+++ b/src/zope/interface/common/interfaces.py
@@ -16,87 +16,197 @@
 from zope.interface import Interface
 from zope.interface import classImplements
 
-class IException(Interface): pass
-class IStandardError(IException): pass
-class IWarning(IException): pass
-class ISyntaxError(IStandardError): pass
-class ILookupError(IStandardError): pass
-class IValueError(IStandardError): pass
-class IRuntimeError(IStandardError): pass
-class IArithmeticError(IStandardError): pass
-class IAssertionError(IStandardError): pass
-class IAttributeError(IStandardError): pass
-class IDeprecationWarning(IWarning): pass
-class IEOFError(IStandardError): pass
-class IEnvironmentError(IStandardError): pass
-class IFloatingPointError(IArithmeticError): pass
-class IIOError(IEnvironmentError): pass
-class IImportError(IStandardError): pass
-class IIndentationError(ISyntaxError): pass
-class IIndexError(ILookupError): pass
-class IKeyError(ILookupError): pass
-class IKeyboardInterrupt(IStandardError): pass
-class IMemoryError(IStandardError): pass
-class INameError(IStandardError): pass
-class INotImplementedError(IRuntimeError): pass
-class IOSError(IEnvironmentError): pass
-class IOverflowError(IArithmeticError): pass
-class IOverflowWarning(IWarning): pass
-class IReferenceError(IStandardError): pass
-class IRuntimeWarning(IWarning): pass
-class IStopIteration(IException): pass
-class ISyntaxWarning(IWarning): pass
-class ISystemError(IStandardError): pass
-class ISystemExit(IException): pass
-class ITabError(IIndentationError): pass
-class ITypeError(IStandardError): pass
-class IUnboundLocalError(INameError): pass
-class IUnicodeError(IValueError): pass
-class IUserWarning(IWarning): pass
-class IZeroDivisionError(IArithmeticError): pass
-
-classImplements(ArithmeticError, IArithmeticError)
-classImplements(AssertionError, IAssertionError)
-classImplements(AttributeError, IAttributeError)
-classImplements(DeprecationWarning, IDeprecationWarning)
-classImplements(EnvironmentError, IEnvironmentError)
-classImplements(EOFError, IEOFError)
+class IException(Interface):
+    "Interface for `Exception`"
 classImplements(Exception, IException)
-classImplements(FloatingPointError, IFloatingPointError)
-classImplements(ImportError, IImportError)
-classImplements(IndentationError, IIndentationError)
-classImplements(IndexError, IIndexError)
-classImplements(IOError, IIOError)
-classImplements(KeyboardInterrupt, IKeyboardInterrupt)
-classImplements(KeyError, IKeyError)
-classImplements(LookupError, ILookupError)
-classImplements(MemoryError, IMemoryError)
-classImplements(NameError, INameError)
-classImplements(NotImplementedError, INotImplementedError)
-classImplements(OSError, IOSError)
-classImplements(OverflowError, IOverflowError)
-try:
-    classImplements(OverflowWarning, IOverflowWarning)
-except NameError:  #pragma NO COVER
-    pass # OverflowWarning was removed in Python 2.5
-classImplements(ReferenceError, IReferenceError)
-classImplements(RuntimeError, IRuntimeError)
-classImplements(RuntimeWarning, IRuntimeWarning)
+
+
+class IStandardError(IException):
+    "Interface for `StandardError` (Python 2 only.)"
 try:
     classImplements(StandardError, IStandardError)
 except NameError:  #pragma NO COVER
     pass # StandardError does not exist in Python 3
-classImplements(StopIteration, IStopIteration)
-classImplements(SyntaxError, ISyntaxError)
-classImplements(SyntaxWarning, ISyntaxWarning)
-classImplements(SystemError, ISystemError)
-classImplements(SystemExit, ISystemExit)
-classImplements(TabError, ITabError)
-classImplements(TypeError, ITypeError)
-classImplements(UnboundLocalError, IUnboundLocalError)
-classImplements(UnicodeError, IUnicodeError)
-classImplements(UserWarning, IUserWarning)
-classImplements(ValueError, IValueError)
-classImplements(Warning, IWarning)
-classImplements(ZeroDivisionError, IZeroDivisionError)
 
+
+class IWarning(IException):
+    "Interface for `Warning`"
+classImplements(Warning, IWarning)
+
+
+class ISyntaxError(IStandardError):
+    "Interface for `SyntaxError`"
+classImplements(SyntaxError, ISyntaxError)
+
+
+class ILookupError(IStandardError):
+    "Interface for `LookupError`"
+classImplements(LookupError, ILookupError)
+
+
+class IValueError(IStandardError):
+    "Interface for `ValueError`"
+classImplements(ValueError, IValueError)
+
+
+class IRuntimeError(IStandardError):
+    "Interface for `RuntimeError`"
+classImplements(RuntimeError, IRuntimeError)
+
+
+class IArithmeticError(IStandardError):
+    "Interface for `ArithmeticError`"
+classImplements(ArithmeticError, IArithmeticError)
+
+
+class IAssertionError(IStandardError):
+    "Interface for `AssertionError`"
+classImplements(AssertionError, IAssertionError)
+
+
+class IAttributeError(IStandardError):
+    "Interface for `AttributeError`"
+classImplements(AttributeError, IAttributeError)
+
+
+class IDeprecationWarning(IWarning):
+    "Interface for `DeprecationWarning`"
+classImplements(DeprecationWarning, IDeprecationWarning)
+
+
+class IEOFError(IStandardError):
+    "Interface for `EOFError`"
+classImplements(EOFError, IEOFError)
+
+
+class IEnvironmentError(IStandardError):
+    "Interface for `EnvironmentError`"
+classImplements(EnvironmentError, IEnvironmentError)
+
+
+class IFloatingPointError(IArithmeticError):
+    "Interface for `FloatingPointError`"
+classImplements(FloatingPointError, IFloatingPointError)
+
+
+class IIOError(IEnvironmentError):
+    "Interface for `IOError`"
+classImplements(IOError, IIOError)
+
+
+class IImportError(IStandardError):
+    "Interface for `ImportError`"
+classImplements(ImportError, IImportError)
+
+
+class IIndentationError(ISyntaxError):
+    "Interface for `IndentationError`"
+classImplements(IndentationError, IIndentationError)
+
+
+class IIndexError(ILookupError):
+    "Interface for `IndexError`"
+classImplements(IndexError, IIndexError)
+
+
+class IKeyError(ILookupError):
+    "Interface for `KeyError`"
+classImplements(KeyError, IKeyError)
+
+
+class IKeyboardInterrupt(IStandardError):
+    "Interface for `KeyboardInterrupt`"
+classImplements(KeyboardInterrupt, IKeyboardInterrupt)
+
+
+class IMemoryError(IStandardError):
+    "Interface for `MemoryError`"
+classImplements(MemoryError, IMemoryError)
+
+
+class INameError(IStandardError):
+    "Interface for `NameError`"
+classImplements(NameError, INameError)
+
+
+class INotImplementedError(IRuntimeError):
+    "Interface for `NotImplementedError`"
+classImplements(NotImplementedError, INotImplementedError)
+
+
+class IOSError(IEnvironmentError):
+    "Interface for `OSError`"
+classImplements(OSError, IOSError)
+
+
+class IOverflowError(IArithmeticError):
+    "Interface for `ArithmeticError`"
+classImplements(OverflowError, IOverflowError)
+
+
+class IOverflowWarning(IWarning):
+    """Deprecated, no standard class implements this.
+
+    This was the interface for ``OverflowWarning`` prior to Python 2.5,
+    but that class was removed for all versions after that.
+    """
+
+
+class IReferenceError(IStandardError):
+    "Interface for `ReferenceError`"
+classImplements(ReferenceError, IReferenceError)
+
+
+class IRuntimeWarning(IWarning):
+    "Interface for `RuntimeWarning`"
+classImplements(RuntimeWarning, IRuntimeWarning)
+
+
+class IStopIteration(IException):
+    "Interface for `StopIteration`"
+classImplements(StopIteration, IStopIteration)
+
+
+class ISyntaxWarning(IWarning):
+    "Interface for `SyntaxWarning`"
+classImplements(SyntaxWarning, ISyntaxWarning)
+
+
+class ISystemError(IStandardError):
+    "Interface for `SystemError`"
+classImplements(SystemError, ISystemError)
+
+
+class ISystemExit(IException):
+    "Interface for `SystemExit`"
+classImplements(SystemExit, ISystemExit)
+
+
+class ITabError(IIndentationError):
+    "Interface for `TabError`"
+classImplements(TabError, ITabError)
+
+
+class ITypeError(IStandardError):
+    "Interface for `TypeError`"
+classImplements(TypeError, ITypeError)
+
+
+class IUnboundLocalError(INameError):
+    "Interface for `UnboundLocalError`"
+classImplements(UnboundLocalError, IUnboundLocalError)
+
+
+class IUnicodeError(IValueError):
+    "Interface for `UnicodeError`"
+classImplements(UnicodeError, IUnicodeError)
+
+
+class IUserWarning(IWarning):
+    "Interface for `UserWarning`"
+classImplements(UserWarning, IUserWarning)
+
+
+class IZeroDivisionError(IArithmeticError):
+    "Interface for `ZeroDivisionError`"
+classImplements(ZeroDivisionError, IZeroDivisionError)

--- a/src/zope/interface/common/mapping.py
+++ b/src/zope/interface/common/mapping.py
@@ -11,7 +11,10 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""Mapping Interfaces
+"""Mapping Interfaces.
+
+Importing this module does *not* mark any standard classes
+as implementing any of these interfaces.
 """
 from zope.interface import Interface
 
@@ -22,7 +25,7 @@ class IItemMapping(Interface):
     def __getitem__(key):
         """Get a value for a key
 
-        A KeyError is raised if there is no value for the key.
+        A `KeyError` is raised if there is no value for the key.
         """
 
 
@@ -42,13 +45,13 @@ class IReadMapping(IItemMapping):
 
 class IWriteMapping(Interface):
     """Mapping methods for changing data"""
-    
+
     def __delitem__(key):
         """Delete a value from the mapping using the key."""
 
     def __setitem__(key, value):
         """Set a new item in the mapping."""
-        
+
 
 class IEnumerableMapping(IReadMapping):
     """Mapping objects whose items can be enumerated.
@@ -78,9 +81,16 @@ class IMapping(IWriteMapping, IEnumerableMapping):
     ''' Simple mapping interface '''
 
 class IIterableMapping(IEnumerableMapping):
+    """A mapping that has distinct methods for iterating
+    without copying.
+
+    On Python 2, a `dict` has these methods, but on Python 3
+    the methods defined in `IEnumerableMapping` already iterate
+    without copying.
+    """
 
     def iterkeys():
-        "iterate over keys; equivalent to __iter__"
+        "iterate over keys; equivalent to ``__iter__``"
 
     def itervalues():
         "iterate over values"
@@ -89,32 +99,47 @@ class IIterableMapping(IEnumerableMapping):
         "iterate over items"
 
 class IClonableMapping(Interface):
-    
+    """Something that can produce a copy of itself.
+
+    This is available in `dict`.
+    """
+
     def copy():
         "return copy of dict"
 
 class IExtendedReadMapping(IIterableMapping):
-    
+    """
+    Something with a particular method equivalent to ``__contains__``.
+
+    On Python 2, `dict` provides this method, but it was removed
+    in Python 3.
+    """
+
     def has_key(key):
-        """Tell if a key exists in the mapping; equivalent to __contains__"""
+        """Tell if a key exists in the mapping; equivalent to ``__contains__``"""
 
 class IExtendedWriteMapping(IWriteMapping):
-    
+    """Additional mutation methods.
+
+    These are all provided by `dict`.
+    """
+
     def clear():
         "delete all items"
-    
+
     def update(d):
         " Update D from E: for k in E.keys(): D[k] = E[k]"
-    
+
     def setdefault(key, default=None):
         "D.setdefault(k[,d]) -> D.get(k,d), also set D[k]=d if k not in D"
-    
+
     def pop(k, *args):
-        """remove specified key and return the corresponding value
-        *args may contain a single default value, or may not be supplied.
-        If key is not found, default is returned if given, otherwise 
-        KeyError is raised"""
-    
+        """Remove specified key and return the corresponding value.
+
+        ``*args`` may contain a single default value, or may not be supplied.
+        If key is not found, default is returned if given, otherwise
+        `KeyError` is raised"""
+
     def popitem():
         """remove and return some (key, value) pair as a
         2-tuple; but raise KeyError if mapping is empty"""

--- a/src/zope/interface/common/sequence.py
+++ b/src/zope/interface/common/sequence.py
@@ -12,7 +12,11 @@
 #
 ##############################################################################
 """Sequence Interfaces
+
+Importing this module does *not* mark any standard classes
+as implementing any of these interfaces.
 """
+
 __docformat__ = 'restructuredtext'
 from zope.interface import Interface
 
@@ -22,7 +26,7 @@ class IMinimalSequence(Interface):
     All sequences are iterable.  This requires at least one of the
     following:
 
-    - a `__getitem__()` method that takes a single argument; interger
+    - a `__getitem__()` method that takes a single argument; integer
       values starting at 0 must be supported, and `IndexError` should
       be raised for the first index for which there is no value, or
 
@@ -32,7 +36,7 @@ class IMinimalSequence(Interface):
     """
 
     def __getitem__(index):
-        """`x.__getitem__(index)` <==> `x[index]`
+        """``x.__getitem__(index) <==> x[index]``
 
         Declaring this interface does not specify whether `__getitem__`
         supports slice objects."""
@@ -40,43 +44,43 @@ class IMinimalSequence(Interface):
 class IFiniteSequence(IMinimalSequence):
 
     def __len__():
-        """`x.__len__()` <==> `len(x)`"""
+        """``x.__len__() <==> len(x)``"""
 
 class IReadSequence(IFiniteSequence):
     """read interface shared by tuple and list"""
 
     def __contains__(item):
-        """`x.__contains__(item)` <==> `item in x`"""
+        """``x.__contains__(item) <==> item in x``"""
 
     def __lt__(other):
-        """`x.__lt__(other)` <==> `x < other`"""
+        """``x.__lt__(other) <==> x < other``"""
 
     def __le__(other):
-        """`x.__le__(other)` <==> `x <= other`"""
+        """``x.__le__(other) <==> x <= other``"""
 
     def __eq__(other):
-        """`x.__eq__(other)` <==> `x == other`"""
+        """``x.__eq__(other) <==> x == other``"""
 
     def __ne__(other):
-        """`x.__ne__(other)` <==> `x != other`"""
+        """``x.__ne__(other) <==> x != other``"""
 
     def __gt__(other):
-        """`x.__gt__(other)` <==> `x > other`"""
+        """``x.__gt__(other) <==> x > other``"""
 
     def __ge__(other):
-        """`x.__ge__(other)` <==> `x >= other`"""
+        """``x.__ge__(other) <==> x >= other``"""
 
     def __add__(other):
-        """`x.__add__(other)` <==> `x + other`"""
+        """``x.__add__(other) <==> x + other``"""
 
     def __mul__(n):
-        """`x.__mul__(n)` <==> `x * n`"""
+        """``x.__mul__(n) <==> x * n``"""
 
     def __rmul__(n):
-        """`x.__rmul__(n)` <==> `n * x`"""
+        """``x.__rmul__(n) <==> n * x``"""
 
     def __getslice__(i, j):
-        """`x.__getslice__(i, j)` <==> `x[i:j]`
+        """``x.__getslice__(i, j) <==> x[i:j]``
 
         Use of negative indices is not supported.
 
@@ -90,29 +94,30 @@ class IExtendedReadSequence(IReadSequence):
         """Return number of occurrences of value"""
 
     def index(item, *args):
-        """Return first index of value
+        """index(value, [start, [stop]]) -> int
 
-        `L.index(value, [start, [stop]])` -> integer"""
+        Return first index of *value*
+        """
 
 class IUniqueMemberWriteSequence(Interface):
     """The write contract for a sequence that may enforce unique members"""
 
     def __setitem__(index, item):
-        """`x.__setitem__(index, item)` <==> `x[index] = item`
+        """``x.__setitem__(index, item) <==> x[index] = item``
 
         Declaring this interface does not specify whether `__setitem__`
         supports slice objects.
         """
 
     def __delitem__(index):
-        """`x.__delitem__(index)` <==> `del x[index]`
+        """``x.__delitem__(index) <==> del x[index]``
 
         Declaring this interface does not specify whether `__delitem__`
         supports slice objects.
         """
 
     def __setslice__(i, j, other):
-        """`x.__setslice__(i, j, other)` <==> `x[i:j]=other`
+        """``x.__setslice__(i, j, other) <==> x[i:j] = other``
 
         Use of negative indices is not supported.
 
@@ -120,14 +125,14 @@ class IUniqueMemberWriteSequence(Interface):
         """
 
     def __delslice__(i, j):
-        """`x.__delslice__(i, j)` <==> `del x[i:j]`
+        """``x.__delslice__(i, j) <==> del x[i:j]``
 
         Use of negative indices is not supported.
 
         Deprecated since Python 2.0 but still a part of `UserList`.
         """
     def __iadd__(y):
-        """`x.__iadd__(y)` <==> `x += y`"""
+        """``x.__iadd__(y) <==> x += y``"""
 
     def append(item):
         """Append item to end"""
@@ -154,7 +159,7 @@ class IWriteSequence(IUniqueMemberWriteSequence):
     """Full write contract for sequences"""
 
     def __imul__(n):
-        """`x.__imul__(n)` <==> `x *= n`"""
+        """``x.__imul__(n) <==> x *= n``"""
 
 class ISequence(IReadSequence, IWriteSequence):
     """Full sequence contract"""


### PR DESCRIPTION
I was working on documenting another project and wanted to link to them (especially zope.interface.common.idatetime) but discovered they weren't published.

This makes the API page even longer and more unwieldy. I'm working on a followup PR that splits it into more manageable chunks.