### PR TITLE
Improve InterfaceClass __hash__ performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,13 @@
   an undocumented private C API function, and helps make some
   instances require less memory. See `PR 154 <https://github.com/zopefoundation/zope.interface/pull/154>`_.
 
+- Performance optimization of ``__hash__`` method on ``InterfaceClass``.
+  The method is called very often (i.e several 100.000 times on a Plone 5.2
+  startup). Because the hash value never changes it can be cached.
+  This improves test performance from 0.614s down to 0.575s (1.07x faster).
+  In a real world Plone case a reindex index came down from 402s to 320s (1.26x faster).
+  See `PR 156 <https://github.com/zopefoundation/zope.interface/pull/156>`_.
+
 
 4.7.1 (2019-11-11)
 ==================

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -538,11 +538,15 @@ class InterfaceClass(Element, InterfaceBase, Specification):
         return (n1 > n2) - (n1 < n2)
 
     def __hash__(self):
-        d = self.__dict__
-        if '__module__' not in d or '__name__' not in d: # pragma: no cover
-            warnings.warn('Hashing uninitialized InterfaceClass instance')
-            return 1
-        return hash((self.__name__, self.__module__))
+        try:
+            return self._cached_hash
+        except AttributeError:
+            try:
+                self._cached_hash = hash((self.__name__, self.__module__))
+            except AttributeError: # pragma: no cover
+                warnings.warn('Hashing uninitialized InterfaceClass instance')
+                return 1
+        return self._cached_hash
 
     def __eq__(self, other):
         c = self.__cmp(other)

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -539,14 +539,14 @@ class InterfaceClass(Element, InterfaceBase, Specification):
 
     def __hash__(self):
         try:
-            return self._cached_hash
+            return self._v_cached_hash
         except AttributeError:
             try:
-                self._cached_hash = hash((self.__name__, self.__module__))
+                self._v_cached_hash = hash((self.__name__, self.__module__))
             except AttributeError: # pragma: no cover
                 warnings.warn('Hashing uninitialized InterfaceClass instance')
                 return 1
-        return self._cached_hash
+        return self._v_cached_hash
 
     def __eq__(self, other):
         c = self.__cmp(other)


### PR DESCRIPTION
Performance optimization of ``__hash__`` method on ``InterfaceClass``.

The method is called very often (i.e several 100.000 times on a Plone 5.2 startup). 
Even if a single ``hash`` is very fast, this sums up to a real significant part of processing time.
Because the hash value calculated from ``name`` and ``__module__`` never changes (afaik), it can be cached.

I took Py-Spy to analyze the performance.
On reindexing of an index in ZCatalog the ``__hash__`` took ~9 seconds after 10000 samples before changes. 
With a cached hash like in this implementation ``__hash__`` takes ~4.7 seconds.
The whole reindex index process came down from 402s to 320s (1.26x faster).
The test performance ``python setup.py test`` goes from 0.614s down to 0.575s (1.07x faster).