### PR TITLE
Make verification errors more readable and useful.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,11 +100,13 @@
   and ``Method``. These contain the name of the defining interface
   and the attribute. For methods, it also includes the signature.
 
-- Change the error strings returned by ``verifyObject`` and
+- Change the error strings raised by ``verifyObject`` and
   ``verifyClass``. They now include more human-readable information
   and exclude extraneous lines and spaces. See `issue 170
   <https://github.com/zopefoundation/zope.interface/issues/170>`_.
 
+  .. caution:: This will break consumers (such as doctests) that
+               depended on the exact error messages.
 
 4.7.1 (2019-11-11)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,16 @@
   verify as ``IFullMapping``, ``ISequence`` and ``IReadSequence,``
   respectively on all versions of Python.
 
+- Add human-readable ``__str___`` and ``__repr___`` to ``Attribute``
+  and ``Method``. These contain the name of the defining interface
+  and the attribute. For methods, it also includes the signature.
+
+- Change the error strings returned by ``verifyObject`` and
+  ``verifyClass``. They now include more human-readable information
+  and exclude extraneous lines and spaces. See `issue 170
+  <https://github.com/zopefoundation/zope.interface/issues/170>`_.
+
+
 4.7.1 (2019-11-11)
 ==================
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -2,6 +2,8 @@
 Interfaces
 ==========
 
+.. currentmodule:: zope.interface
+
 Interfaces are objects that specify (document) the external behavior
 of objects that "provide" them.  An interface specifies behavior
 through:
@@ -296,6 +298,7 @@ be used for classes, but in 3.6.0 and higher it can:
 Note that class decorators using the ``@implementer(IFoo)`` syntax are only
 supported in Python 2.6 and later.
 
+.. autofunction:: implementer
 
 Declaring provided interfaces
 -----------------------------
@@ -412,6 +415,8 @@ We can find out what interfaces are directly provided by an object:
   >>> list(zope.interface.directlyProvidedBy(newfoo))
   []
 
+.. autofunction:: provider
+
 Inherited declarations
 ----------------------
 
@@ -466,6 +471,8 @@ be used for this purpose:
   >>> list(zope.interface.implementedBy(C))
   [<InterfaceClass builtins.IFoo>]
 
+.. autofunction:: classImplements
+
 We can use ``classImplementsOnly`` to exclude inherited interfaces:
 
 .. doctest::
@@ -477,6 +484,7 @@ We can use ``classImplementsOnly`` to exclude inherited interfaces:
   >>> list(zope.interface.implementedBy(C))
   [<InterfaceClass builtins.ISpecial>]
 
+.. autofunction:: classImplementsOnly
 
 
 Declaration Objects
@@ -791,7 +799,7 @@ exceptions as its argument:
   ... except Invalid as e:
   ...     str(e)
   '[RangeError(Range(2, 1))]'
-  
+
 And the list will be filled with the individual exceptions:
 
 .. doctest::

--- a/docs/verify.rst
+++ b/docs/verify.rst
@@ -3,30 +3,16 @@
 =====================================
 
 The ``zope.interface.verify`` module provides functions that test whether a
-given interface is implemented by a class or provided by an object, resp.
+given interface is implemented by a class or provided by an object.
 
-
-Verifying classes
-=================
-
-This is covered by unit tests defined in ``zope.interface.tests.test_verify``.
-
+.. currentmodule:: zope.interface.verify
 
 Verifying objects
 =================
 
-An object provides an interface if
+.. autofunction:: verifyObject
 
-- either its class declares that it implements the interfaces, or the object
-  declares that it directly provides the interface;
-
-- the object defines all the methods required by the interface;
-
-- all the methods have the correct signature;
-
-- the object defines all non-method attributes required by the interface.
-
-This doctest currently covers only the latter item.
+.. autoexception:: zope.interface.Invalid
 
 Testing for attributes
 ----------------------
@@ -208,3 +194,25 @@ variable keyword arguments, the implementation must also accept them.
    ...     def needs_varargs(self, **kwargs): pass
    >>> verify_foo()
    The object <Foo...> violates its contract in IFoo.needs_varargs(*args): implementation doesn't support variable arguments.
+
+Verifying Classes
+=================
+
+The function `verifyClass` is used to check that a class implements
+an interface properly, meaning that its instances properly provide the
+interface. Most of the same things that `verifyObject` checks can be
+checked for classes.
+
+.. autofunction:: verifyClass
+
+.. doctest::
+
+    >>> from zope.interface.verify import verifyClass
+    >>> def verify_foo_class():
+    ...    try:
+    ...        return verifyClass(IFoo, Foo)
+    ...    except BrokenMethodImplementation as e:
+    ...        print(e)
+
+    >>> verify_foo_class()
+    The object <class 'Foo'> violates its contract in IFoo.needs_varargs(*args): implementation doesn't support variable arguments.

