### PR TITLE
Fix verification for methods of builtin types with pseudo-default args on PyPy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,21 @@
   `issue 153
   <https://github.com/zopefoundation/zope.interface/issues/153>`_.
 
+- Fix ``verifyClass`` and ``verifyObject`` for builtin types like
+  ``dict`` that have methods taking an optional, unnamed argument with
+  no default value like ``dict.pop``. On PyPy3, the verification is
+  strict, but on PyPy2 (as on all versions of CPython) those methods
+  cannot be verified and are ignored. See `issue 118
+  <https://github.com/zopefoundation/zope.interface/issues/118>`_.
+
+- Update the common interfaces ``IEnumerableMapping``,
+  ``IExtendedReadMapping``, ``IExtendedWriteMapping``,
+  ``IReadSequence`` and ``IUniqueMemberWriteSequence`` to no longer
+  require methods that were removed from Python 3 on Python 3, such as
+  ``__setslice___``. Now, ``dict``, ``list`` and ``tuple`` properly
+  verify as ``IFullMapping``, ``ISequence`` and ``IReadSequence,``
+  respectively on all versions of Python.
+
 4.7.1 (2019-11-11)
 ==================
 

--- a/src/zope/interface/_compat.py
+++ b/src/zope/interface/_compat.py
@@ -54,6 +54,9 @@ else:
     PYTHON3 = True
     PYTHON2 = False
 
+PYPY = hasattr(sys, 'pypy_version_info')
+PYPY2 = PYTHON2 and PYPY
+
 def _skip_under_py3k(test_method):
     import unittest
     return unittest.skipIf(sys.version_info[0] >= 3, "Only on Python 2")(test_method)

--- a/src/zope/interface/common/mapping.py
+++ b/src/zope/interface/common/mapping.py
@@ -17,6 +17,7 @@ Importing this module does *not* mark any standard classes
 as implementing any of these interfaces.
 """
 from zope.interface import Interface
+from zope.interface._compat import PYTHON2 as PY2
 
 class IItemMapping(Interface):
     """Simplest readable mapping object
@@ -89,14 +90,15 @@ class IIterableMapping(IEnumerableMapping):
     without copying.
     """
 
-    def iterkeys():
-        "iterate over keys; equivalent to ``__iter__``"
+    if PY2:
+        def iterkeys():
+            "iterate over keys; equivalent to ``__iter__``"
 
-    def itervalues():
-        "iterate over values"
+        def itervalues():
+            "iterate over values"
 
-    def iteritems():
-        "iterate over items"
+        def iteritems():
+            "iterate over items"
 
 class IClonableMapping(Interface):
     """Something that can produce a copy of itself.
@@ -115,8 +117,9 @@ class IExtendedReadMapping(IIterableMapping):
     in Python 3.
     """
 
-    def has_key(key):
-        """Tell if a key exists in the mapping; equivalent to ``__contains__``"""
+    if PY2:
+        def has_key(key):
+            """Tell if a key exists in the mapping; equivalent to ``__contains__``"""
 
 class IExtendedWriteMapping(IWriteMapping):
     """Additional mutation methods.
@@ -133,12 +136,16 @@ class IExtendedWriteMapping(IWriteMapping):
     def setdefault(key, default=None):
         "D.setdefault(k[,d]) -> D.get(k,d), also set D[k]=d if k not in D"
 
-    def pop(k, *args):
-        """Remove specified key and return the corresponding value.
+    def pop(k, default=None):
+        """
+        pop(k[,default]) -> value
 
-        ``*args`` may contain a single default value, or may not be supplied.
-        If key is not found, default is returned if given, otherwise
-        `KeyError` is raised"""
+        Remove specified key and return the corresponding value.
+
+        If key is not found, *default* is returned if given, otherwise
+        `KeyError` is raised. Note that *default* must not be passed by
+        name.
+        """
 
     def popitem():
         """remove and return some (key, value) pair as a

--- a/src/zope/interface/common/sequence.py
+++ b/src/zope/interface/common/sequence.py
@@ -19,6 +19,7 @@ as implementing any of these interfaces.
 
 __docformat__ = 'restructuredtext'
 from zope.interface import Interface
+from zope.interface._compat import PYTHON2 as PY2
 
 class IMinimalSequence(Interface):
     """Most basic sequence interface.
@@ -79,13 +80,14 @@ class IReadSequence(IFiniteSequence):
     def __rmul__(n):
         """``x.__rmul__(n) <==> n * x``"""
 
-    def __getslice__(i, j):
-        """``x.__getslice__(i, j) <==> x[i:j]``
+    if PY2:
+        def __getslice__(i, j):
+            """``x.__getslice__(i, j) <==> x[i:j]``
 
-        Use of negative indices is not supported.
+            Use of negative indices is not supported.
 
-        Deprecated since Python 2.0 but still a part of `UserList`.
-        """
+            Deprecated since Python 2.0 but still a part of `UserList`.
+            """
 
 class IExtendedReadSequence(IReadSequence):
     """Full read interface for lists"""
@@ -116,21 +118,23 @@ class IUniqueMemberWriteSequence(Interface):
         supports slice objects.
         """
 
-    def __setslice__(i, j, other):
-        """``x.__setslice__(i, j, other) <==> x[i:j] = other``
+    if PY2:
+        def __setslice__(i, j, other):
+            """``x.__setslice__(i, j, other) <==> x[i:j] = other``
 
-        Use of negative indices is not supported.
+            Use of negative indices is not supported.
 
-        Deprecated since Python 2.0 but still a part of `UserList`.
-        """
+            Deprecated since Python 2.0 but still a part of `UserList`.
+            """
 
-    def __delslice__(i, j):
-        """``x.__delslice__(i, j) <==> del x[i:j]``
+        def __delslice__(i, j):
+            """``x.__delslice__(i, j) <==> del x[i:j]``
 
-        Use of negative indices is not supported.
+            Use of negative indices is not supported.
 
-        Deprecated since Python 2.0 but still a part of `UserList`.
-        """
+            Deprecated since Python 2.0 but still a part of `UserList`.
+            """
+
     def __iadd__(y):
         """``x.__iadd__(y) <==> x += y``"""
 

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -698,11 +698,18 @@ def fromFunction(func, interface=None, imlevel=0, name=None):
     defaults = getattr(func, '__defaults__', None) or ()
     code = func.__code__
     # Number of positional arguments
-    na = code.co_argcount-imlevel
+    na = code.co_argcount - imlevel
     names = code.co_varnames[imlevel:]
     opt = {}
     # Number of required arguments
-    nr = na-len(defaults)
+    defaults_count = len(defaults)
+    if not defaults_count:
+        # PyPy3 uses ``__defaults_count__`` for builtin methods
+        # like ``dict.pop``. Surprisingly, these don't have recorded
+        # ``__defaults__``
+        defaults_count = getattr(func, '__defaults_count__', 0)
+
+    nr = na - defaults_count
     if nr < 0:
         defaults = defaults[-nr:]
         nr = 0


### PR DESCRIPTION
On PyPy2, they are ignored (like on CPython), but on PyPy3 they can actually be validated.

Fixes #118

To add tests for this, some minor changes to the common interfaces that remove missing methods on Python 3 were needed.