### PR TITLE
Always build manylinux wheels

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -11,7 +11,7 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp38"* ]]; then
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
-	   rm -rf /io/build /io/*.egg-info
+        rm -rf /io/build /io/*.egg-info
     fi
 done
 

--- a/.manylinux.sh
+++ b/.manylinux.sh
@@ -2,8 +2,4 @@
 
 set -e -x
 
-docker pull $DOCKER_IMAGE
-
-docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/.manylinux-install.sh
-
-pip install twine && twine upload -u zope.wheelbuilder -p $PYPIPASSWORD wheelhouse/*
+docker run --rm -v "$(pwd)":/io $DOCKER_IMAGE $PRE_CMD /io/.manylinux-install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,78 +1,94 @@
 language: python
-sudo: false
-matrix:
-    include:
-        - os: linux
-          python: 2.7
-        - os: linux
-          python: 3.5
-        - os: linux
-          python: 3.6
-        - os: linux
-          python: 3.7
-        - os: linux
-          python: 3.8
-        - os: linux
-          python: pypy
-        - os: linux
-          python: pypy3
-        # It's important to use 'macpython' builds to get the least
-        # restrictive wheel tag. It's also important to avoid
-        # 'homebrew 3' because it floats instead of being a specific version.
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='macpython 2.7'
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='macpython 3.5'
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='macpython 3.6.0'
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='macpython 3.7.0'
-        - services:
-            - docker
-          env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-          before_install:
-            - if [[ $TRAVIS_TAG ]]; then bash .manylinux.sh; fi
-            - exit 0
-        - services:
-            - docker
-          env:
-            - DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
-            - PRE_CMD=linux32
-          before_install:
-            - if [[ $TRAVIS_TAG ]]; then bash .manylinux.sh; fi
-            - exit 0
+
+env:
+  global:
+    TWINE_USERNAME: zope.wheelbuilder
+    TWINE_PASSWORD:
+      secure: "AyR5QxUuZKdmywiepdBG0r8hgFQfaEf2hTxOg/HiXisVNcs1sUPjephBP4MqQBbf1/qxLM95F6Mw3sKneO3gDDQSGCsmvY1MWlDc+6R5TgqVBuOoONji5zGQH7v9RR8IPOyple8BNlFePl1hQ8r0dOT1U6rDVh5FkNJgHYE9OJ4="
+
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
+  - pypy
+  - pypy3
+
+jobs:
+  include:
+
+    # manylinux wheel builds
+    - name: 64-bit manylinux wheels (all Pythons)
+      services: docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_x86_64
+      install: docker pull $DOCKER_IMAGE
+      script: bash .manylinux.sh
+
+    - name: 32-bit manylinux wheels (all Pythons)
+      services: docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_i686 PRE_CMD=linux32
+      install: docker pull $DOCKER_IMAGE
+      script: bash .manylinux.sh
+
+    # It's important to use 'macpython' builds to get the least
+    # restrictive wheel tag. It's also important to avoid
+    # 'homebrew 3' because it floats instead of being a specific version.
+    - name: Python 2.7 wheels for MacOS
+      os: osx
+      language: generic
+      # We require at least 2.7.15 to upload wheels.
+      # See https://github.com/zopefoundation/BTrees/issues/113
+      env: TERRYFY_PYTHON='macpython 2.7.17'
+    - name: Python 3.5 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.5'
+    - name: Python 3.6 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.6.0'
+    - name: Python 3.7 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.7.0'
+
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then get_python_environment $TERRYFY_PYTHON venv; fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      git clone https://github.com/MacPython/terryfy
+      source terryfy/travis_tools.sh
+      get_python_environment $TERRYFY_PYTHON venv
+    fi
+
 install:
   - pip install -U pip setuptools
   - pip install -U coveralls coverage
   - pip install -U -e ".[test]"
-script:
-    - coverage run setup.py test -q
-notifications:
-    email: false
-after_success:
-    - coveralls
-    - echo [distutils]                                  > ~/.pypirc
-    - echo index-servers = pypi                        >> ~/.pypirc
-    - echo [pypi]                                      >> ~/.pypirc
-    - echo username=zope.wheelbuilder                  >> ~/.pypirc
-    - echo password=$PYPIPASSWORD                      >> ~/.pypirc
-    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then pip install twine; fi
-    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then python setup.py bdist_wheel; fi
-    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then twine upload dist/*; fi
 
-env:
-    global:
-        secure: "CeOq8/6F8IlbRpKEk2z3RPD/q5cBCPXGOUgjYryG/c+7P6SCTxaTKfxiJPqT3sGgO8x/HcJVuvZghyqCPvysk3cbnq4SiMtI1S0hS/N3DFsGZHn25YQBipAYjA4YDUb6GqCpsSUIXdbGMEzG7DOSB6c+49+//wkjbBFHmPNWvMQ="
+script:
+  - python --version
+  - coverage run setup.py -q test
+  - python setup.py bdist_wheel
+
+after_success:
+  - coveralls
+  - |
+    if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then
+      # macpython 3.5 doesn't support recent TLS protocols which causes twine
+      # upload to fail, so we use the system Python to run twine
+      /usr/bin/python -m pip install twine
+      twine upload --skip-existing dist/*
+    fi
+  - |
+    if [[ $TRAVIS_TAG && -n "$DOCKER_IMAGE" ]]; then
+      pip install twine
+      twine upload --skip-existing wheelhouse/*
+    fi
+
+notifications:
+  email: false
 
 cache: pip
-
 before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log


### PR DESCRIPTION
This PR makes it so we _always_ build manylinux wheels, but only upload
them for git tags.

Highlights:

- Move regular Linux Python builds outside the build matrix, for
  conciseness.

- Switch manylinux1 builds to manylinux2010 (they should still get the
  manylinux1 tag if they're compatible, but they'll be built with a more
  modern compiler toolchain).

- Move twine upload from .manylinux.sh into .travis.yml's after_success,
  right next to the twine upload used for Mac OS builds.

- This means we can't short-circuit the builds with 'exit 0' in
  before_install:, so overwrite the install: and script: sections too.

- Move the 'docker pull' from .manylinux.sh into the install: section
  so it's not empty.

- Provide twine credentials via environment variables instead of
  command-line/pypirc file.

- Put related commands inside a single multiline if statement.

- Use setup.py -q test (quiet build) instead of setup.py test -q (which
  does nothing at all AFAICT).

This mirrors changes made to other zopefoundation packages tracked in
https://github.com/zopefoundation/meta/issues/11.