### PR TITLE
The _empty singleton has no-op subscribe/unsubscribe methods.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,12 +54,18 @@
   fields in your subclass before attempting to hash or sort it. See
   `issue 157 <https://github.com/zopefoundation/zope.interface/issues/157>`_.
 
-- Remove unneeded overwrite and call to anyway inherited `__hash__` method
-  from `.declarations.Implements` class. Watching a reindex index process in
-  ZCatalog with on a Py-Spy after 10k samples the time for `.adapter._lookup`
-  was reduced from 27.5s to 18.8s (~1.5x faster). Overall reindex index time
-  shrunk from 369s to 293s (1.26x faster). See
-  `PR 161 <https://github.com/zopefoundation/zope.interface/pull/161>`_.
+- Remove unneeded override of the ``__hash__`` method from
+  ``zope.interface.declarations.Implements``. Watching a reindex index
+  process in ZCatalog with on a Py-Spy after 10k samples the time for
+  ``.adapter._lookup`` was reduced from 27.5s to 18.8s (~1.5x faster).
+  Overall reindex index time shrunk from 369s to 293s (1.26x faster).
+  See `PR 161
+  <https://github.com/zopefoundation/zope.interface/pull/161>`_.
+
+- Make the Python implementation closer to the C implementation by
+  ignoring all exceptions, not just ``AttributeError``, during (parts
+  of) interface adaptation. See `issue 163
+  <https://github.com/zopefoundation/zope.interface/issues/163>`_.
 
 4.7.1 (2019-11-11)
 ==================

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -159,7 +159,10 @@ class InterfaceBase(object):
     def __call__(self, obj, alternate=_marker):
         """Adapt an object to the interface
         """
-        conform = getattr(obj, '__conform__', None)
+        try:
+            conform = getattr(obj, '__conform__', None)
+        except:
+            conform = None
         if conform is not None:
             adapter = self._call_conform(conform)
             if adapter is not None:

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -997,6 +997,24 @@ class AdapterLookupBaseTests(unittest.TestCase):
         result = alb.queryMultiAdapter((foo,), IBar, default=_default)
         self.assertTrue(result is _default)
 
+    def test_queryMultiAdapter_errors_on_attribute_access(self):
+        # Which leads to using the _empty singleton as "requires"
+        # argument. See https://github.com/zopefoundation/zope.interface/issues/162
+        from zope.interface.interface import InterfaceClass
+        IFoo = InterfaceClass('IFoo')
+        registry = self._makeRegistry()
+        alb = self._makeOne(registry)
+        alb.lookup = alb._uncached_lookup
+        class UnexpectedErrorsLikeAcquisition(object):
+
+            def __getattribute__(self, name):
+                raise RuntimeError("Acquisition does this. Ha-ha!")
+
+        result = alb.queryMultiAdapter(
+            (UnexpectedErrorsLikeAcquisition(),),
+            IFoo,
+        )
+
     def test_queryMultiAdaptor_factory_miss(self):
         from zope.interface.declarations import implementer
         from zope.interface.interface import InterfaceClass


### PR DESCRIPTION
Turns out they can be called in some very strange error cases. See #162 and #163 for details.

This should fix #162 (at least the provided test case, five.intid, passes now).

It also does enough work on #163 that (a) the test can be written and run in pure-python mode, which was needed to debug it and (b) five.intid runs in pure-python mode (well, with a bunch of other small hacks to Acquisition, ExtensionClass, DocumentTemplate and AccessControl), but I won't claim that it fully resolves that issue. For one thing, there are no specific tests. For another, I see more such differences.

@jensens Does this solve the issues, or at least get you further?