### PR TITLE
More memory optimizations for a 6-7% reduction.

### DIFF
--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -309,7 +309,7 @@ static void
 Spec_dealloc(Spec* self)
 {
     if (self->weakreflist != NULL) {
-	PyObject_ClearWeakRefs(OBJECT(self));
+        PyObject_ClearWeakRefs(OBJECT(self));
     }
     Spec_clear(self);
     Py_TYPE(self)->tp_free(OBJECT(self));

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -272,7 +272,7 @@ typedef struct {
       The remainder aren't used in C code but must be stored here
       to prevent instance layout conflicts.
     */
-    PyObject* dependents;
+    PyObject* _dependents;
     PyObject* _bases;
     PyObject* _v_attrs;
     PyObject* __iro__;
@@ -287,7 +287,7 @@ static int
 Spec_traverse(Spec* self, visitproc visit, void* arg)
 {
     Py_VISIT(self->_implied);
-    Py_VISIT(self->dependents);
+    Py_VISIT(self->_dependents);
     Py_VISIT(self->_v_attrs);
     Py_VISIT(self->__iro__);
     Py_VISIT(self->__sro__);
@@ -298,7 +298,7 @@ static int
 Spec_clear(Spec* self)
 {
     Py_CLEAR(self->_implied);
-    Py_CLEAR(self->dependents);
+    Py_CLEAR(self->_dependents);
     Py_CLEAR(self->_v_attrs);
     Py_CLEAR(self->__iro__);
     Py_CLEAR(self->__sro__);
@@ -408,7 +408,7 @@ static struct PyMethodDef Spec_methods[] = {
 
 static PyMemberDef Spec_members[] = {
   {"_implied", T_OBJECT_EX, offsetof(Spec, _implied), 0, ""},
-  {"dependents", T_OBJECT_EX, offsetof(Spec, dependents), 0, ""},
+  {"_dependents", T_OBJECT_EX, offsetof(Spec, _dependents), 0, ""},
   {"_bases", T_OBJECT_EX, offsetof(Spec, _bases), 0, ""},
   {"_v_attrs", T_OBJECT_EX, offsetof(Spec, _v_attrs), 0, ""},
   {"__iro__", T_OBJECT_EX, offsetof(Spec, __iro__), 0, ""},

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -62,15 +62,10 @@ class named(object):
 class Declaration(Specification):
     """Interface declarations"""
 
+    __slots__ = ()
+
     def __init__(self, *interfaces):
         Specification.__init__(self, _normalizeargs(interfaces))
-
-    def changed(self, originally_changed):
-        Specification.changed(self, originally_changed)
-        try:
-            del self._v_attrs
-        except AttributeError:
-            pass
 
     def __contains__(self, interface):
         """Test whether an interface is in the specification
@@ -625,9 +620,12 @@ def noLongerProvides(object, interface):
 
 
 @_use_c_impl
-class ClassProvidesBase(object):
-    # In C, this extends SpecificationBase, so its kind of weird here that it
-    # doesn't.
+class ClassProvidesBase(SpecificationBase):
+
+    __slots__ = (
+        '_cls',
+        '_implements',
+    )
 
     def __get__(self, inst, cls):
         if cls is self._cls:
@@ -916,6 +914,8 @@ def _normalizeargs(sequence, output=None):
 
     return output
 
-_empty = Declaration()
+# XXX: Declarations are mutable, allowing adjustments to their __bases__
+# so having one as a singleton may not be a great idea.
+_empty = Declaration() # type: Declaration
 
 objectSpecificationDescriptor = ObjectSpecificationDescriptor()

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -67,7 +67,9 @@ class Element(object):
 
         self.__name__ = __name__
         self.__doc__ = __doc__
-        self.__tagged_values = {}
+        # Tagged values are rare, especially on methods or attributes.
+        # Deferring the allocation can save substantial memory.
+        self.__tagged_values = None
 
     def getName(self):
         """ Returns the name of the object. """
@@ -79,18 +81,22 @@ class Element(object):
 
     def getTaggedValue(self, tag):
         """ Returns the value associated with 'tag'. """
+        if not self.__tagged_values:
+            raise KeyError(tag)
         return self.__tagged_values[tag]
 
     def queryTaggedValue(self, tag, default=None):
         """ Returns the value associated with 'tag'. """
-        return self.__tagged_values.get(tag, default)
+        return self.__tagged_values.get(tag, default) if self.__tagged_values else default
 
     def getTaggedValueTags(self):
         """ Returns a list of all tags. """
-        return self.__tagged_values.keys()
+        return self.__tagged_values.keys() if self.__tagged_values else ()
 
     def setTaggedValue(self, tag, value):
         """ Associates 'value' with 'key'. """
+        if self.__tagged_values is None:
+            self.__tagged_values = {}
         self.__tagged_values[tag] = value
 
 

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -101,31 +101,31 @@ class DeclarationTests(unittest.TestCase):
     def test_changed_wo_existing__v_attrs(self):
         decl = self._makeOne()
         decl.changed(decl) # doesn't raise
-        self.assertFalse('_v_attrs' in decl.__dict__)
+        self.assertIsNone(decl._v_attrs)
 
     def test_changed_w_existing__v_attrs(self):
         decl = self._makeOne()
         decl._v_attrs = object()
         decl.changed(decl)
-        self.assertFalse('_v_attrs' in decl.__dict__)
+        self.assertIsNone(decl._v_attrs)
 
     def test___contains__w_self(self):
         from zope.interface.interface import InterfaceClass
         IFoo = InterfaceClass('IFoo')
         decl = self._makeOne()
-        self.assertFalse(decl in decl)
+        self.assertNotIn(decl, decl)
 
     def test___contains__w_unrelated_iface(self):
         from zope.interface.interface import InterfaceClass
         IFoo = InterfaceClass('IFoo')
         decl = self._makeOne()
-        self.assertFalse(IFoo in decl)
+        self.assertNotIn(IFoo, decl)
 
     def test___contains__w_base_interface(self):
         from zope.interface.interface import InterfaceClass
         IFoo = InterfaceClass('IFoo')
         decl = self._makeOne(IFoo)
-        self.assertTrue(IFoo in decl)
+        self.assertIn(IFoo, decl)
 
     def test___iter___empty(self):
         decl = self._makeOne()
@@ -454,7 +454,7 @@ class Test_implementedByFallback(unittest.TestCase):
         self.assertTrue(spec.inherit is foo)
         self.assertTrue(foo.__implemented__ is spec)
         self.assertTrue(foo.__providedBy__ is objectSpecificationDescriptor)
-        self.assertFalse('__provides__' in foo.__dict__)
+        self.assertNotIn('__provides__', foo.__dict__)
 
     def test_w_None_no_bases_w_class(self):
         from zope.interface.declarations import ClassProvides
@@ -601,7 +601,7 @@ class Test__implements_advice(unittest.TestCase):
         class Foo(object):
             __implements_advice_data__ = ((IFoo,), classImplements)
         self._callFUT(Foo)
-        self.assertFalse('__implements_advice_data__' in Foo.__dict__)
+        self.assertNotIn('__implements_advice_data__', Foo.__dict__)
         self.assertIsInstance(Foo.__implemented__,  Implements)
         self.assertEqual(list(Foo.__implemented__), [IFoo])
 

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -370,7 +370,7 @@ class SpecificationTests(unittest.TestCase):
         spec._v_attrs = 'Foo'
         spec._implied[I] = ()
         spec.changed(spec)
-        self.assertTrue(getattr(spec, '_v_attrs', self) is self)
+        self.assertIsNone(spec._v_attrs)
         self.assertFalse(I in spec._implied)
 
     def test_interfaces_skips_already_seen(self):


### PR DESCRIPTION
Details in commit messages. In short:

- Make Declaration, Specification, ClassProvides use `__slots__` or `tp_members`. Shouldn't affect pickling as outlined in #154. Would break sticking arbitrary objects on them, of course.
- Avoid allocating WeakKeyDictionary for dependents unless needed (< 50% of the time)
- Likewise for tagged value storage.

I think these optimizations are safe. Adding `__slots__` to `Element`, `Method` or `Attribute` leads to hard-to-resolve layout or metaclass conflicts, so I didn't touch them. Also, using `__doc__` as an instance variable makes it *really, really* hard to do anything with it.

On loading a sample application[1] of 6000 modules that defined 2200 interfaces, I got a total memory savings of about 6-7% (roughly 235MB to 223MB) from 4.7.1, as measured (repeatedly) using psutil. Startup time was essentially unchanged according to the shell's `time` command. Actual differences will depend on the application and its use of interfaces and interface features.

[1] Not an actual application, but a buildout eggs directory that *used* to belong to a Pyramid+Zope 3 application (but has also been shared with some other minor things) and so has some version of its collected dependencies (duplicates were filtered out).