### PR TITLE
Reorganize API docs

### DIFF
--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -1,0 +1,13 @@
+==================
+ Adapter Registry
+==================
+
+Usage of the adapter registry is documented in :ref:`adapter-registry`.
+
+
+The adapter registry's API is defined by
+:class:`zope.interface.interfaces.IAdapterRegistry`:
+
+.. autointerface:: zope.interface.adapter.IAdapterRegistry
+   :members:
+   :member-order: bysource

--- a/docs/api/common.rst
+++ b/docs/api/common.rst
@@ -1,0 +1,28 @@
+====================================
+ Python Standard Library Interfaces
+====================================
+
+The ``zope.interface.common`` package provides interfaces for objects
+distributed as part of the Python standard library. Importing these
+modules has the effect of making the standard library objects
+implement the correct interface.
+
+``zope.interface.common.interfaces``
+====================================
+
+.. automodule:: zope.interface.common.interfaces
+
+``zope.interface.common.idatetime``
+===================================
+
+.. automodule:: zope.interface.common.idatetime
+
+``zope.interface.common.mapping``
+=================================
+
+.. automodule:: zope.interface.common.mapping
+
+``zope.interface.common.sequence``
+==================================
+
+.. automodule:: zope.interface.common.sequence

--- a/docs/api/components.rst
+++ b/docs/api/components.rst
@@ -1,0 +1,77 @@
+======================
+ Component Registries
+======================
+
+The component registry's API is defined by
+``zope.interface.interfaces.IComponents``:
+
+.. autointerface:: zope.interface.interfaces.IComponentLookup
+   :members:
+   :member-order: bysource
+
+
+.. autointerface:: zope.interface.interfaces.IComponentRegistry
+   :members:
+   :member-order: bysource
+
+.. autointerface:: zope.interface.interfaces.IComponents
+   :members:
+   :member-order: bysource
+
+One default implementation of `~zope.interface.interfaces.IComponents` is provided.
+
+.. autoclass:: zope.interface.registry.Components
+
+Events
+======
+
+Adding and removing components from the component registry create
+registration and unregistration events. Like most things, they are
+defined by an interface and a default implementation is provided.
+
+Registration
+------------
+
+.. autointerface:: zope.interface.interfaces.IRegistrationEvent
+
+.. autointerface:: zope.interface.interfaces.IRegistered
+.. autoclass:: zope.interface.interfaces.Registered
+
+.. autointerface:: zope.interface.interfaces.IUnregistered
+.. autoclass:: zope.interface.interfaces.Unregistered
+
+
+Details
+-------
+
+These are all types of ``ObjectEvent``, meaning they have an object
+that provides specific details about the event. Component registries
+create detail objects for four types of components they manage.
+
+All four share a common base interface.
+
+.. autointerface:: zope.interface.interfaces.IRegistration
+
+* Utilties
+
+  .. autointerface:: zope.interface.interfaces.IUtilityRegistration
+  .. autoclass:: zope.interface.registry.UtilityRegistration
+
+* Handlers
+
+  .. autointerface:: zope.interface.interfaces.IHandlerRegistration
+  .. autoclass:: zope.interface.registry.HandlerRegistration
+
+* Adapters
+
+  For ease of implementation, a shared base class is used for these
+  events. It should not be referenced by clients, but it is documented
+  to show the common attributes.
+
+  .. autointerface:: zope.interface.interfaces._IBaseAdapterRegistration
+
+  .. autointerface:: zope.interface.interfaces.IAdapterRegistration
+  .. autoclass:: zope.interface.registry.AdapterRegistration
+
+  .. autointerface:: zope.interface.interfaces.ISubscriptionAdapterRegistration
+  .. autoclass:: zope.interface.registry.SubscriptionRegistration

--- a/docs/api/components.rst
+++ b/docs/api/components.rst
@@ -32,6 +32,7 @@ defined by an interface and a default implementation is provided.
 Registration
 ------------
 
+.. autointerface:: zope.interface.interfaces.IObjectEvent
 .. autointerface:: zope.interface.interfaces.IRegistrationEvent
 
 .. autointerface:: zope.interface.interfaces.IRegistered
@@ -44,7 +45,7 @@ Registration
 Details
 -------
 
-These are all types of ``ObjectEvent``, meaning they have an object
+These are all types of ``IObjectEvent``, meaning they have an object
 that provides specific details about the event. Component registries
 create detail objects for four types of components they manage.
 
@@ -75,3 +76,9 @@ All four share a common base interface.
 
   .. autointerface:: zope.interface.interfaces.ISubscriptionAdapterRegistration
   .. autoclass:: zope.interface.registry.SubscriptionRegistration
+
+Exceptions
+==========
+
+.. autoclass:: zope.interface.interfaces.ComponentLookupError
+.. autoclass:: zope.interface.interfaces.Invalid

--- a/docs/api/declarations.rst
+++ b/docs/api/declarations.rst
@@ -1,206 +1,23 @@
 =========================================
- :mod:`zope.interface` API Documentation
+ API for ``zope.interface.declarations``
 =========================================
 
 
-:class:`zope.interface.interface.Specification`
-===============================================
+``Declaration``
+===============
+
 
 API
 ---
 
-Specification objects implement the API defined by
-:class:`zope.interface.interfaces.ISpecification`:
-
-.. autointerface:: zope.interface.interfaces.ISpecification
-   :members:
-   :member-order: bysource
-
-
-Usage
------
-
-For example:
-
-.. doctest::
-
-   >>> from zope.interface.interface import Specification
-   >>> from zope.interface import Interface
-   >>> class I1(Interface):
-   ...     pass
-   >>> class I2(I1):
-   ...     pass
-   >>> class I3(I2):
-   ...     pass
-   >>> [i.__name__ for i in I1.__bases__]
-   ['Interface']
-   >>> [i.__name__ for i in I2.__bases__]
-   ['I1']
-   >>> I3.extends(I1)
-   True
-   >>> I2.__bases__ = (Interface, )
-   >>> [i.__name__ for i in I2.__bases__]
-   ['Interface']
-   >>> I3.extends(I1)
-   False
-
-Exmples for :meth:`Specification.providedBy`:
-
-.. doctest::
-
-   >>> from zope.interface import *
-   >>> class I1(Interface):
-   ...     pass
-   >>> class C(object):
-   ...     implements(I1)
-   >>> c = C()
-   >>> class X(object):
-   ...     pass
-   >>> x = X()
-   >>> I1.providedBy(x)
-   False
-   >>> I1.providedBy(C)
-   False
-   >>> I1.providedBy(c)
-   True
-   >>> directlyProvides(x, I1)
-   >>> I1.providedBy(x)
-   True
-   >>> directlyProvides(C, I1)
-   >>> I1.providedBy(C)
-   True
-
-Examples for :meth:`Specification.isOrExtends`:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> from zope.interface.declarations import Declaration
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(I1): pass
-   ...
-   >>> class I3(Interface): pass
-   ...
-   >>> class I4(I3): pass
-   ...
-   >>> spec = Declaration()
-   >>> int(spec.extends(Interface))
-   1
-   >>> spec = Declaration(I2)
-   >>> int(spec.extends(Interface))
-   1
-   >>> int(spec.extends(I1))
-   1
-   >>> int(spec.extends(I2))
-   1
-   >>> int(spec.extends(I3))
-   0
-   >>> int(spec.extends(I4))
-   0
-
-Examples for :meth:`Specification.interfaces`:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(I1): pass
-   ...
-   >>> class I3(Interface): pass
-   ...
-   >>> class I4(I3): pass
-   ...
-   >>> spec = Specification((I2, I3))
-   >>> spec = Specification((I4, spec))
-   >>> i = spec.interfaces()
-   >>> [x.getName() for x in i]
-   ['I4', 'I2', 'I3']
-   >>> list(i)
-   []
-
-Exmples for :meth:`Specification.extends`:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> from zope.interface.declarations import Declaration
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(I1): pass
-   ...
-   >>> class I3(Interface): pass
-   ...
-   >>> class I4(I3): pass
-   ...
-   >>> spec = Declaration()
-   >>> int(spec.extends(Interface))
-   1
-   >>> spec = Declaration(I2)
-   >>> int(spec.extends(Interface))
-   1
-   >>> int(spec.extends(I1))
-   1
-   >>> int(spec.extends(I2))
-   1
-   >>> int(spec.extends(I3))
-   0
-   >>> int(spec.extends(I4))
-   0
-   >>> I2.extends(I2)
-   False
-   >>> I2.extends(I2, False)
-   True
-   >>> I2.extends(I2, strict=False)
-   True
-
-
-:class:`zope.interface.interface.InterfaceClass`
-================================================
-
-API
----
-
-Specification objects implement the API defined by
-:class:`zope.interface.interfaces.IInterface`:
-
-.. autointerface:: zope.interface.interfaces.IInterface
-   :members:
-   :member-order: bysource
-
-
-Usage
------
-
-Exmples for :meth:`InterfaceClass.extends`:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> class I1(Interface): pass
-   ...
-   >>>
-   >>> i = I1.interfaces()
-   >>> [x.getName() for x in i]
-   ['I1']
-   >>> list(i)
-   []
-
-
-:class:`zope.interface.declarations.Declaration`
-================================================
-
-API
----
-
-Specification objects implement the API defined by
+Declaration objects implement the API defined by
 :class:`zope.interface.interfaces.IDeclaration`:
 
 .. autointerface:: zope.interface.interfaces.IDeclaration
    :members:
    :member-order: bysource
 
+.. autoclass:: zope.interface.declarations.Declaration
 
 Usage
 -----
@@ -209,6 +26,7 @@ Exmples for :meth:`Declaration.__contains__`:
 
 .. doctest::
 
+   >>> from zope.interface.declarations import Declaration
    >>> from zope.interface import Interface
    >>> class I1(Interface): pass
    ...
@@ -339,8 +157,9 @@ Exmples for :meth:`Declaration.__add__`:
    ['I3', 'I4', 'I1']
 
 
-:func:`zope.interface.declarations.implementedBy`
-=================================================
+
+``implementedBy``
+=================
 
 API
 ---
@@ -356,6 +175,9 @@ Consider the following example:
 .. doctest::
 
    >>> from zope.interface import Interface
+   >>> from zope.interface import implements
+   >>> from zope.interface import classImplementsOnly
+   >>> from zope.interface import implementedBy
    >>> class I1(Interface): pass
    ...
    >>> class I2(Interface): pass
@@ -414,8 +236,9 @@ instance does not have a ``__name__`` attribute.
 This also manages storage of implementation specifications.
 
 
-:func:`zope.interface.declarations.classImplementsOnly`
-=======================================================
+
+``classImplementsOnly``
+=======================
 
 API
 ---
