### PR TITLE
Clean up appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,13 @@ environment:
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - ps: |
+      $env:PYTHON = "C:\\Python${env:PYTHON}"
+      if (-not (Test-Path $env:PYTHON)) {
+        curl -o install_python.ps1 https://raw.githubusercontent.com/matthew-brett/multibuild/11a389d78892cf90addac8f69433d5e22bfa422a/install_python.ps1
+        .\install_python.ps1
+      }
+  - ps: if (-not (Test-Path $env:PYTHON)) { throw "No $env:PYTHON" }
   - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
   - pip install -e .
 
@@ -26,13 +33,13 @@ build_script:
   - python -W ignore setup.py -q bdist_wheel
 
 test_script:
-  - python setup.py test -q
+  - python setup.py -q test
 
 artifacts:
   - path: 'dist\*.whl'
     name: wheel
 
 deploy_script:
-  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { pip install twine; twine upload dist/* }
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { pip install twine; twine --skip-existing upload dist/* }
 
 deploy: on


### PR DESCRIPTION
- Make sure that the Python we want actually exists (and install it if
  necessary) -- this will make our lives easier next year, when Python
  3.9 shows up

- Make the test run quiet (setup.py test -q ignores the -q)

- Pass --skip-existing to twine upload so the build of the tag can be
  retried if necessary without causing spurious failures

I think it might also be a good idea to add a custom version template to
avoid nonsense like https://ci.appveyor.com/project/mgedmin/zope-interface/builds/28770734,
but I'm not entirely sure what happened there and whether a custom
version template would help.  (All I know is all my project appveyors
YML have `version: build-{build}-{branch}` and I've never seen that kind
of error.)