--- a/docs/verify.rst
+++ b/docs/verify.rst
@@ -151,6 +151,14 @@ different type of exception, so we need an updated helper.
    ...    except BrokenMethodImplementation as e:
    ...        print(e)
 
+Not being callable is an error.
+
+.. doctest::
+
+   >>> Foo.simple = 42
+   >>> verify_foo()
+   The object <Foo...> violates its contract in IFoo.simple(arg1): implementation is not a method.
+
 Taking too few arguments is an error.
 
 .. doctest::

--- a/docs/verify.rst
+++ b/docs/verify.rst
@@ -1,6 +1,6 @@
-===================================
-Verifying interface implementations
-===================================
+=====================================
+ Verifying interface implementations
+=====================================
 
 The ``zope.interface.verify`` module provides functions that test whether a
 given interface is implemented by a class or provided by an object, resp.
@@ -52,33 +52,30 @@ Attributes of the object, be they defined by its class or added by its
    >>> verifyObject(IFoo, Foo())
    True
 
-If either attribute is missing, verification will fail:
+If either attribute is missing, verification will fail by raising an
+exception. (We'll define a helper to make this easier to show.)
 
 .. doctest::
+
+   >>> def verify_foo():
+   ...    foo = Foo()
+   ...    try:
+   ...        return verifyObject(IFoo, foo)
+   ...    except BrokenImplementation as e:
+   ...        print(e)
 
    >>> @implementer(IFoo)
    ... class Foo(object):
    ...     x = 1
-   >>> try: #doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-   ...     verifyObject(IFoo, Foo())
-   ... except BrokenImplementation as e:
-   ...     print(e)
-   An object has failed to implement interface <InterfaceClass ...IFoo>
-   <BLANKLINE>
-           The y attribute was not provided.
-   <BLANKLINE>
+   >>> verify_foo()
+   The object <Foo...> has failed to implement interface <InterfaceClass ...IFoo>: The IFoo.y attribute was not provided.
    >>> @implementer(IFoo)
    ... class Foo(object):
    ...     def __init__(self):
    ...         self.y = 2
-   >>> try: #doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-   ...     verifyObject(IFoo, Foo())
-   ... except BrokenImplementation as e:
-   ...     print(e)
-   An object has failed to implement interface <InterfaceClass ...IFoo>
-   <BLANKLINE>
-           The x attribute was not provided.
-   <BLANKLINE>
+   >>> verify_foo()
+   The object <Foo...> has failed to implement interface <InterfaceClass ...IFoo>: The IFoo.x attribute was not provided.
+
 
 If an attribute is implemented as a property that raises an ``AttributeError``
 when trying to get its value, the attribute is considered missing:
@@ -92,14 +89,9 @@ when trying to get its value, the attribute is considered missing:
    ...     @property
    ...     def x(self):
    ...         raise AttributeError
-   >>> try: #doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-   ...     verifyObject(IFoo, Foo())
-   ... except BrokenImplementation as e:
-   ...     print(e)
-   An object has failed to implement interface <InterfaceClass ...IFoo>
-   <BLANKLINE>
-           The x attribute was not provided.
-   <BLANKLINE>
+   >>> verify_foo()
+   The object <Foo...> has failed to implement interface <InterfaceClass ...IFoo>: The IFoo.x attribute was not provided.
+
 
 Any other exception raised by a property will propagate to the caller of
 ``verifyObject``:
@@ -111,7 +103,7 @@ Any other exception raised by a property will propagate to the caller of
    ...     @property
    ...     def x(self):
    ...         raise Exception
-   >>> verifyObject(IFoo, Foo())
+   >>> verify_foo()
    Traceback (most recent call last):
    Exception
 
@@ -126,5 +118,85 @@ any harm:
    ...     @property
    ...     def y(self):
    ...         raise Exception
-   >>> verifyObject(IFoo, Foo())
+   >>> verify_foo()
    True
+
+
+Testing For Methods
+-------------------
+
+Methods are also validated to exist. We'll start by defining a method
+that takes one argument. If we don't provide it, we get an error.
+
+.. doctest::
+
+   >>> class IFoo(Interface):
+   ...    def simple(arg1): "Takes one positional argument"
+   >>> @implementer(IFoo)
+   ... class Foo(object):
+   ...    pass
+   >>> verify_foo()
+   The object <Foo...> has failed to implement interface <InterfaceClass builtins.IFoo>: The IFoo.simple(arg1) attribute was not provided.
+
+Once they exist, they are checked for compatible signatures. This is a
+different type of exception, so we need an updated helper.
+
+.. doctest::
+
+   >>> from zope.interface.exceptions import BrokenMethodImplementation
+   >>> def verify_foo():
+   ...    foo = Foo()
+   ...    try:
+   ...        return verifyObject(IFoo, foo)
+   ...    except BrokenMethodImplementation as e:
+   ...        print(e)
+
+Taking too few arguments is an error.
+
+.. doctest::
+
+   >>> Foo.simple = lambda: "I take no arguments"
+   >>> verify_foo()
+   The object <Foo...> violates its contract in IFoo.simple(arg1): implementation doesn't allow enough arguments.
+
+Requiring too many arguments is an error. (Recall that the ``self``
+argument is implicit.)
+
+.. doctest::
+
+   >>> Foo.simple = lambda self, a, b: "I require two arguments"
+   >>> verify_foo()
+   The object <Foo...> violates its contract in IFoo.simple(arg1): implementation requires too many arguments.
+
+Variable arguments can be used to implement the required number, as
+can arguments with defaults.
+
+.. doctest::
+
+   >>> Foo.simple = lambda self, *args: "Varargs work."
+   >>> verify_foo()
+   True
+   >>> Foo.simple = lambda self, a=1, b=2: "Default args work."
+   >>> verify_foo()
+   True
+
+If our interface defines a method that uses variable positional or
+variable keyword arguments, the implementation must also accept them.
+
+.. doctest::
+
+   >>> class IFoo(Interface):
+   ...    def needs_kwargs(**kwargs): pass
+   >>> @implementer(IFoo)
+   ... class Foo(object):
+   ...     def needs_kwargs(self, a=1, b=2): pass
+   >>> verify_foo()
+   The object <Foo...> violates its contract in IFoo.needs_kwargs(**kwargs): implementation doesn't support keyword arguments.
+
+   >>> class IFoo(Interface):
+   ...    def needs_varargs(*args): pass
+   >>> @implementer(IFoo)
+   ... class Foo(object):
+   ...     def needs_varargs(self, **kwargs): pass
+   >>> verify_foo()
+   The object <Foo...> violates its contract in IFoo.needs_varargs(*args): implementation doesn't support variable arguments.

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -642,6 +642,22 @@ class Attribute(Element):
 
     interface = None
 
+    def _get_str_info(self):
+        """Return extra data to put at the end of __str__."""
+        return ""
+
+    def __str__(self):
+        of = self.interface.__name__ + '.' if self.interface else ''
+        return of + self.__name__ + self._get_str_info()
+
+    def __repr__(self):
+        return "<%s.%s at 0x%x %s>" % (
+            type(self).__module__,
+            type(self).__name__,
+            id(self),
+            self
+        )
+
 
 class Method(Attribute):
     """Method interfaces
@@ -690,6 +706,8 @@ class Method(Attribute):
             sig.append("**" + self.kwargs)
 
         return "(%s)" % ", ".join(sig)
+
+    _get_str_info = getSignatureString
 
 
 def fromFunction(func, interface=None, imlevel=0, name=None):

--- a/src/zope/interface/interfaces.py
+++ b/src/zope/interface/interfaces.py
@@ -580,6 +580,10 @@ class IInterfaceDeclaration(Interface):
 
         Instances of ``C`` implement ``I1``, ``I2``, and whatever interfaces
         instances of ``A`` and ``B`` implement.
+
+        .. deprecated:: 5.0
+           This only works for Python 2. The `implementer` decorator
+           is preferred for all versions.
         """
 
     def implementsOnly(*interfaces):
@@ -612,6 +616,10 @@ class IInterfaceDeclaration(Interface):
 
         Instances of ``C`` implement ``I1``, ``I2``, regardless of what
         instances of ``A`` and ``B`` implement.
+
+        .. deprecated:: 5.0
+           This only works for Python 2. The `implementer_only` decorator
+           is preferred for all versions.
         """
 
     def classProvides(*interfaces):
@@ -642,7 +650,12 @@ class IInterfaceDeclaration(Interface):
           directlyProvides(theclass, I1)
 
         after the class has been created.
+
+        .. deprecated:: 5.0
+           This only works for Python 2. The `provider` decorator
+           is preferred for all versions.
         """
+
     def provider(*interfaces):
         """A class decorator version of `classProvides`"""
 

--- a/src/zope/interface/tests/test_exceptions.py
+++ b/src/zope/interface/tests/test_exceptions.py
@@ -27,16 +27,24 @@ class DoesNotImplementTests(unittest.TestCase):
         from zope.interface.exceptions import DoesNotImplement
         return DoesNotImplement
 
-    def _makeOne(self):
+    def _makeOne(self, *args):
         iface = _makeIface()
-        return self._getTargetClass()(iface)
+        return self._getTargetClass()(iface, *args)
 
     def test___str__(self):
         dni = self._makeOne()
-        # XXX The trailing newlines and blank spaces are a stupid artifact.
-        self.assertEqual(str(dni),
-            'An object does not implement interface <InterfaceClass '
-               'zope.interface.tests.test_exceptions.IDummy>\n\n        ')
+        self.assertEqual(
+            str(dni),
+            'An object does not implement the interface '
+            '<InterfaceClass zope.interface.tests.test_exceptions.IDummy>.')
+
+    def test___str__w_candidate(self):
+        dni = self._makeOne('candidate')
+        self.assertEqual(
+            str(dni),
+            'The object \'candidate\' does not implement the interface '
+            '<InterfaceClass zope.interface.tests.test_exceptions.IDummy>.')
+
 
 class BrokenImplementationTests(unittest.TestCase):
 
@@ -44,17 +52,25 @@ class BrokenImplementationTests(unittest.TestCase):
         from zope.interface.exceptions import BrokenImplementation
         return BrokenImplementation
 
-    def _makeOne(self, name='missing'):
+    def _makeOne(self, *args):
         iface = _makeIface()
-        return self._getTargetClass()(iface, name)
+        return self._getTargetClass()(iface, 'missing', *args)
 
     def test___str__(self):
         dni = self._makeOne()
-        # XXX The trailing newlines and blank spaces are a stupid artifact.
-        self.assertEqual(str(dni),
-            'An object has failed to implement interface <InterfaceClass '
-               'zope.interface.tests.test_exceptions.IDummy>\n\n'
-               '        The missing attribute was not provided.\n        ')
+        self.assertEqual(
+            str(dni),
+            'An object has failed to implement interface '
+            '<InterfaceClass zope.interface.tests.test_exceptions.IDummy>: '
+            "The 'missing' attribute was not provided.")
+
+    def test___str__w_candidate(self):
+        dni = self._makeOne('candidate')
+        self.assertEqual(
+            str(dni),
+            'The object \'candidate\' has failed to implement interface '
+            '<InterfaceClass zope.interface.tests.test_exceptions.IDummy>: '
+            "The 'missing' attribute was not provided.")
 
 class BrokenMethodImplementationTests(unittest.TestCase):
 
@@ -62,11 +78,17 @@ class BrokenMethodImplementationTests(unittest.TestCase):
         from zope.interface.exceptions import BrokenMethodImplementation
         return BrokenMethodImplementation
 
-    def _makeOne(self, method='aMethod', mess='I said so'):
-        return self._getTargetClass()(method, mess)
+    def _makeOne(self, *args):
+        return self._getTargetClass()('aMethod', 'I said so', *args)
 
     def test___str__(self):
         dni = self._makeOne()
-        self.assertEqual(str(dni),
-            'The implementation of aMethod violates its contract\n'
-             '        because I said so.\n        ')
+        self.assertEqual(
+            str(dni),
+            "An object violates its contract in 'aMethod': I said so.")
+
+    def test___str__w_candidate(self):
+        dni = self._makeOne('candidate')
+        self.assertEqual(
+            str(dni),
+            "The object 'candidate' violates its contract in 'aMethod': I said so.")

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -1857,6 +1857,30 @@ class AttributeTests(ElementTests):
         from zope.interface.interface import Attribute
         return Attribute
 
+    def test__repr__w_interface(self):
+        method = self._makeOne()
+        method.interface = type(self)
+        r = repr(method)
+        self.assertTrue(r.startswith('<zope.interface.interface.Attribute at'), r)
+        self.assertTrue(r.endswith(' AttributeTests.TestAttribute>'), r)
+
+    def test__repr__wo_interface(self):
+        method = self._makeOne()
+        r = repr(method)
+        self.assertTrue(r.startswith('<zope.interface.interface.Attribute at'), r)
+        self.assertTrue(r.endswith(' TestAttribute>'), r)
+
+    def test__str__w_interface(self):
+        method = self._makeOne()
+        method.interface = type(self)
+        r = str(method)
+        self.assertEqual(r, 'AttributeTests.TestAttribute')
+
+    def test__str__wo_interface(self):
+        method = self._makeOne()
+        r = str(method)
+        self.assertEqual(r, 'TestAttribute')
+
 
 class MethodTests(AttributeTests):
 
@@ -1918,6 +1942,34 @@ class MethodTests(AttributeTests):
         method = self._makeOne()
         method.kwargs = 'kw'
         self.assertEqual(method.getSignatureString(), "(**kw)")
+
+    def test__repr__w_interface(self):
+        method = self._makeOne()
+        method.kwargs = 'kw'
+        method.interface = type(self)
+        r = repr(method)
+        self.assertTrue(r.startswith('<zope.interface.interface.Method at'), r)
+        self.assertTrue(r.endswith(' MethodTests.TestMethod(**kw)>'), r)
+
+    def test__repr__wo_interface(self):
+        method = self._makeOne()
+        method.kwargs = 'kw'
+        r = repr(method)
+        self.assertTrue(r.startswith('<zope.interface.interface.Method at'), r)
+        self.assertTrue(r.endswith(' TestMethod(**kw)>'), r)
+
+    def test__str__w_interface(self):
+        method = self._makeOne()
+        method.kwargs = 'kw'
+        method.interface = type(self)
+        r = str(method)
+        self.assertEqual(r, 'MethodTests.TestMethod(**kw)')
+
+    def test__str__wo_interface(self):
+        method = self._makeOne()
+        method.kwargs = 'kw'
+        r = str(method)
+        self.assertEqual(r, 'TestMethod(**kw)')
 
 
 class Test_fromFunction(unittest.TestCase):

--- a/src/zope/interface/verify.py
+++ b/src/zope/interface/verify.py
@@ -110,7 +110,7 @@ def _verify(iface, candidate, tentative=False, vtype=None):
             continue
         else:
             if not callable(attr):
-                raise BrokenMethodImplementation(name, "Not a method", candidate)
+                raise BrokenMethodImplementation(desc, "implementation is not a method", candidate)
             # sigh, it's callable, but we don't know how to introspect it, so
             # we have to give it a pass.
             continue

--- a/src/zope/interface/verify.py
+++ b/src/zope/interface/verify.py
@@ -36,20 +36,27 @@ MethodTypes = (MethodType, )
 
 
 def _verify(iface, candidate, tentative=False, vtype=None):
-    """Verify that *candidate* might correctly implement *iface*.
+    """
+    Verify that *candidate* might correctly provide *iface*.
 
     This involves:
 
-      - Making sure the candidate defines all the necessary methods
+    - Making sure the candidate claims that it provides the
+      interface using ``iface.providedBy`` (unless *tentative* is `True`,
+      in which case this step is skipped). This means that the candidate's class
+      declares that it `implements <zope.interface.implementer>` the interface,
+      or the candidate itself declares that it `provides <zope.interface.provider>`
+      the interface
 
-      - Making sure the methods have the correct signature
+    - Making sure the candidate defines all the necessary methods
 
-      - Making sure the candidate asserts that it implements the interface
+    - Making sure the methods have the correct signature (to the
+      extent possible)
 
-    Note that this isn't the same as verifying that the class does
-    implement the interface.
+    - Making sure the candidate defines all the necessary attributes
 
-    If  *tentative* is true (not the default), suppress the "is implemented by" test.
+    :raises zope.interface.Invalid: If any of the previous
+       conditions does not hold.
     """
 
     if vtype == 'c':
@@ -126,11 +133,15 @@ def _verify(iface, candidate, tentative=False, vtype=None):
     return True
 
 def verifyClass(iface, candidate, tentative=False):
+    """
+    Verify that the *candidate* might correctly provide *iface*.
+    """
     return _verify(iface, candidate, tentative, vtype='c')
 
 def verifyObject(iface, candidate, tentative=False):
     return _verify(iface, candidate, tentative, vtype='o')
 
+verifyObject.__doc__ = _verify.__doc__
 
 _MSG_TOO_MANY = 'implementation requires too many arguments'
 _KNOWN_PYPY2_FALSE_POSITIVES = frozenset((


### PR DESCRIPTION
Eliminate the trailing newlines and blank spaces (the code called them "a stupid artifact").

Include the name of the defining interface (so the user can easily look up any requirements on the attribute) and, for methods, the expected signature (no more guessing about how many arguments are required!).

This is implemented by giving Attribute and Method useful reprs and strs. Previously, they just had the defaults.

Fixes #170