@@ -453,8 +276,9 @@ Instances of ``C`` provide only ``I1``, ``I2``, and regardless of
 whatever interfaces instances of ``A`` and ``B`` implement.
 
 
-:func:`zope.interface.declarations.classImplements`
-===================================================
+
+``classImplements``
+===================
 
 API
 ---
@@ -470,6 +294,7 @@ Consider the following example:
 .. doctest::
 
    >>> from zope.interface import Interface
+   >>> from zope.interface import classImplements
    >>> class I1(Interface): pass
    ...
    >>> class I2(Interface): pass
@@ -497,8 +322,9 @@ Instances of ``C`` provide ``I1``, ``I2``, ``I5``, and whatever
 interfaces instances of ``A`` and ``B`` provide.
 
 
-:class:`zope.interface.declarations.implementer`
-================================================
+
+``implementer``
+===============
 
 API
 ---
@@ -508,8 +334,9 @@ API
    :member-order: bysource
 
 
-:class:`zope.interface.declarations.implementer_only`
-=====================================================
+
+``implementer_only``
+====================
 
 API
 ---
@@ -519,8 +346,9 @@ API
    :member-order: bysource
 
 
-:func:`zope.interface.declarations.implements`
-==============================================
+
+``implements``
+==============
 
 API
 ---
@@ -528,9 +356,8 @@ API
 .. autofunction:: zope.interface.declarations.implements
 
 
-
-:func:`zope.interface.declarations.implementsOnly`
-==================================================
+``implementsOnly``
+==================
 
 API
 ---
@@ -539,8 +366,9 @@ API
 
 
 
-:class:`zope.interface.declarations.ProvidesClass`
-==================================================
+
+``ProvidesClass``
+=================
 
 API
 ---
@@ -571,8 +399,9 @@ Descriptor semantics (via ``Provides.__get__``):
 
 
 
-:func:`zope.interface.declarations.Provides`
-============================================
+
+``Provides``
+============
 
 API
 ---
@@ -597,6 +426,7 @@ collect function to help with this:
    ...     for i in range(4):
    ...         gc.collect()
    >>> collect()
+   >>> from zope.interface import directlyProvides
    >>> from zope.interface.declarations import InstanceDeclarations
    >>> before = len(InstanceDeclarations)
    >>> class C(object):
@@ -624,8 +454,9 @@ collect function to help with this:
    True
 
 
-:func:`zope.interface.declarations.directlyProvides`
-====================================================
+
+``directlyProvides``
+====================
 
 API
 ---
@@ -641,6 +472,7 @@ Consider the following example:
 .. doctest::
 
    >>> from zope.interface import Interface
+   >>> from zope.interface import providedBy
    >>> class I1(Interface): pass
    ...
    >>> class I2(Interface): pass
@@ -682,6 +514,7 @@ subtract the unwanted interfaces. For example:
 
 .. doctest::
 
+   >>> from zope.interface import directlyProvidedBy
    >>> directlyProvides(ob, directlyProvidedBy(ob)-I2)
    >>> int(I1 in providedBy(ob))
    1
@@ -699,6 +532,7 @@ include additional interfaces.  For example:
 
    >>> int(I2 in providedBy(ob))
    0
+   >>> from zope.interface import directlyProvidedBy
    >>> directlyProvides(ob, directlyProvidedBy(ob), I2)
 
 adds ``I2`` to the interfaces directly provided by ``ob``:
@@ -714,8 +548,9 @@ don't support descriptors.
 We can do away with this check when we get rid of the old EC
 
 
-:func:`zope.interface.declarations.alsoProvides`
-================================================
+
+``alsoProvides``
+================
 
 API
 ---
@@ -731,6 +566,7 @@ Consider the following example:
 .. doctest::
 
    >>> from zope.interface import Interface
+   >>> from zope.interface import alsoProvides
    >>> class I1(Interface): pass
    ...
    >>> class I2(Interface): pass
@@ -782,8 +618,9 @@ instances have been declared for instances of ``C``. Notice that the
 ``alsoProvides`` just extends the provided interfaces.
 
 
-:func:`zope.interface.declarations.noLongerProvides`
-====================================================
+
+``noLongerProvides``
+====================
 
 API
 ---
@@ -820,6 +657,7 @@ Remove ``I2`` from ``c`` again:
 
 .. doctest::
 
+   >>> from zope.interface import noLongerProvides
    >>> noLongerProvides(c, I2)
    >>> I2.providedBy(c)
    False
@@ -834,8 +672,9 @@ Removing an interface that is provided through the class is not possible:
    ValueError: Can only remove directly provided interfaces.
 
 
-:func:`zope.interface.declarations.directlyProvidedBy`
-======================================================
+
+``directlyProvidedBy``
+======================
 
 API
 ---
@@ -843,8 +682,9 @@ API
 .. autofunction:: zope.interface.declarations.directlyProvidedBy
 
 
-:func:`zope.interface.declarations.classProvides`
-=================================================
+
+``classProvides``
+=================
 
 API
 ---
@@ -861,6 +701,7 @@ For example:
 
    >>> from zope.interface import Interface
    >>> from zope.interface.declarations import implementer
+   >>> from zope.interface import classProvides
    >>> class IFooFactory(Interface):
    ...     pass
    >>> class IFoo(Interface):
@@ -892,8 +733,9 @@ Which is equivalent to:
    ['IFoo']
 
 
-:class:`zope.interface.declarations.provider`
-=============================================
+
+``provider``
+============
 
 API
 ---
@@ -903,8 +745,8 @@ API
    :member-order: bysource
 
 
-:func:`zope.interface.declarations.moduleProvides`
-==================================================
+``moduleProvides``
+==================
 
 API
 ---
@@ -913,8 +755,9 @@ API
 
 
 
-:func:`zope.interface.declarations.ObjectSpecification`
-=======================================================
+
+``ObjectSpecification``
+=======================
 
 API
 ---
@@ -930,6 +773,7 @@ For example:
 .. doctest::
 
    >>> from zope.interface import Interface
+   >>> from zope.interface import implementsOnly
    >>> class I1(Interface): pass
    ...
    >>> class I2(Interface): pass
@@ -988,8 +832,9 @@ For example:
    1
 
 
-:func:`zope.interface.declarations.providedBy`
-==============================================
+
+``providedBy``
+==============
 
 API
 ---
@@ -997,8 +842,9 @@ API
 .. autofunction:: zope.interface.declarations.providedBy
 
 
-:class:`zope.interface.declarations.ObjectSpecificationDescriptor`
-==================================================================
+
+``ObjectSpecificationDescriptor``
+=================================
 
 API
 ---
@@ -1031,8 +877,8 @@ Get an ObjectSpecification bound to either an instance or a class,
 depending on how we were accessed.
 
 
-:class:`zope.interface.declarations.named`
-==========================================
+``named``
+=========
 
 API
 ---
@@ -1060,73 +906,3 @@ For example:
 When registering an adapter or utility component, the registry looks for the
 ``__component_name__`` attribute and uses it, if no name was explicitly
 provided.
-
-
-:class:`zope.interface.adapter.AdapterRegistry`
-===============================================
-
-API
----
-
-The adapter registry's API is defined by
-:class:`zope.interface.interfaces.IAdapterRegistry`:
-
-.. autointerface:: zope.interface.adapter.IAdapterRegistry
-   :members:
-   :member-order: bysource
-
-Usage
------
-
-See :ref:`adapter-registry`.
-
-``zope.interface.registry.Components``
-======================================
-
-API
----
-
-The component registry's API is defined by
-``zope.interface.interfaces.IComponents``:
-
-.. autointerface:: zope.interface.interfaces.IComponents
-   :members:
-   :member-order: bysource
-
-
-.. autointerface:: zope.interface.interfaces.IComponentLookup
-   :members:
-   :member-order: bysource
-
-
-.. autointerface:: zope.interface.interfaces.IComponentRegistry
-   :members:
-   :member-order: bysource
-
-Python Standard Library Interfaces
-==================================
-
-The ``zope.interface.common`` package provides interfaces for objects
-distributed as part of the Python standard library. Importing these
-modules has the effect of making the standard library objects
-implement the correct interface.
-
-``zope.interface.common.interfaces``
-------------------------------------
-
-.. automodule:: zope.interface.common.interfaces
-
-``zope.interface.common.idatetime``
------------------------------------
-
-.. automodule:: zope.interface.common.idatetime
-
-``zope.interface.common.mapping``
----------------------------------
-
-.. automodule:: zope.interface.common.mapping
-
-``zope.interface.common.sequence``
-----------------------------------
-
-.. automodule:: zope.interface.common.sequence

--- a/docs/api/declarations.rst
+++ b/docs/api/declarations.rst
@@ -1,26 +1,516 @@
-=========================================
- API for ``zope.interface.declarations``
-=========================================
+==================================================
+ Declaring and Checking The Interfaces of Objects
+==================================================
+
+Declaring what interfaces an object implements or provides, and later
+being able to check those, is an important part of this package.
+Declaring interfaces, in particular, can be done both statically at
+object definition time and dynamically later on.
+
+The functionality that allows declaring and checking interfaces is
+provided directly in the ``zope.interface`` module. It is described by
+the interface ``zope.interface.interfaces.IInterfaceDeclaration``. We
+will first look at that interface, and then we will look more
+carefully at each object it documents, including providing examples.
+
+.. autointerface:: zope.interface.interfaces.IInterfaceDeclaration
 
 
-``Declaration``
-===============
+.. currentmodule:: zope.interface.declarations
+
+Declaring The Interfaces of Objects
+===================================
 
 
-API
----
+implementer
+-----------
 
