### PR TITLE
Make rtd.txt install the checked out code, not the version from PyPI [skip ci]

### DIFF
--- a/rtd.txt
+++ b/rtd.txt
@@ -1,1 +1,6 @@
+# Make sure we have this code installed. r.s.autointerface
+# has a dep on zope.interface and without care we get the released
+# version from PyPI, not the code here.
+# See https://github.com/zopefoundation/zope.interface/pull/121#issuecomment-406372435
+-e .
 repoze.sphinx.autointerface


### PR DESCRIPTION
See https://github.com/zopefoundation/zope.interface/pull/121#issuecomment-406372435