### PR TITLE
Fixes #165 (Uninitialized self._dependents in unsubscribe)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,13 @@
   `_lookup`s owntime is ~5x.
   See `PR 167 <https://github.com/zopefoundation/zope.interface/pull/167>`_.
 
+- Fixes problem with local interface class definitions in functions/methods in
+  the same module using the same class name. Those where considered to be hash-wise
+  the same. Use ``__qualname__`` for the hash to fix it.
+  The ``repr`` and ``__identifier__`` are not touched, because it would break a lot
+  of tests and code which uses zope.interface and relies on the current naming.
+  See `Issue 165 <https://github.com/zopefoundation/zope.interface/issues/165>`_.
+
 
 4.7.1 (2019-11-11)
 ==================

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -370,6 +370,10 @@ class InterfaceClass(Element, InterfaceBase, Specification):
 
         self.__module__ = __module__
 
+        # local class definitions may share the same module and name,
+        # use qualname for hashes
+        self.__qualname__ = attrs.get('__qualname__', name)
+
         d = attrs.get('__doc__')
         if d is not None:
             if not isinstance(d, Attribute):
@@ -591,7 +595,7 @@ class InterfaceClass(Element, InterfaceBase, Specification):
         try:
             return self._v_cached_hash
         except AttributeError:
-            self._v_cached_hash = hash((self.__name__, self.__module__))
+            self._v_cached_hash = hash((self.__qualname__, self.__module__))
         return self._v_cached_hash
 
     def __eq__(self, other):

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -585,8 +585,8 @@ class InterfaceClass(Element, InterfaceBase, Specification):
         if other is None:
             return -1
 
-        n1 = (self.__name__, self.__module__)
-        n2 = (getattr(other, '__name__', ''), getattr(other, '__module__', ''))
+        n1 = (self.__qualname__, self.__module__)
+        n2 = (getattr(other, '__qualname__', ''), getattr(other, '__module__', ''))
 
         # This spelling works under Python3, which doesn't have cmp().
         return (n1 > n2) - (n1 < n2)

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -885,7 +885,6 @@ class InterfaceClassTests(unittest.TestCase):
         self.assertFalse(one > other)
         self.assertTrue(other > one)
 
-
 class InterfaceTests(unittest.TestCase):
 
     def test_attributes_link_to_interface(self):
@@ -1847,6 +1846,34 @@ class InterfaceTests(unittest.TestCase):
             self.assertTrue(I(c) is self)
         finally:
             adapter_hooks[:] = old_adapter_hooks
+
+    def test_local_interfaces_with_same_name_and_module_are_different(self):
+        # see https://github.com/zopefoundation/zope.interface/issues/165
+        from zope.interface import Interface
+
+        def make_IFoo_1():
+            class IFoo(Interface):
+                pass
+
+            return IFoo
+
+        def make_IFoo_2():
+            class IFoo(Interface):
+                pass
+
+            return IFoo
+
+        ifoo1 = make_IFoo_1()
+        ifoo2 = make_IFoo_2()
+        self.assertFalse(ifoo1 is ifoo2)
+        self.assertNotEqual(ifoo1, ifoo2)
+        self.assertIn(ifoo1, Interface._dependents)
+        self.assertIn(ifoo2, Interface._dependents)
+        self.asserNotEqual(
+            list(Interface._dependents).index(ifoo1),
+            list(Interface._dependents).index(ifoo2),
+        )
+        self.assertNotEqual(hash(ifoo1), hash(ifoo2))
 
 
 class AttributeTests(ElementTests):

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -885,6 +885,7 @@ class InterfaceClassTests(unittest.TestCase):
         self.assertFalse(one > other)
         self.assertTrue(other > one)
 
+
 class InterfaceTests(unittest.TestCase):
 
     def test_attributes_link_to_interface(self):
@@ -1869,7 +1870,7 @@ class InterfaceTests(unittest.TestCase):
         self.assertNotEqual(ifoo1, ifoo2)
         self.assertIn(ifoo1, Interface._dependents)
         self.assertIn(ifoo2, Interface._dependents)
-        self.asserNotEqual(
+        self.assertNotEqual(
             list(Interface._dependents).index(ifoo1),
             list(Interface._dependents).index(ifoo2),
         )


### PR DESCRIPTION
a problem with multiple local interface class definitions under the same name.

see #165 