-Declaration objects implement the API defined by
-:class:`zope.interface.interfaces.IDeclaration`:
+.. autoclass:: implementer
+
+
+implementer_only
+----------------
+
+.. autoclass:: implementer_only
+
+
+implements
+----------
+
+(The `implementer` decorator is preferred to this.)
+
+.. autofunction:: implements
+
+
+implementsOnly
+--------------
+
+(The `implementer_only` decorator is preferred to this.)
+
+.. autofunction:: implementsOnly
+
+
+classImplementsOnly
+-------------------
+
+.. autofunction:: classImplementsOnly
+
+
+Consider the following example:
+
+.. doctest::
+
+   >>> from zope.interface import implementedBy
+   >>> from zope.interface import implements
+   >>> from zope.interface import classImplementsOnly
+   >>> from zope.interface import Interface
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(Interface): pass
+   ...
+   >>> class I3(Interface): pass
+   ...
+   >>> class I4(Interface): pass
+   ...
+   >>> class A(object):
+   ...   implements(I3)
+   >>> class B(object):
+   ...   implements(I4)
+   >>> class C(A, B):
+   ...   pass
+   >>> classImplementsOnly(C, I1, I2)
+   >>> [i.getName() for i in implementedBy(C)]
+   ['I1', 'I2']
+
+Instances of ``C`` provide only ``I1``, ``I2``, and regardless of
+whatever interfaces instances of ``A`` and ``B`` implement.
+
+
+classImplements
+---------------
+
+.. autofunction:: classImplements
+
+Consider the following example:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> from zope.interface import classImplements
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(Interface): pass
+   ...
+   >>> class I3(Interface): pass
+   ...
+   >>> class I4(Interface): pass
+   ...
+   >>> class I5(Interface): pass
+   ...
+   >>> class A(object):
+   ...   implements(I3)
+   >>> class B(object):
+   ...   implements(I4)
+   >>> class C(A, B):
+   ...   pass
+   >>> classImplements(C, I1, I2)
+   >>> [i.getName() for i in implementedBy(C)]
+   ['I1', 'I2', 'I3', 'I4']
+   >>> classImplements(C, I5)
+   >>> [i.getName() for i in implementedBy(C)]
+   ['I1', 'I2', 'I5', 'I3', 'I4']
+
+Instances of ``C`` provide ``I1``, ``I2``, ``I5``, and whatever
+interfaces instances of ``A`` and ``B`` provide.
+
+
+directlyProvides
+----------------
+
+.. autofunction:: directlyProvides
+
+
+Consider the following example:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> from zope.interface import providedBy
+   >>> from zope.interface import directlyProvides
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(Interface): pass
+   ...
+   >>> class IA1(Interface): pass
+   ...
+   >>> class IA2(Interface): pass
+   ...
+   >>> class IB(Interface): pass
+   ...
+   >>> class IC(Interface): pass
+   ...
+   >>> class A(object):
+   ...     implements(IA1, IA2)
+   >>> class B(object):
+   ...     implements(IB)
+   >>> class C(A, B):
+   ...    implements(IC)
+   >>> ob = C()
+   >>> directlyProvides(ob, I1, I2)
+   >>> int(I1 in providedBy(ob))
+   1
+   >>> int(I2 in providedBy(ob))
+   1
+   >>> int(IA1 in providedBy(ob))
+   1
+   >>> int(IA2 in providedBy(ob))
+   1
+   >>> int(IB in providedBy(ob))
+   1
+   >>> int(IC in providedBy(ob))
+   1
+
+The object, ``ob`` provides ``I1``, ``I2``, and whatever interfaces
+instances have been declared for instances of ``C``.
+
+To remove directly provided interfaces, use ``directlyProvidedBy`` and
+subtract the unwanted interfaces. For example:
+
+.. doctest::
+
+   >>> from zope.interface import directlyProvidedBy
+   >>> directlyProvides(ob, directlyProvidedBy(ob)-I2)
+   >>> int(I1 in providedBy(ob))
+   1
+   >>> int(I2 in providedBy(ob))
+   0
+
+removes ``I2`` from the interfaces directly provided by ``ob``. The object,
+``ob`` no longer directly provides ``I2``, although it might still
+provide ``I2`` if its class implements ``I2``.
+
+To add directly provided interfaces, use ``directlyProvidedBy`` and
+include additional interfaces.  For example:
+
+.. doctest::
+
+   >>> int(I2 in providedBy(ob))
+   0
+   >>> from zope.interface import directlyProvidedBy
+   >>> directlyProvides(ob, directlyProvidedBy(ob), I2)
+
+adds ``I2`` to the interfaces directly provided by ``ob``:
+
+.. doctest::
+
+   >>> int(I2 in providedBy(ob))
+   1
+
+We need to avoid setting this attribute on meta classes that
+don't support descriptors.
+
+We can do away with this check when we get rid of the old EC
+
+
+alsoProvides
+------------
+
+.. autofunction:: alsoProvides
+
+
+Consider the following example:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> from zope.interface import alsoProvides
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(Interface): pass
+   ...
+   >>> class IA1(Interface): pass
+   ...
+   >>> class IA2(Interface): pass
+   ...
+   >>> class IB(Interface): pass
+   ...
+   >>> class IC(Interface): pass
+   ...
+   >>> class A(object):
+   ...     implements(IA1, IA2)
+   >>> class B(object):
+   ...     implements(IB)
+   >>> class C(A, B):
+   ...    implements(IC)
+   >>> ob = C()
+   >>> directlyProvides(ob, I1)
+   >>> int(I1 in providedBy(ob))
+   1
+   >>> int(I2 in providedBy(ob))
+   0
+   >>> int(IA1 in providedBy(ob))
+   1
+   >>> int(IA2 in providedBy(ob))
+   1
+   >>> int(IB in providedBy(ob))
+   1
+   >>> int(IC in providedBy(ob))
+   1
+   >>> alsoProvides(ob, I2)
+   >>> int(I1 in providedBy(ob))
+   1
+   >>> int(I2 in providedBy(ob))
+   1
+   >>> int(IA1 in providedBy(ob))
+   1
+   >>> int(IA2 in providedBy(ob))
+   1
+   >>> int(IB in providedBy(ob))
+   1
+   >>> int(IC in providedBy(ob))
+   1
+
+The object, ``ob`` provides ``I1``, ``I2``, and whatever interfaces
+instances have been declared for instances of ``C``. Notice that the
+``alsoProvides`` just extends the provided interfaces.
+
+
+noLongerProvides
+----------------
+
+.. autofunction:: noLongerProvides
+
+Consider the following two interfaces:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(Interface): pass
+   ...
+
+``I1`` is provided through the class, ``I2`` is directly provided
+by the object:
+
+.. doctest::
+
+   >>> class C(object):
+   ...    implements(I1)
+   >>> c = C()
+   >>> alsoProvides(c, I2)
+   >>> I2.providedBy(c)
+   True
+
+Remove ``I2`` from ``c`` again:
+
+.. doctest::
+
+   >>> from zope.interface import noLongerProvides
+   >>> noLongerProvides(c, I2)
+   >>> I2.providedBy(c)
+   False
+
+Removing an interface that is provided through the class is not possible:
+
+.. doctest::
+
+   >>> noLongerProvides(c, I1)
+   Traceback (most recent call last):
+   ...
+   ValueError: Can only remove directly provided interfaces.
+
+
+classProvides
+-------------
+
+.. autofunction:: classProvides
+
+
+For example:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> from zope.interface.declarations import implementer
+   >>> from zope.interface import classProvides
+   >>> class IFooFactory(Interface):
+   ...     pass
+   >>> class IFoo(Interface):
+   ...     pass
+   >>> @implementer(IFoo)
+   ... class C(object):
+   ...     classProvides(IFooFactory)
+   >>> [i.getName() for i in C.__provides__]
+   ['IFooFactory']
+   >>> [i.getName() for i in C().__provides__]
+   ['IFoo']
+
+Which is equivalent to:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> class IFoo(Interface): pass
+   ...
+   >>> class IFooFactory(Interface): pass
+   ...
+   >>> @implementer(IFoo)
+   ... class C(object):
+   ...   pass
+   >>> directlyProvides(C, IFooFactory)
+   >>> [i.getName() for i in C.__providedBy__]
+   ['IFooFactory']
+   >>> [i.getName() for i in C().__providedBy__]
+   ['IFoo']
+
+
+provider
+--------
+
+.. autoclass:: provider
+
+
+moduleProvides
+--------------
+
+.. autofunction:: moduleProvides
+
+
+named
+-----
+
+.. autoclass:: zope.interface.declarations.named
+
+For example:
+
+.. doctest::
+
+   >>> from zope.interface.declarations import named
+
+   >>> @named('foo')
+   ... class Foo(object):
+   ...     pass
+
+   >>> Foo.__component_name__
+   'foo'
+
+When registering an adapter or utility component, the registry looks for the
+``__component_name__`` attribute and uses it, if no name was explicitly
+provided.
+
+
+Querying The Interfaces Of Objects
+==================================
+
+All of these functions return an
+`~zope.interface.interfaces.IDeclaration`.
+You'll notice that an ``IDeclaration`` is a type of
+`~zope.interface.interfaces.ISpecification`, as is
+``zope.interface.Interface``, so they share some common behaviour.
 
 .. autointerface:: zope.interface.interfaces.IDeclaration
    :members:
    :member-order: bysource
 
-.. autoclass:: zope.interface.declarations.Declaration
 
-Usage
------
+implementedBy
+-------------
+
+.. autofunction:: implementedByFallback
+
+
+Consider the following example:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> from zope.interface import implements
+   >>> from zope.interface import classImplementsOnly
+   >>> from zope.interface import implementedBy
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(Interface): pass
+   ...
+   >>> class I3(Interface): pass
+   ...
+   >>> class I4(Interface): pass
+   ...
+   >>> class A(object):
+   ...   implements(I3)
+   >>> class B(object):
+   ...   implements(I4)
+   >>> class C(A, B):
+   ...   pass
+   >>> classImplementsOnly(C, I1, I2)
+   >>> [i.getName() for i in implementedBy(C)]
+   ['I1', 'I2']
+
+Instances of ``C`` provide only ``I1``, ``I2``, and regardless of
+whatever interfaces instances of ``A`` and ``B`` implement.
+
+Another example:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(I1): pass
+   ...
+   >>> class I3(Interface): pass
+   ...
+   >>> class I4(I3): pass
+   ...
+   >>> class C1(object):
+   ...   implements(I2)
+   >>> class C2(C1):
+   ...   implements(I3)
+   >>> [i.getName() for i in implementedBy(C2)]
+   ['I3', 'I2']
+
+Really, any object should be able to receive a successful answer, even
+an instance:
+
+.. doctest::
+
+   >>> class Callable(object):
+   ...     def __call__(self):
+   ...         return self
+   >>> implementedBy(Callable())
+   <implementedBy __builtin__.?>
+
+Note that the name of the spec ends with a '?', because the ``Callable``
+instance does not have a ``__name__`` attribute.
+
+This also manages storage of implementation specifications.
+
+
+providedBy
+----------
+
+.. autofunction:: providedBy
+
+
+directlyProvidedBy
+------------------
+
+.. autofunction:: directlyProvidedBy
+
+
+Classes
+=======
+
+
+Declarations
+------------
+
+Declaration objects implement the API defined by
+:class:`~zope.interface.interfaces.IDeclaration`.
+
+
+.. autoclass:: Declaration
+
 
 Exmples for :meth:`Declaration.__contains__`:
 
@@ -158,228 +648,11 @@ Exmples for :meth:`Declaration.__add__`:
 
 
 
-``implementedBy``
-=================
+ProvidesClass
+-------------
 
