### PR TITLE
Performance optimization in _lookup _lookupAll and _subscriptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,14 @@
   of) interface adaptation. See `issue 163
   <https://github.com/zopefoundation/zope.interface/issues/163>`_.
 
+- Micro-optimization in `.adapter. `, `.adapter._lookupAll` and
+  `.adapter._subscriptions`: By loading components.get into a local variable
+  before entering the loop a bytcode "LOAD_FAST 0 (components)" in the loop
+  can be eliminated. In Plone, while running all tests, average speedup of
+  `_lookup`s owntime is ~5x.
+  See `PR 167 <https://github.com/zopefoundation/zope.interface/pull/167>`_.
+
+
 4.7.1 (2019-11-11)
 ==================
 

--- a/src/zope/interface/adapter.py
+++ b/src/zope/interface/adapter.py
@@ -662,17 +662,17 @@ def _lookup(components, specs, provided, name, i, l):
     # The components.get in loops is executed 100 of 1000s times.
     # by loading get into a local variable the bytecode
     # "LOAD_FAST 0 (components)" in the loop can be eliminated.
-    cget = components.get
+    components_get = components.get
     if i < l:
         for spec in specs[i].__sro__:
-            comps = cget(spec)
+            comps = components_get(spec)
             if comps:
                 r = _lookup(comps, specs, provided, name, i+1, l)
                 if r is not None:
                     return r
     else:
         for iface in provided:
-            comps = cget(iface)
+            comps = components_get(iface)
             if comps:
                 r = comps.get(name)
                 if r is not None:
@@ -681,28 +681,28 @@ def _lookup(components, specs, provided, name, i, l):
     return None
 
 def _lookupAll(components, specs, provided, result, i, l):
-    cget = components.get  # see _lookup above
+    components_get = components.get  # see _lookup above
     if i < l:
         for spec in reversed(specs[i].__sro__):
-            comps = cget(spec)
+            comps = components_get(spec)
             if comps:
                 _lookupAll(comps, specs, provided, result, i+1, l)
     else:
         for iface in reversed(provided):
-            comps = cget(iface)
+            comps = components_get(iface)
             if comps:
                 result.update(comps)
 
 def _subscriptions(components, specs, provided, name, result, i, l):
-    cget = components.get  # see _lookup above
+    components_get = components.get  # see _lookup above
     if i < l:
         for spec in reversed(specs[i].__sro__):
-            comps = cget(spec)
+            comps = components_get(spec)
             if comps:
                 _subscriptions(comps, specs, provided, name, result, i+1, l)
     else:
         for iface in reversed(provided):
-            comps = cget(iface)
+            comps = components_get(iface)
             if comps:
                 comps = comps.get(name)
                 if comps:

--- a/src/zope/interface/adapter.py
+++ b/src/zope/interface/adapter.py
@@ -658,16 +658,21 @@ def _convert_None_to_Interface(x):
         return x
 
 def _lookup(components, specs, provided, name, i, l):
+    # this function is called very often.
+    # The components.get in loops is executed 100 of 1000s times.
+    # by loading get into a local variable the bytecode
+    # "LOAD_FAST 0 (components)" in the loop can be eliminated.
+    cget = components.get
     if i < l:
         for spec in specs[i].__sro__:
-            comps = components.get(spec)
+            comps = cget(spec)
             if comps:
                 r = _lookup(comps, specs, provided, name, i+1, l)
                 if r is not None:
                     return r
     else:
         for iface in provided:
-            comps = components.get(iface)
+            comps = cget(iface)
             if comps:
                 r = comps.get(name)
                 if r is not None:
@@ -676,26 +681,28 @@ def _lookup(components, specs, provided, name, i, l):
     return None
 
 def _lookupAll(components, specs, provided, result, i, l):
+    cget = components.get  # see _lookup above
     if i < l:
         for spec in reversed(specs[i].__sro__):
-            comps = components.get(spec)
+            comps = cget(spec)
             if comps:
                 _lookupAll(comps, specs, provided, result, i+1, l)
     else:
         for iface in reversed(provided):
-            comps = components.get(iface)
+            comps = cget(iface)
             if comps:
                 result.update(comps)
 
 def _subscriptions(components, specs, provided, name, result, i, l):
+    cget = components.get  # see _lookup above
     if i < l:
         for spec in reversed(specs[i].__sro__):
-            comps = components.get(spec)
+            comps = cget(spec)
             if comps:
                 _subscriptions(comps, specs, provided, name, result, i+1, l)
     else:
         for iface in reversed(provided):
-            comps = components.get(iface)
+            comps = cget(iface)
             if comps:
                 comps = comps.get(name)
                 if comps:


### PR DESCRIPTION
Micro-optimization in `.adapter._lookup`, `.adapter._lookupAll` and   `.adapter._subscriptions`: By loading components.get into a local variable  before entering the loop a bytcode "LOAD_FAST 0 (components)" in the loop can be eliminated. 

In Plone, while running all tests, average speedup of   `_lookup`s owntime is ~5x (this time measured with py-spy and 35k samples while running all tests)