### PR TITLE
Remove unneeded overwrite and call to anyway inherited __hash__ method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,13 @@
   fields in your subclass before attempting to hash or sort it. See
   `issue 157 <https://github.com/zopefoundation/zope.interface/issues/157>`_.
 
+- Remove unneeded overwrite and call to anyway inherited `__hash__` method
+  from `.declarations.Implements` class. Watching a reindex index process in
+  ZCatalog with on a Py-Spy after 10k samples the time for `.adapter._lookup`
+  was reduced from 27.5s to 18.8s (~1.5x faster). Overall reindex index time
+  shrunk from 369s to 293s (1.26x faster). See
+  `PR 161 <https://github.com/zopefoundation/zope.interface/pull/161>`_.
+
 4.7.1 (2019-11-11)
 ==================
 

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -223,9 +223,6 @@ class Implements(Declaration):
         # This spelling works under Python3, which doesn't have cmp().
         return (n1 > n2) - (n1 < n2)
 
-    def __hash__(self):
-        return Declaration.__hash__(self)
-
     # We want equality to be based on identity. However, we can't actually
     # implement __eq__/__ne__ to do this because sometimes we get wrapped in a proxy.
     # We need to let the proxy types implement these methods so they can handle unwrapping

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -223,12 +223,12 @@ class Implements(Declaration):
         # This spelling works under Python3, which doesn't have cmp().
         return (n1 > n2) - (n1 < n2)
 
-    # We want equality to be based on identity. However, we can't actually
+    # We want equality and hashing to be based on identity. However, we can't actually
     # implement __eq__/__ne__ to do this because sometimes we get wrapped in a proxy.
     # We need to let the proxy types implement these methods so they can handle unwrapping
     # and then rely on: (1) the interpreter automatically changing `implements == proxy` into
     # `proxy == implements` (which will call proxy.__eq__ to do the unwrapping) and then
-    # (2) the default equality semantics being identity based.
+    # (2) the default equality and hashing semantics being identity based.
 
     def __lt__(self, other):
         c = self.__cmp(other)


### PR DESCRIPTION
Remove unneeded overwrite and call to anyway inherited `__hash__` method  from `.declarations.Implements` class. 

Watching a reindex index process in ZCatalog with Py-Spy after 10k samples the TotalTime for `.adapter._lookup`  was reduced from 27.5s to 18.8s (~1.5x faster) by taking almost the same OwnTime (before 15.7s/after 13.18s). Before the removed `__hash__` had an OwnTime of 7.76s.

Overall reindex index time  shrunk from 369s to 293s (1.26x faster).

I wonder why this method was necessary? Or is it still for some edge case? 
I am sure it was not placed there w/o a reason.