-API
----
+.. autoclass:: ProvidesClass
 
-.. autofunction:: zope.interface.declarations.implementedByFallback
-
-
-Usage
------
-
-Consider the following example:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> from zope.interface import implements
-   >>> from zope.interface import classImplementsOnly
-   >>> from zope.interface import implementedBy
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(Interface): pass
-   ...
-   >>> class I3(Interface): pass
-   ...
-   >>> class I4(Interface): pass
-   ...
-   >>> class A(object):
-   ...   implements(I3)
-   >>> class B(object):
-   ...   implements(I4)
-   >>> class C(A, B):
-   ...   pass
-   >>> classImplementsOnly(C, I1, I2)
-   >>> [i.getName() for i in implementedBy(C)]
-   ['I1', 'I2']
-
-Instances of ``C`` provide only ``I1``, ``I2``, and regardless of
-whatever interfaces instances of ``A`` and ``B`` implement.
-
-Another example:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(I1): pass
-   ...
-   >>> class I3(Interface): pass
-   ...
-   >>> class I4(I3): pass
-   ...
-   >>> class C1(object):
-   ...   implements(I2)
-   >>> class C2(C1):
-   ...   implements(I3)
-   >>> [i.getName() for i in implementedBy(C2)]
-   ['I3', 'I2']
-
-Really, any object should be able to receive a successful answer, even
-an instance:
-
-.. doctest::
-
-   >>> class Callable(object):
-   ...     def __call__(self):
-   ...         return self
-   >>> implementedBy(Callable())
-   <implementedBy __builtin__.?>
-
-Note that the name of the spec ends with a '?', because the ``Callable``
-instance does not have a ``__name__`` attribute.
-
-This also manages storage of implementation specifications.
-
-
-
-``classImplementsOnly``
-=======================
-
-API
----
-
-.. autofunction:: zope.interface.declarations.classImplementsOnly
-
-
-Usage
------
-
-Consider the following example:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(Interface): pass
-   ...
-   >>> class I3(Interface): pass
-   ...
-   >>> class I4(Interface): pass
-   ...
-   >>> class A(object):
-   ...   implements(I3)
-   >>> class B(object):
-   ...   implements(I4)
-   >>> class C(A, B):
-   ...   pass
-   >>> classImplementsOnly(C, I1, I2)
-   >>> [i.getName() for i in implementedBy(C)]
-   ['I1', 'I2']
-
-Instances of ``C`` provide only ``I1``, ``I2``, and regardless of
-whatever interfaces instances of ``A`` and ``B`` implement.
-
-
-
-``classImplements``
-===================
-
-API
----
-
-.. autofunction:: zope.interface.declarations.classImplements
-
-
-Usage
------
-
-Consider the following example:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> from zope.interface import classImplements
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(Interface): pass
-   ...
-   >>> class I3(Interface): pass
-   ...
-   >>> class I4(Interface): pass
-   ...
-   >>> class I5(Interface): pass
-   ...
-   >>> class A(object):
-   ...   implements(I3)
-   >>> class B(object):
-   ...   implements(I4)
-   >>> class C(A, B):
-   ...   pass
-   >>> classImplements(C, I1, I2)
-   >>> [i.getName() for i in implementedBy(C)]
-   ['I1', 'I2', 'I3', 'I4']
-   >>> classImplements(C, I5)
-   >>> [i.getName() for i in implementedBy(C)]
-   ['I1', 'I2', 'I5', 'I3', 'I4']
-
-Instances of ``C`` provide ``I1``, ``I2``, ``I5``, and whatever
-interfaces instances of ``A`` and ``B`` provide.
-
-
-
-``implementer``
-===============
-
-API
----
-
-.. autoclass:: zope.interface.declarations.implementer
-   :members:
-   :member-order: bysource
-
-
-
-``implementer_only``
-====================
-
-API
----
-
-.. autoclass:: zope.interface.declarations.implementer_only
-   :members:
-   :member-order: bysource
-
-
-
-``implements``
-==============
-
-API
----
-
-.. autofunction:: zope.interface.declarations.implements
-
-
-``implementsOnly``
-==================
-
-API
----
-
-.. autofunction:: zope.interface.declarations.implementsOnly
-
-
-
-
-``ProvidesClass``
-=================
-
-API
----
-
-.. autoclass:: zope.interface.declarations.ProvidesClass
-   :members:
-   :member-order: bysource
-
-
-Usage
------
 
 Descriptor semantics (via ``Provides.__get__``):
 
@@ -398,19 +671,17 @@ Descriptor semantics (via ``Provides.__get__``):
    0
 
 
+Implementation Details
+======================
 
+The following section discusses some implementation details and
+demonstrates their use. You'll notice that they are all demonstrated
+using the previously-defined functions.
 
-``Provides``
-============
+Provides
+--------
 
-API
----
-
-.. autofunction:: zope.interface.declarations.Provides
-
-
-Usage
------
+.. autofunction:: Provides
 
 In the examples below, we are going to make assertions about
 the size of the weakvalue dictionary.  For the assertions to be
@@ -454,319 +725,11 @@ collect function to help with this:
    True
 
 
+ObjectSpecification
+-------------------
 
-``directlyProvides``
-====================
+.. autofunction:: ObjectSpecification
 
-API
----
-
-.. autofunction:: zope.interface.declarations.directlyProvides
-
-
-Usage
------
-
-Consider the following example:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> from zope.interface import providedBy
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(Interface): pass
-   ...
-   >>> class IA1(Interface): pass
-   ...
-   >>> class IA2(Interface): pass
-   ...
-   >>> class IB(Interface): pass
-   ...
-   >>> class IC(Interface): pass
-   ...
-   >>> class A(object):
-   ...     implements(IA1, IA2)
-   >>> class B(object):
-   ...     implements(IB)
-   >>> class C(A, B):
-   ...    implements(IC)
-   >>> ob = C()
-   >>> directlyProvides(ob, I1, I2)
-   >>> int(I1 in providedBy(ob))
-   1
-   >>> int(I2 in providedBy(ob))
-   1
-   >>> int(IA1 in providedBy(ob))
-   1
-   >>> int(IA2 in providedBy(ob))
-   1
-   >>> int(IB in providedBy(ob))
-   1
-   >>> int(IC in providedBy(ob))
-   1
-
-The object, ``ob`` provides ``I1``, ``I2``, and whatever interfaces
-instances have been declared for instances of ``C``.
-
-To remove directly provided interfaces, use ``directlyProvidedBy`` and
-subtract the unwanted interfaces. For example:
-
-.. doctest::
-
-   >>> from zope.interface import directlyProvidedBy
-   >>> directlyProvides(ob, directlyProvidedBy(ob)-I2)
-   >>> int(I1 in providedBy(ob))
-   1
-   >>> int(I2 in providedBy(ob))
-   0
-
-removes ``I2`` from the interfaces directly provided by ``ob``. The object,
-``ob`` no longer directly provides ``I2``, although it might still
-provide ``I2`` if its class implements ``I2``.
-
-To add directly provided interfaces, use ``directlyProvidedBy`` and
-include additional interfaces.  For example:
-
-.. doctest::
-
-   >>> int(I2 in providedBy(ob))
-   0
-   >>> from zope.interface import directlyProvidedBy
-   >>> directlyProvides(ob, directlyProvidedBy(ob), I2)
-
-adds ``I2`` to the interfaces directly provided by ``ob``:
-
-.. doctest::
-
-   >>> int(I2 in providedBy(ob))
-   1
-
-We need to avoid setting this attribute on meta classes that
-don't support descriptors.
-
-We can do away with this check when we get rid of the old EC
-
-
-
-``alsoProvides``
-================
-
-API
----
-
-.. autofunction:: zope.interface.declarations.alsoProvides
-
-
-Usage
------
-
-Consider the following example:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> from zope.interface import alsoProvides
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(Interface): pass
-   ...
-   >>> class IA1(Interface): pass
-   ...
-   >>> class IA2(Interface): pass
-   ...
-   >>> class IB(Interface): pass
-   ...
-   >>> class IC(Interface): pass
-   ...
-   >>> class A(object):
-   ...     implements(IA1, IA2)
-   >>> class B(object):
-   ...     implements(IB)
-   >>> class C(A, B):
-   ...    implements(IC)
-   >>> ob = C()
-   >>> directlyProvides(ob, I1)
-   >>> int(I1 in providedBy(ob))
-   1
-   >>> int(I2 in providedBy(ob))
-   0
-   >>> int(IA1 in providedBy(ob))
-   1
-   >>> int(IA2 in providedBy(ob))
-   1
-   >>> int(IB in providedBy(ob))
-   1
-   >>> int(IC in providedBy(ob))
-   1
-   >>> alsoProvides(ob, I2)
-   >>> int(I1 in providedBy(ob))
-   1
-   >>> int(I2 in providedBy(ob))
-   1
-   >>> int(IA1 in providedBy(ob))
-   1
-   >>> int(IA2 in providedBy(ob))
-   1
-   >>> int(IB in providedBy(ob))
-   1
-   >>> int(IC in providedBy(ob))
-   1
-
-The object, ``ob`` provides ``I1``, ``I2``, and whatever interfaces
-instances have been declared for instances of ``C``. Notice that the
-``alsoProvides`` just extends the provided interfaces.
-
-
-
-``noLongerProvides``
-====================
-
-API
----
-
-.. autofunction:: zope.interface.declarations.noLongerProvides
-
-
-Usage
------
-
-Consider the following two interfaces:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> class I1(Interface): pass
-   ...
-   >>> class I2(Interface): pass
-   ...
-
-``I1`` is provided through the class, ``I2`` is directly provided
-by the object:
-
-.. doctest::
-
-   >>> class C(object):
-   ...    implements(I1)
-   >>> c = C()
-   >>> alsoProvides(c, I2)
-   >>> I2.providedBy(c)
-   True
-
-Remove ``I2`` from ``c`` again:
-
-.. doctest::
-
-   >>> from zope.interface import noLongerProvides
-   >>> noLongerProvides(c, I2)
-   >>> I2.providedBy(c)
-   False
-
-Removing an interface that is provided through the class is not possible:
-
-.. doctest::
-
-   >>> noLongerProvides(c, I1)
-   Traceback (most recent call last):
-   ...
-   ValueError: Can only remove directly provided interfaces.
-
-
-
-``directlyProvidedBy``
-======================
-
-API
----
-
-.. autofunction:: zope.interface.declarations.directlyProvidedBy
-
-
-
-``classProvides``
-=================
-
-API
----
-
-.. autofunction:: zope.interface.declarations.classProvides
-
-
-Usage
------
-
-For example:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> from zope.interface.declarations import implementer
-   >>> from zope.interface import classProvides
-   >>> class IFooFactory(Interface):
-   ...     pass
-   >>> class IFoo(Interface):
-   ...     pass
-   >>> @implementer(IFoo)
-   ... class C(object):
-   ...     classProvides(IFooFactory)
-   >>> [i.getName() for i in C.__provides__]
-   ['IFooFactory']
-   >>> [i.getName() for i in C().__provides__]
-   ['IFoo']
-
-Which is equivalent to:
-
-.. doctest::
-
-   >>> from zope.interface import Interface
-   >>> class IFoo(Interface): pass
-   ...
-   >>> class IFooFactory(Interface): pass
-   ...
-   >>> @implementer(IFoo)
-   ... class C(object):
-   ...   pass
-   >>> directlyProvides(C, IFooFactory)
-   >>> [i.getName() for i in C.__providedBy__]
-   ['IFooFactory']
-   >>> [i.getName() for i in C().__providedBy__]
-   ['IFoo']
-
-
-
-``provider``
-============
-
-API
----
-
-.. autoclass:: zope.interface.declarations.provider
-   :members:
-   :member-order: bysource
-
-
-``moduleProvides``
-==================
-
-API
----
-
-.. autofunction:: zope.interface.declarations.moduleProvides
-
-
-
-
-``ObjectSpecification``
-=======================
-
-API
----
-
-.. autofunction:: zope.interface.declarations.ObjectSpecification
-
-
-Usage
------
 
 For example:
 
