### PR TITLE
Fix 'verifyObject' for class objects with staticmethods on Python 3.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,4 +8,5 @@ exclude_lines =
     pragma: no cover
     class I[A-Z]\w+\((Interface|I[A-Z].*)\):
     raise NotImplementedError
+    raise AssertionError
     self\.fail

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changes
 
 - Add support for Python 3.7
 
+- Fix ``verifyObject`` for class objects with staticmethods on
+  Python 3. See `issue 126
+  <https://github.com/zopefoundation/zope.interface/issues/126>`_.
 
 4.5.0 (2018-04-19)
 ------------------

--- a/src/zope/interface/tests/test_verify.py
+++ b/src/zope/interface/tests/test_verify.py
@@ -557,5 +557,26 @@ class Test_verifyObject(Test_verifyClass):
         self.assertRaises(DoesNotImplement,
                           self._callFUT, IDummyModule, dummy)
 
+    def test_staticmethod_hit_on_class(self):
+        from zope.interface import Interface
+        from zope.interface import provider
+        from zope.interface.verify import verifyObject
+
+        class IFoo(Interface):
+
+            def bar(a, b):
+                pass
+
+        @provider(IFoo)
+        class Foo(object):
+
+            @staticmethod
+            def bar(a, b):
+                pass
+
+        # Don't use self._callFUT, we don't want to instantiate the
+        # class.
+        verifyObject(IFoo, Foo)
+
 class OldSkool:
     pass

--- a/src/zope/interface/tests/test_verify.py
+++ b/src/zope/interface/tests/test_verify.py
@@ -565,14 +565,14 @@ class Test_verifyObject(Test_verifyClass):
         class IFoo(Interface):
 
             def bar(a, b):
-                pass
+                "The bar method"
 
         @provider(IFoo)
         class Foo(object):
 
             @staticmethod
             def bar(a, b):
-                pass
+                raise AssertionError("We're never actually called")
 
         # Don't use self._callFUT, we don't want to instantiate the
         # class.

--- a/src/zope/interface/verify.py
+++ b/src/zope/interface/verify.py
@@ -66,8 +66,11 @@ def _verify(iface, candidate, tentative=0, vtype=None):
             continue
 
         if isinstance(attr, FunctionType):
-            if sys.version_info[0] >= 3 and isinstance(candidate, type):
+            if sys.version_info[0] >= 3 and isinstance(candidate, type) and vtype == 'c':
                 # This is an "unbound method" in Python 3.
+                # Only unwrap this if we're verifying implementedBy;
+                # otherwise we can unwrap @staticmethod on classes that directly
+                # provide an interface.
                 meth = fromFunction(attr, iface, name=name,
                                     imlevel=1)
             else:


### PR DESCRIPTION
Fixes #126