@@ -831,30 +794,10 @@ For example:
    >>> int(providedBy(c).extends(I5))
    1
 
+ObjectSpecificationDescriptor
+-----------------------------
 
-
-``providedBy``
-==============
-
-API
----
-
-.. autofunction:: zope.interface.declarations.providedBy
-
-
-
-``ObjectSpecificationDescriptor``
-=================================
-
-API
----
-
-.. autoclass:: zope.interface.declarations.ObjectSpecificationDescriptor
-   :members:
-   :member-order: bysource
-
-Usage
------
+.. autoclass:: ObjectSpecificationDescriptor
 
 For example:
 
@@ -875,34 +818,3 @@ For example:
 
 Get an ObjectSpecification bound to either an instance or a class,
 depending on how we were accessed.
-
-
-``named``
-=========
-
-API
----
-
-.. autoclass:: zope.interface.declarations.named
-   :members:
-   :member-order: bysource
-
-Usage
------
-
-For example:
-
-.. doctest::
-
-   >>> from zope.interface.declarations import named
-
-   >>> @named('foo')
-   ... class Foo(object):
-   ...     pass
-
-   >>> Foo.__component_name__
-   'foo'
-
-When registering an adapter or utility component, the registry looks for the
-``__component_name__`` attribute and uses it, if no name was explicitly
-provided.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,14 @@
+===============
+ API Reference
+===============
+
+Contents:
+
+.. toctree::
+   :maxdepth: 2
+
+   specifications
+   declarations
+   adapters
+   components
+   common

--- a/docs/api/specifications.rst
+++ b/docs/api/specifications.rst
@@ -5,11 +5,15 @@
 .. currentmodule:: zope.interface.interfaces
 
 
-This document discusses the actual interface objects themselves. The
-broader concept is of "specifications."
+This document discusses the actual interface objects themselves. We
+begin with a basic concept of specifying an object's behaviour (with
+an `ISpecification`), and then we describe the way we write such a
+specification (`IInterface`). Combinations of specifications (e.g., an
+object that provides multiple interfaces) are covered by
+`IDeclaration`.
 
-``zope.interface.interface.Specification``
-==========================================
+Specification
+=============
 
 Specification objects implement the API defined by
 :class:`ISpecification`:
@@ -19,9 +23,6 @@ Specification objects implement the API defined by
    :member-order: bysource
 
 .. autoclass:: zope.interface.interface.Specification
-
-Usage
------
 
 For example:
 
@@ -47,7 +48,7 @@ For example:
    >>> I3.extends(I1)
    False
 
-Exmples for :meth:`Specification.providedBy`:
+Exmples for :meth:`.Specification.providedBy`:
 
 .. doctest::
 
@@ -73,7 +74,7 @@ Exmples for :meth:`Specification.providedBy`:
    >>> I1.providedBy(C)
    True
 
-Examples for :meth:`Specification.isOrExtends`:
+Examples for :meth:`.Specification.isOrExtends`:
 
 .. doctest::
 
@@ -102,7 +103,7 @@ Examples for :meth:`Specification.isOrExtends`:
    >>> int(spec.extends(I4))
    0
 
-Examples for :meth:`Specification.interfaces`:
+Examples for :meth:`.Specification.interfaces`:
 
 .. doctest::
 
@@ -123,7 +124,7 @@ Examples for :meth:`Specification.interfaces`:
    >>> list(i)
    []
 
-Exmples for :meth:`Specification.extends`:
+Exmples for :meth:`.Specification.extends`:
 
 .. doctest::
 
@@ -159,8 +160,8 @@ Exmples for :meth:`Specification.extends`:
    True
 
 
-``zope.interface.Interface``
-============================
+Interface
+=========
 
 Interfaces are a particular type of `ISpecification` and implement the
 API defined by :class:`IInterface`.

--- a/docs/api/specifications.rst
+++ b/docs/api/specifications.rst
@@ -1,0 +1,190 @@
+==========================
+ Interface Specifications
+==========================
+
+
+``zope.interface.interface.Specification``
+==========================================
+
+API
+---
+
+Specification objects implement the API defined by
+:class:`zope.interface.interfaces.ISpecification`:
+
+.. autointerface:: zope.interface.interfaces.ISpecification
+   :members:
+   :member-order: bysource
+
+.. autoclass:: zope.interface.interface.Specification
+
+Usage
+-----
+
+For example:
+
+.. doctest::
+
+   >>> from zope.interface.interface import Specification
+   >>> from zope.interface import Interface
+   >>> class I1(Interface):
+   ...     pass
+   >>> class I2(I1):
+   ...     pass
+   >>> class I3(I2):
+   ...     pass
+   >>> [i.__name__ for i in I1.__bases__]
+   ['Interface']
+   >>> [i.__name__ for i in I2.__bases__]
+   ['I1']
+   >>> I3.extends(I1)
+   True
+   >>> I2.__bases__ = (Interface, )
+   >>> [i.__name__ for i in I2.__bases__]
+   ['Interface']
+   >>> I3.extends(I1)
+   False
+
+Exmples for :meth:`Specification.providedBy`:
+
+.. doctest::
+
+   >>> from zope.interface import *
+   >>> class I1(Interface):
+   ...     pass
+   >>> class C(object):
+   ...     implements(I1)
+   >>> c = C()
+   >>> class X(object):
+   ...     pass
+   >>> x = X()
+   >>> I1.providedBy(x)
+   False
+   >>> I1.providedBy(C)
+   False
+   >>> I1.providedBy(c)
+   True
+   >>> directlyProvides(x, I1)
+   >>> I1.providedBy(x)
+   True
+   >>> directlyProvides(C, I1)
+   >>> I1.providedBy(C)
+   True
+
+Examples for :meth:`Specification.isOrExtends`:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> from zope.interface.declarations import Declaration
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(I1): pass
+   ...
+   >>> class I3(Interface): pass
+   ...
+   >>> class I4(I3): pass
+   ...
+   >>> spec = Declaration()
+   >>> int(spec.extends(Interface))
+   1
+   >>> spec = Declaration(I2)
+   >>> int(spec.extends(Interface))
+   1
+   >>> int(spec.extends(I1))
+   1
+   >>> int(spec.extends(I2))
+   1
+   >>> int(spec.extends(I3))
+   0
+   >>> int(spec.extends(I4))
+   0
+
+Examples for :meth:`Specification.interfaces`:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(I1): pass
+   ...
+   >>> class I3(Interface): pass
+   ...
+   >>> class I4(I3): pass
+   ...
+   >>> spec = Specification((I2, I3))
+   >>> spec = Specification((I4, spec))
+   >>> i = spec.interfaces()
+   >>> [x.getName() for x in i]
+   ['I4', 'I2', 'I3']
+   >>> list(i)
+   []
+
+Exmples for :meth:`Specification.extends`:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> from zope.interface.declarations import Declaration
+   >>> class I1(Interface): pass
+   ...
+   >>> class I2(I1): pass
+   ...
+   >>> class I3(Interface): pass
+   ...
+   >>> class I4(I3): pass
+   ...
+   >>> spec = Declaration()
+   >>> int(spec.extends(Interface))
+   1
+   >>> spec = Declaration(I2)
+   >>> int(spec.extends(Interface))
+   1
+   >>> int(spec.extends(I1))
+   1
+   >>> int(spec.extends(I2))
+   1
+   >>> int(spec.extends(I3))
+   0
+   >>> int(spec.extends(I4))
+   0
+   >>> I2.extends(I2)
+   False
+   >>> I2.extends(I2, False)
+   True
+   >>> I2.extends(I2, strict=False)
+   True
+
+
+``zope.interface.Interface``
+============================
+
+API
+---
+
+Interfaces are a specilization of `ISpecification` and implement the
+API defined by :class:`zope.interface.interfaces.IInterface`:
+
+.. autointerface:: zope.interface.interfaces.IInterface
+   :members:
+   :member-order: bysource
+
+.. autoclass:: zope.interface.Interface
+
+Usage
+-----
+
+Exmples for :meth:`InterfaceClass.extends`:
+
+.. doctest::
+
+   >>> from zope.interface import Interface
+   >>> class I1(Interface): pass
+   ...
+   >>>
+   >>> i = I1.interfaces()
+   >>> [x.getName() for x in i]
+   ['I1']
+   >>> list(i)
+   []

--- a/docs/api/specifications.rst
+++ b/docs/api/specifications.rst
@@ -2,17 +2,19 @@
  Interface Specifications
 ==========================
 
+.. currentmodule:: zope.interface.interfaces
+
+
+This document discusses the actual interface objects themselves. The
+broader concept is of "specifications."
 
 ``zope.interface.interface.Specification``
 ==========================================
 
-API
----
-
 Specification objects implement the API defined by
-:class:`zope.interface.interfaces.ISpecification`:
+:class:`ISpecification`:
 
-.. autointerface:: zope.interface.interfaces.ISpecification
+.. autointerface:: ISpecification
    :members:
    :member-order: bysource
 
@@ -160,15 +162,29 @@ Exmples for :meth:`Specification.extends`:
 ``zope.interface.Interface``
 ============================
 
-API
----
+Interfaces are a particular type of `ISpecification` and implement the
+API defined by :class:`IInterface`.
 
-Interfaces are a specilization of `ISpecification` and implement the
-API defined by :class:`zope.interface.interfaces.IInterface`:
+Before we get there, we need to discuss two related concepts. The
+first is that of an "element", which provides us a simple way to query
+for information generically (this is important because we'll see that
+``IInterface`` implements this interface):
 
-.. autointerface:: zope.interface.interfaces.IInterface
-   :members:
-   :member-order: bysource
+.. autointerface:: IElement
+.. autoclass:: zope.interface.interface.Element
+   :no-members:
+
+Next, we look at ``IAttribute`` and ``IMethod``. These make up the
+content, or body, of an ``Interface``.
+
+.. autointerface:: zope.interface.interfaces.IAttribute
+.. autoclass:: zope.interface.interface.Attribute
+
+.. autoclass:: IMethod
+
+Finally we can look at the definition of ``IInterface``.
+
+.. autointerface:: IInterface
 
 .. autoclass:: zope.interface.Interface
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Contents:
    human
    verify
    foodforthought
-   api
+   api/index
    hacking
    changes
 
@@ -38,4 +38,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -214,7 +214,7 @@ def _implements_name(ob):
 def implementedByFallback(cls):
     """Return the interfaces implemented for a class' instances
 
-      The value returned is an IDeclaration.
+      The value returned is an `~zope.interface.interfaces.IDeclaration`.
     """
     try:
         spec = cls.__dict__.get('__implemented__')
@@ -302,7 +302,7 @@ def classImplementsOnly(cls, *interfaces):
     """Declare the only interfaces implemented by instances of a class
 
       The arguments after the class are one or more interfaces or interface
-      specifications (``IDeclaration`` objects).
+      specifications (`~zope.interface.interfaces.IDeclaration` objects).
 
       The interfaces given (including the interfaces in the specifications)
       replace any previous declarations.
@@ -316,7 +316,7 @@ def classImplements(cls, *interfaces):
     """Declare additional interfaces implemented for instances of a class
 
       The arguments after the class are one or more interfaces or
-      interface specifications (``IDeclaration`` objects).
+      interface specifications (`~zope.interface.interfaces.IDeclaration` objects).
 
       The interfaces given (including the interfaces in the specifications)
       are added to any interfaces previously declared.
@@ -349,13 +349,13 @@ def _implements_advice(cls):
     return cls
 
 
-class implementer:
+class implementer(object):
     """Declare the interfaces implemented by instances of a class.
 
       This function is called as a class decorator.
 
       The arguments are one or more interfaces or interface
-      specifications (IDeclaration objects).
+      specifications (`~zope.interface.interfaces.IDeclaration` objects).
 
       The interfaces given (including the interfaces in the
       specifications) are added to any interfaces previously
@@ -365,7 +365,7 @@ class implementer:
       unless implementsOnly was used.
 
       This function is provided for convenience. It provides a more
-      convenient way to call classImplements. For example::
+      convenient way to call `classImplements`. For example::
 
         @implementer(I1)
         class C(object):
@@ -394,19 +394,19 @@ class implementer:
             raise TypeError("Can't declare implements", ob)
         return ob
 
-class implementer_only:
+class implementer_only(object):
     """Declare the only interfaces implemented by instances of a class
 
       This function is called as a class decorator.
 
       The arguments are one or more interfaces or interface
-      specifications (IDeclaration objects).
+      specifications (`~zope.interface.interfaces.IDeclaration` objects).
 
       Previous declarations including declarations for base classes
       are overridden.
 
       This function is provided for convenience. It provides a more
-      convenient way to call classImplementsOnly. For example::
+      convenient way to call `classImplementsOnly`. For example::
 
         @implementer_only(I1)
         class C(object): pass
@@ -457,17 +457,17 @@ def implements(*interfaces):
       This function is called in a class definition.
 
       The arguments are one or more interfaces or interface
-      specifications (IDeclaration objects).
+      specifications (`~zope.interface.interfaces.IDeclaration` objects).
 
       The interfaces given (including the interfaces in the
       specifications) are added to any interfaces previously
       declared.
 
       Previous declarations include declarations for base classes
-      unless implementsOnly was used.
+      unless `implementsOnly` was used.
 
       This function is provided for convenience. It provides a more
-      convenient way to call classImplements. For example::
+      convenient way to call `classImplements`. For example::
 
         implements(I1)
 
@@ -489,13 +489,13 @@ def implementsOnly(*interfaces):
       This function is called in a class definition.
 
       The arguments are one or more interfaces or interface
-      specifications (IDeclaration objects).
+      specifications (`~zope.interface.interfaces.IDeclaration` objects).
 
       Previous declarations including declarations for base classes
       are overridden.
 
       This function is provided for convenience. It provides a more
-      convenient way to call classImplementsOnly. For example::
+      convenient way to call `classImplementsOnly`. For example::
 
         implementsOnly(I1)
 
@@ -516,7 +516,7 @@ def implementsOnly(*interfaces):
 # Instance declarations
 
 class Provides(Declaration):  # Really named ProvidesClass
-    """Implement __provides__, the instance-specific specification
+    """Implement ``__provides__``, the instance-specific specification
 
     When an object is pickled, we pickle the interfaces that it implements.
     """
@@ -568,7 +568,7 @@ def directlyProvides(object, *interfaces):
     """Declare interfaces declared directly for an object
 
       The arguments after the object are one or more interfaces or interface
-      specifications (``IDeclaration`` objects).
+      specifications (`~zope.interface.interfaces.IDeclaration` objects).
 
       The interfaces given (including the interfaces in the specifications)
       replace interfaces previously declared for the object.
@@ -604,7 +604,7 @@ def alsoProvides(object, *interfaces):
     """Declare interfaces declared directly for an object
 
     The arguments after the object are one or more interfaces or interface
-    specifications (``IDeclaration`` objects).
+    specifications (`~zope.interface.interfaces.IDeclaration` objects).
 
     The interfaces given (including the interfaces in the specifications) are
     added to the interfaces previously declared for the object.
@@ -646,7 +646,7 @@ else:
 
 
 class ClassProvides(Declaration, ClassProvidesBase):
-    """Special descriptor for class __provides__
+    """Special descriptor for class ``__provides__``
 
     The descriptor caches the implementedBy info, so that
     we can get declarations for objects without instance-specific
@@ -667,7 +667,7 @@ class ClassProvides(Declaration, ClassProvidesBase):
 def directlyProvidedBy(object):
     """Return the interfaces directly provided by the given object
 
-    The value returned is an ``IDeclaration``.
+    The value returned is an `~zope.interface.interfaces.IDeclaration`.
     """
     provides = getattr(object, "__provides__", None)
     if (provides is None # no spec
@@ -688,7 +688,7 @@ def classProvides(*interfaces):
       This function is called in a class definition.
 
       The arguments are one or more interfaces or interface specifications
-      (``IDeclaration`` objects).
+      (`~zope.interface.interfaces.IDeclaration` objects).
 
       The given interfaces (including the interfaces in the specifications)
       are used to create the class's direct-object interface specification.
@@ -700,7 +700,7 @@ def classProvides(*interfaces):
       implemented by instances of the class.
 
       This function is provided for convenience. It provides a more convenient
-      way to call directlyProvides for a class. For example::
+      way to call `directlyProvides` for a class. For example::
 
         classProvides(I1)
 
@@ -740,7 +740,7 @@ def _classProvides_advice(cls):
     directlyProvides(cls, *interfaces)
     return cls
 
-class provider:
+class provider(object):
     """Class decorator version of classProvides"""
 
     def __init__(self, *interfaces):
@@ -756,7 +756,7 @@ def moduleProvides(*interfaces):
     This function is used in a module definition.
 
     The arguments are one or more interfaces or interface specifications
-    (``IDeclaration`` objects).
+    (`~zope.interface.interfaces.IDeclaration` objects).
 
     The given interfaces (including the interfaces in the specifications) are
     used to create the module's direct-object interface specification.  An

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -48,6 +48,9 @@ def taggedValue(key, value):
 
 
 class Element(object):
+    """
+    Default implementation of `zope.interface.interfaces.IElement`.
+    """
 
     # We can't say this yet because we don't have enough
     # infrastructure in place.
@@ -55,8 +58,6 @@ class Element(object):
     #implements(IElement)
 
     def __init__(self, __name__, __doc__=''):
-        """Create an 'attribute' description
-        """
         if not __doc__ and __name__.find(' ') >= 0:
             __doc__ = __name__
             __name__ = None

--- a/src/zope/interface/interfaces.py
+++ b/src/zope/interface/interfaces.py
@@ -421,7 +421,7 @@ class IInterfaceDeclaration(Interface):
         """
 
     def implementer(*interfaces):
-        """Create a decorator for declaring interfaces implemented by a facory
+        """Create a decorator for declaring interfaces implemented by a factory.
 
         A callable is returned that makes an implements declaration on
         objects passed to it.
@@ -431,7 +431,7 @@ class IInterfaceDeclaration(Interface):
         """Declare the only interfaces implemented by instances of a class
 
         The arguments after the class are one or more interfaces or
-        interface specifications (IDeclaration objects).
+        interface specifications (`IDeclaration` objects).
 
         The interfaces given (including the interfaces in the
         specifications) replace any previous declarations.
@@ -458,14 +458,14 @@ class IInterfaceDeclaration(Interface):
     def directlyProvidedBy(object):
         """Return the interfaces directly provided by the given object
 
-        The value returned is an IDeclaration.
+        The value returned is an `IDeclaration`.
         """
 
     def directlyProvides(object, *interfaces):
         """Declare interfaces declared directly for an object
 
         The arguments after the object are one or more interfaces or
-        interface specifications (IDeclaration objects).
+        interface specifications (`IDeclaration` objects).
 
         The interfaces given (including the interfaces in the
         specifications) replace interfaces previously
@@ -482,7 +482,7 @@ class IInterfaceDeclaration(Interface):
         The object, ``ob`` provides ``I1``, ``I2``, and whatever interfaces
         instances have been declared for instances of ``C``.
 
-        To remove directly provided interfaces, use ``directlyProvidedBy`` and
+        To remove directly provided interfaces, use `directlyProvidedBy` and
         subtract the unwanted interfaces. For example::
 
           directlyProvides(ob, directlyProvidedBy(ob)-I2)
@@ -492,7 +492,7 @@ class IInterfaceDeclaration(Interface):
         although it might still provide ``I2`` if it's class
         implements ``I2``.
 
-        To add directly provided interfaces, use ``directlyProvidedBy`` and
+        To add directly provided interfaces, use `directlyProvidedBy` and
         include additional interfaces.  For example::
 
           directlyProvides(ob, directlyProvidedBy(ob), I2)
@@ -518,11 +518,11 @@ class IInterfaceDeclaration(Interface):
 
         is equivalent to::
 
-          directlyProvides(ob, directlyProvidedBy(ob)-I1)
+          directlyProvides(ob, directlyProvidedBy(ob) - I1)
 
         with the exception that if ``I1`` is an interface that is
         provided by ``ob`` through the class's implementation,
-        ValueError is raised.
+        `ValueError` is raised.
         """
 
     def implements(*interfaces):
@@ -531,7 +531,7 @@ class IInterfaceDeclaration(Interface):
         This function is called in a class definition (Python 2.x only).
 
         The arguments are one or more interfaces or interface
-        specifications (IDeclaration objects).
+        specifications (`IDeclaration` objects).
 
         The interfaces given (including the interfaces in the
         specifications) are added to any interfaces previously
@@ -541,7 +541,7 @@ class IInterfaceDeclaration(Interface):
         unless implementsOnly was used.
 
         This function is provided for convenience. It provides a more
-        convenient way to call classImplements. For example::
+        convenient way to call `classImplements`. For example::
 
           implements(I1)
 
@@ -567,13 +567,13 @@ class IInterfaceDeclaration(Interface):
         This function is called in a class definition (Python 2.x only).
 
         The arguments are one or more interfaces or interface
-        specifications (IDeclaration objects).
+        specifications (`IDeclaration` objects).
 
         Previous declarations including declarations for base classes
         are overridden.
 
         This function is provided for convenience. It provides a more
-        convenient way to call classImplementsOnly. For example::
+        convenient way to call `classImplementsOnly`. For example::
 
           implementsOnly(I1)
 
@@ -599,7 +599,7 @@ class IInterfaceDeclaration(Interface):
         This function is called in a class definition.
 
         The arguments are one or more interfaces or interface
-        specifications (IDeclaration objects).
+        specifications (`IDeclaration` objects).
 
         The given interfaces (including the interfaces in the
         specifications) are used to create the class's direct-object
@@ -612,7 +612,7 @@ class IInterfaceDeclaration(Interface):
         interfaces implemented by instances of the class.
 
         This function is provided for convenience. It provides a more
-        convenient way to call directlyProvides for a class. For example::
+        convenient way to call `directlyProvides` for a class. For example::
 
           classProvides(I1)
 
@@ -623,7 +623,7 @@ class IInterfaceDeclaration(Interface):
         after the class has been created.
         """
     def provider(*interfaces):
-        """A class decorator version of classProvides"""
+        """A class decorator version of `classProvides`"""
 
     def moduleProvides(*interfaces):
         """Declare interfaces provided by a module
@@ -631,7 +631,7 @@ class IInterfaceDeclaration(Interface):
         This function is used in a module definition.
 
         The arguments are one or more interfaces or interface
-        specifications (IDeclaration objects).
+        specifications (`IDeclaration` objects).
 
         The given interfaces (including the interfaces in the
         specifications) are used to create the module's direct-object
@@ -641,7 +641,7 @@ class IInterfaceDeclaration(Interface):
         definition.
 
         This function is provided for convenience. It provides a more
-        convenient way to call directlyProvides for a module. For example::
+        convenient way to call `directlyProvides` for a module. For example::
 
           moduleImplements(I1)
 
@@ -654,9 +654,9 @@ class IInterfaceDeclaration(Interface):
         """Create an interface specification
 
         The arguments are one or more interfaces or interface
-        specifications (IDeclaration objects).
+        specifications (`IDeclaration` objects).
 
-        A new interface specification (IDeclaration) with
+        A new interface specification (`IDeclaration`) with
         the given interfaces is returned.
         """
 

--- a/src/zope/interface/interfaces.py
+++ b/src/zope/interface/interfaces.py
@@ -163,16 +163,16 @@ class IInterface(ISpecification, IElement):
     Interface objects describe the behavior of an object by containing
     useful information about the object.  This information includes:
 
-      o Prose documentation about the object.  In Python terms, this
-        is called the "doc string" of the interface.  In this element,
-        you describe how the object works in prose language and any
-        other useful information about the object.
+    - Prose documentation about the object.  In Python terms, this
+      is called the "doc string" of the interface.  In this element,
+      you describe how the object works in prose language and any
+      other useful information about the object.
 
-      o Descriptions of attributes.  Attribute descriptions include
-        the name of the attribute and prose documentation describing
-        the attributes usage.
+    - Descriptions of attributes.  Attribute descriptions include
+      the name of the attribute and prose documentation describing
+      the attributes usage.
 
-      o Descriptions of methods.  Method descriptions can include:
+    - Descriptions of methods.  Method descriptions can include:
 
         - Prose "doc string" documentation about the method and its
           usage.
@@ -183,12 +183,12 @@ class IInterface(ISpecification, IElement):
           method accepts arbitrary arguments and whether the method
           accepts arbitrary keyword arguments.
 
-      o Optional tagged data.  Interface objects (and their attributes and
-        methods) can have optional, application specific tagged data
-        associated with them.  Examples uses for this are examples,
-        security assertions, pre/post conditions, and other possible
-        information you may want to associate with an Interface or its
-        attributes.
+    - Optional tagged data.  Interface objects (and their attributes and
+      methods) can have optional, application specific tagged data
+      associated with them.  Examples uses for this are examples,
+      security assertions, pre/post conditions, and other possible
+      information you may want to associate with an Interface or its
+      attributes.
 
     Not all of this information is mandatory.  For example, you may
     only want the methods of your interface to have prose
@@ -197,7 +197,7 @@ class IInterface(ISpecification, IElement):
     take any of these components.
 
     Interfaces are created with the Python class statement using
-    either Interface.Interface or another interface, as in::
+    either `zope.interface.Interface` or another interface, as in::
 
       from zope.interface import Interface
 
@@ -217,16 +217,16 @@ class IInterface(ISpecification, IElement):
 
     You use interfaces in two ways:
 
-    o You assert that your object implement the interfaces.
+    - You assert that your object implement the interfaces.
 
       There are several ways that you can assert that an object
       implements an interface:
 
-      1. Call zope.interface.implements in your class definition.
+      1. Call `zope.interface.implements` in your class definition.
 
-      2. Call zope.interfaces.directlyProvides on your object.
+      2. Call `zope.interfaces.directlyProvides` on your object.
 
-      3. Call 'zope.interface.classImplements' to assert that instances
+      3. Call `zope.interface.classImplements` to assert that instances
          of a class implement an interface.
 
          For example::
@@ -240,7 +240,7 @@ class IInterface(ISpecification, IElement):
          class itself implements, but only what its instances
          implement.
 
-    o You query interface meta-data. See the IInterface methods and
+    - You query interface meta-data. See the IInterface methods and
       attributes for details.
 
     """
@@ -271,7 +271,7 @@ class IInterface(ISpecification, IElement):
     def __getitem__(name):
         """Get the description for a name
 
-        If the named attribute is not defined, a KeyError is raised.
+        If the named attribute is not defined, a `KeyError` is raised.
         """
 
     def direct(name):
@@ -389,20 +389,20 @@ class IInterfaceDeclaration(Interface):
         This is the union of the interfaces directly provided by an
         object and interfaces implemented by it's class.
 
-        The value returned is an IDeclaration.
+        The value returned is an `IDeclaration`.
         """
 
     def implementedBy(class_):
         """Return the interfaces implemented for a class' instances
 
-        The value returned is an IDeclaration.
+        The value returned is an `IDeclaration`.
         """
 
     def classImplements(class_, *interfaces):
         """Declare additional interfaces implemented for instances of a class
 
         The arguments after the class are one or more interfaces or
-        interface specifications (IDeclaration objects).
+        interface specifications (`IDeclaration` objects).
 
         The interfaces given (including the interfaces in the
         specifications) are added to any interfaces previously

--- a/src/zope/interface/interfaces.py
+++ b/src/zope/interface/interfaces.py
@@ -447,10 +447,10 @@ class IInterfaceDeclaration(Interface):
         Instances of ``C`` provide only ``I1``, ``I2``, and regardless of
         whatever interfaces instances of ``A`` and ``B`` implement.
         """
-        
+
     def implementer_only(*interfaces):
-        """Create a decorator for declaring the only interfaces implemented 
-        
+        """Create a decorator for declaring the only interfaces implemented
+
         A callable is returned that makes an implements declaration on
         objects passed to it.
         """
@@ -800,7 +800,7 @@ class IComponentLookup(Interface):
     def getAdapter(object, interface, name=_BLANK):
         """Look for a named adapter to an interface for an object
 
-        If a matching adapter cannot be found, a ComponentLookupError
+        If a matching adapter cannot be found, a `ComponentLookupError`
         is raised.
         """
 
@@ -813,7 +813,7 @@ class IComponentLookup(Interface):
     def getMultiAdapter(objects, interface, name=_BLANK):
         """Look for a multi-adapter to an interface for multiple objects
 
-        If a matching adapter cannot be found, a ComponentLookupError
+        If a matching adapter cannot be found, a `ComponentLookupError`
         is raised.
         """
 
@@ -956,63 +956,65 @@ class IComponentRegistry(Interface):
                         info=_BLANK, factory=None):
         """Register a utility
 
-        factory
-           Factory for the component to be registerd.
+        :param factory:
+           Factory for the component to be registered.
 
-        component
+        :param component:
            The registered component
 
-        provided
+        :param provided:
            This is the interface provided by the utility.  If the
            component provides a single interface, then this
            argument is optional and the component-implemented
            interface will be used.
 
-        name
+        :param name:
            The utility name.
 
-        info
+        :param info:
            An object that can be converted to a string to provide
            information about the registration.
 
-        Only one of component and factory can be used.
-        A Registered event is generated with an IUtilityRegistration.
+        Only one of *component* and *factory* can be used.
+
+        A `IRegistered` event is generated with an `IUtilityRegistration`.
         """
 
     def unregisterUtility(component=None, provided=None, name=_BLANK,
                           factory=None):
         """Unregister a utility
 
-        A boolean is returned indicating whether the registry was
-        changed.  If the given component is None and there is no
-        component registered, or if the given component is not
-        None and is not registered, then the function returns
-        False, otherwise it returns True.
+        :returns:
+            A boolean is returned indicating whether the registry was
+            changed.  If the given *component* is None and there is no
+            component registered, or if the given *component* is not
+            None and is not registered, then the function returns
+            False, otherwise it returns True.
 
-        factory
-           Factory for the component to be unregisterd.
+        :param factory:
+           Factory for the component to be unregistered.
 
-        component
+        :param component:
            The registered component The given component can be
            None, in which case any component registered to provide
            the given provided interface with the given name is
            unregistered.
 
-        provided
+        :param provided:
            This is the interface provided by the utility.  If the
            component is not None and provides a single interface,
            then this argument is optional and the
            component-implemented interface will be used.
 
-        name
+        :param name:
            The utility name.
 
-        Only one of component and factory can be used.
-        An UnRegistered event is generated with an IUtilityRegistration.
+        Only one of *component* and *factory* can be used.
+        An `IUnregistered` event is generated with an `IUtilityRegistration`.
         """
 
     def registeredUtilities():
-        """Return an iterable of IUtilityRegistration instances.
+        """Return an iterable of `IUtilityRegistration` instances.
 
         These registrations describe the current utility registrations
         in the object.
@@ -1022,59 +1024,56 @@ class IComponentRegistry(Interface):
                        info=_BLANK):
         """Register an adapter factory
 
-        Parameters:
-
-        factory
+        :param factory:
             The object used to compute the adapter
 
-        required
+        :param required:
             This is a sequence of specifications for objects to be
             adapted.  If omitted, then the value of the factory's
-            __component_adapts__ attribute will be used.  The
-            __component_adapts__ attribute is usually attribute is
-            normally set in class definitions using adapts
-            function, or for callables using the adapter
+            ``__component_adapts__`` attribute will be used.  The
+            ``__component_adapts__`` attribute is
+            normally set in class definitions using
+            the `.adapter`
             decorator.  If the factory doesn't have a
-            __component_adapts__ adapts attribute, then this
+            ``__component_adapts__`` adapts attribute, then this
             argument is required.
 
-        provided
+        :param provided:
             This is the interface provided by the adapter and
             implemented by the factory.  If the factory
             implements a single interface, then this argument is
             optional and the factory-implemented interface will be
             used.
 
-        name
+        :param name:
             The adapter name.
 
-        info
+        :param info:
            An object that can be converted to a string to provide
            information about the registration.
 
-        A Registered event is generated with an IAdapterRegistration.
+        A `IRegistered` event is generated with an `IAdapterRegistration`.
         """
 
     def unregisterAdapter(factory=None, required=None,
                           provided=None, name=_BLANK):
         """Unregister an adapter factory
 
-        A boolean is returned indicating whether the registry was
-        changed.  If the given component is None and there is no
-        component registered, or if the given component is not
-        None and is not registered, then the function returns
-        False, otherwise it returns True.
+        :returns:
+            A boolean is returned indicating whether the registry was
+            changed.  If the given component is None and there is no
+            component registered, or if the given component is not
+            None and is not registered, then the function returns
+            False, otherwise it returns True.
 
-        Parameters:
-
-        factory
+        :param factory:
             This is the object used to compute the adapter. The
             factory can be None, in which case any factory
             registered to implement the given provided interface
             for the given required specifications with the given
             name is unregistered.
 
-        required
+        :param required:
             This is a sequence of specifications for objects to be
             adapted.  If the factory is not None and the required
             arguments is omitted, then the value of the factory's
@@ -1085,21 +1084,21 @@ class IComponentRegistry(Interface):
             is None or doesn't have a __component_adapts__ adapts
             attribute, then this argument is required.
 
-        provided
+        :param provided:
             This is the interface provided by the adapter and
             implemented by the factory.  If the factory is not
             None and implements a single interface, then this
             argument is optional and the factory-implemented
             interface will be used.
 
-        name
+        :param name:
             The adapter name.
 
-        An Unregistered event is generated with an IAdapterRegistration.
+        An `IUnregistered` event is generated with an `IAdapterRegistration`.
         """
 
     def registeredAdapters():
-        """Return an iterable of IAdapterRegistration instances.
+        """Return an iterable of `IAdapterRegistration` instances.
 
         These registrations describe the current adapter registrations
         in the object.
@@ -1109,93 +1108,88 @@ class IComponentRegistry(Interface):
                                     name=_BLANK, info=''):
         """Register a subscriber factory
 
-        Parameters:
-
-        factory
+        :param factory:
             The object used to compute the adapter
 
-        required
+        :param required:
             This is a sequence of specifications for objects to be
             adapted.  If omitted, then the value of the factory's
-            __component_adapts__ attribute will be used.  The
-            __component_adapts__ attribute is usually attribute is
-            normally set in class definitions using adapts
-            function, or for callables using the adapter
+            ``__component_adapts__`` attribute will be used.  The
+            ``__component_adapts__`` attribute is
+            normally set using the adapter
             decorator.  If the factory doesn't have a
-            __component_adapts__ adapts attribute, then this
+            ``__component_adapts__`` adapts attribute, then this
             argument is required.
 
-        provided
+        :param provided:
             This is the interface provided by the adapter and
             implemented by the factory.  If the factory implements
             a single interface, then this argument is optional and
             the factory-implemented interface will be used.
 
-        name
+        :param name:
             The adapter name.
 
             Currently, only the empty string is accepted.  Other
             strings will be accepted in the future when support for
             named subscribers is added.
 
-        info
+        :param info:
            An object that can be converted to a string to provide
            information about the registration.
 
-        A Registered event is generated with an
-        ISubscriptionAdapterRegistration.
+        A `IRegistered` event is generated with an
+        `ISubscriptionAdapterRegistration`.
         """
 
     def unregisterSubscriptionAdapter(factory=None, required=None,
                                       provides=None, name=_BLANK):
         """Unregister a subscriber factory.
 
-        A boolean is returned indicating whether the registry was
-        changed.  If the given component is None and there is no
-        component registered, or if the given component is not
-        None and is not registered, then the function returns
-        False, otherwise it returns True.
+        :returns:
+            A boolean is returned indicating whether the registry was
+            changed.  If the given component is None and there is no
+            component registered, or if the given component is not
+            None and is not registered, then the function returns
+            False, otherwise it returns True.
 
-        Parameters:
-
-        factory
+        :param factory:
             This is the object used to compute the adapter. The
             factory can be None, in which case any factories
             registered to implement the given provided interface
             for the given required specifications with the given
             name are unregistered.
 
-        required
+        :param required:
             This is a sequence of specifications for objects to be
-            adapted.  If the factory is not None and the required
-            arguments is omitted, then the value of the factory's
-            __component_adapts__ attribute will be used.  The
-            __component_adapts__ attribute attribute is normally
-            set in class definitions using adapts function, or for
-            callables using the adapter decorator.  If the factory
-            is None or doesn't have a __component_adapts__ adapts
-            attribute, then this argument is required.
+            adapted.  If omitted, then the value of the factory's
+            ``__component_adapts__`` attribute will be used.  The
+            ``__component_adapts__`` attribute is
+            normally set using the adapter
+            decorator.  If the factory doesn't have a
+            ``__component_adapts__`` adapts attribute, then this
+            argument is required.
 
-        provided
+        :param provided:
             This is the interface provided by the adapter and
             implemented by the factory.  If the factory is not
             None implements a single interface, then this argument
             is optional and the factory-implemented interface will
             be used.
 
-        name
+        :param name:
             The adapter name.
 
             Currently, only the empty string is accepted.  Other
             strings will be accepted in the future when support for
             named subscribers is added.
 
-        An Unregistered event is generated with an
-        ISubscriptionAdapterRegistration.
+        An `IUnregistered` event is generated with an
+        `ISubscriptionAdapterRegistration`.
         """
 
     def registeredSubscriptionAdapters():
-        """Return an iterable of ISubscriptionAdapterRegistration instances.
+        """Return an iterable of `ISubscriptionAdapterRegistration` instances.
 
         These registrations describe the current subscription adapter
         registrations in the object.
@@ -1207,36 +1201,33 @@ class IComponentRegistry(Interface):
         A handler is a subscriber that doesn't compute an adapter
         but performs some function when called.
 
-        Parameters:
-
-        handler
+        :param handler:
             The object used to handle some event represented by
             the objects passed to it.
 
-        required
+        :param required:
             This is a sequence of specifications for objects to be
             adapted.  If omitted, then the value of the factory's
-            __component_adapts__ attribute will be used.  The
-            __component_adapts__ attribute is usually attribute is
-            normally set in class definitions using adapts
-            function, or for callables using the adapter
+            ``__component_adapts__`` attribute will be used.  The
+            ``__component_adapts__`` attribute is
+            normally set using the adapter
             decorator.  If the factory doesn't have a
-            __component_adapts__ adapts attribute, then this
+            ``__component_adapts__`` adapts attribute, then this
             argument is required.
 
-        name
+        :param name:
             The handler name.
 
             Currently, only the empty string is accepted.  Other
             strings will be accepted in the future when support for
             named handlers is added.
 
-        info
+        :param info:
            An object that can be converted to a string to provide
            information about the registration.
 
 
-        A Registered event is generated with an IHandlerRegistration.
+        A `IRegistered` event is generated with an `IHandlerRegistration`.
         """
 
     def unregisterHandler(handler=None, required=None, name=_BLANK):
@@ -1245,41 +1236,38 @@ class IComponentRegistry(Interface):
         A handler is a subscriber that doesn't compute an adapter
         but performs some function when called.
 
-        A boolean is returned indicating whether the registry was
-        changed.
+        :returns: A boolean is returned indicating whether the registry was
+            changed.
 
-        Parameters:
-
-        handler
+        :param handler:
             This is the object used to handle some event
             represented by the objects passed to it. The handler
             can be None, in which case any handlers registered for
             the given required specifications with the given are
             unregistered.
 
-        required
+        :param required:
             This is a sequence of specifications for objects to be
             adapted.  If omitted, then the value of the factory's
-            __component_adapts__ attribute will be used.  The
-            __component_adapts__ attribute is usually attribute is
-            normally set in class definitions using adapts
-            function, or for callables using the adapter
+            ``__component_adapts__`` attribute will be used.  The
+            ``__component_adapts__`` attribute is
+            normally set using the adapter
             decorator.  If the factory doesn't have a
-            __component_adapts__ adapts attribute, then this
+            ``__component_adapts__`` adapts attribute, then this
             argument is required.
 
-        name
+        :param name:
             The handler name.
 
             Currently, only the empty string is accepted.  Other
             strings will be accepted in the future when support for
             named handlers is added.
 
-        An Unregistered event is generated with an IHandlerRegistration.
+        An `IUnregistered` event is generated with an `IHandlerRegistration`.
         """
 
     def registeredHandlers():
-        """Return an iterable of IHandlerRegistration instances.
+        """Return an iterable of `IHandlerRegistration` instances.
 
         These registrations describe the current handler registrations
         in the object.


### PR DESCRIPTION
The promised follow up to #120. This breaks the reference documentation into four major categories, and then groups things further within those categories. Copious amounts of cross references were inserted (or made clickable). A number of neglected objects were added to the documentation (E.g., the component events).

Hopefully this makes things easier to follow (it does for me).