### PR TITLE
Add more common interfaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,24 @@
   Like the above, this will break consumers depending on the exact
   output of error messages if more than one error is present.
 
+- Add ``zope.interface.common.collections``,
+  ``zope.interface.common.numbers``, and ``zope.interface.common.io``.
+  These modules define interfaces based on the ABCs defined in the
+  standard library ``collections.abc``, ``numbers`` and ``io``
+  modules, respectively. Importing these modules will make the
+  standard library concrete classes that are registered with those
+  ABCs declare the appropriate interface. See `issue 138
+  <https://github.com/zopefoundation/zope.interface/issues/138>`_.
+
+- Add ``zope.interface.common.builtins``. This module defines
+  interfaces of common builtin types, such as ``ITextString`` and
+  ``IByteString``, ``IDict``, etc. These interfaces extend the
+  appropriate interfaces from ``collections`` and ``numbers``, and the
+  standard library classes implement them after importing this module.
+  This is intended as a replacement for third-party packages like
+  `dolmen.builtins <https://pypi.org/project/dolmen.builtins/>`_.
+  See `issue 138 <https://github.com/zopefoundation/zope.interface/issues/138>`_.
+
 
 4.7.1 (2019-11-11)
 ==================

--- a/docs/api/common.rst
+++ b/docs/api/common.rst
@@ -36,3 +36,13 @@ zope.interface.common.numbers
 =============================
 
 .. automodule:: zope.interface.common.numbers
+
+zope.interface.common.builtins
+==============================
+
+.. automodule:: zope.interface.common.builtins
+
+zope.interface.common.io
+========================
+
+.. automodule:: zope.interface.common.io

--- a/docs/api/common.rst
+++ b/docs/api/common.rst
@@ -26,3 +26,8 @@ implement the correct interface.
 ==================================
 
 .. automodule:: zope.interface.common.sequence
+
+zope.interface.common.collections
+=================================
+
+.. automodule:: zope.interface.common.collections

--- a/docs/api/common.rst
+++ b/docs/api/common.rst
@@ -31,3 +31,8 @@ zope.interface.common.collections
 =================================
 
 .. automodule:: zope.interface.common.collections
+
+zope.interface.common.numbers
+=============================
+
+.. automodule:: zope.interface.common.numbers

--- a/docs/api/common.rst
+++ b/docs/api/common.rst
@@ -4,28 +4,18 @@
 
 The ``zope.interface.common`` package provides interfaces for objects
 distributed as part of the Python standard library. Importing these
-modules has the effect of making the standard library objects
+modules (usually) has the effect of making the standard library objects
 implement the correct interface.
 
-``zope.interface.common.interfaces``
-====================================
+zope.interface.common.interface
+===============================
 
 .. automodule:: zope.interface.common.interfaces
 
-``zope.interface.common.idatetime``
-===================================
+zope.interface.common.idatetime
+===============================
 
 .. automodule:: zope.interface.common.idatetime
-
-``zope.interface.common.mapping``
-=================================
-
-.. automodule:: zope.interface.common.mapping
-
-``zope.interface.common.sequence``
-==================================
-
-.. automodule:: zope.interface.common.sequence
 
 zope.interface.common.collections
 =================================
@@ -46,3 +36,15 @@ zope.interface.common.io
 ========================
 
 .. automodule:: zope.interface.common.io
+
+.. Deprecated or discouraged modules below this
+
+zope.interface.common.mapping
+=============================
+
+.. automodule:: zope.interface.common.mapping
+
+zope.interface.common.sequence
+==============================
+
+.. automodule:: zope.interface.common.sequence

--- a/src/zope/interface/common/__init__.py
+++ b/src/zope/interface/common/__init__.py
@@ -1,4 +1,15 @@
-from weakref import WeakKeyDictionary
+##############################################################################
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+##############################################################################
+
 from types import FunctionType
 
 from zope.interface import classImplements
@@ -10,22 +21,6 @@ from zope.interface.interface import _decorator_non_return
 __all__ = [
     # Nothing public here.
 ]
-
-# Map of standard library class to its primary
-# interface. We assume there's a simple linearization
-# so that each standard library class can be represented
-# by a single interface.
-# TODO: Maybe store this in the individual interfaces? We're
-# only really keeping this around for test purposes.
-stdlib_class_registry = WeakKeyDictionary()
-
-def stdlib_classImplements(cls, iface):
-    # Execute ``classImplements(cls, iface)`` and record
-    # that in the registry for validation by tests.
-    if cls in stdlib_class_registry:
-        raise KeyError(cls)
-    stdlib_class_registry[cls] = iface
-    classImplements(cls, iface)
 
 
 # pylint:disable=inherit-non-class,
@@ -40,6 +35,70 @@ def optional(meth):
 
 
 class ABCInterfaceClass(InterfaceClass):
+    """
+    An interface that is automatically derived from a
+    :class:`abc.ABCMeta` type.
+
+    Internal use only.
+
+    When created, any existing classes that are registered to conform
+    to the ABC are declared to implement this interface. This is *not*
+    automatically updated as the ABC registry changes.
+
+    Note that this is not fully symmetric. For example, it is usually
+    the case that a subclass relationship carries the interface
+    declarations over::
+
+        >>> from zope.interface import Interface
+        >>> class I1(Interface):
+        ...     pass
+        ...
+        >>> from zope.interface import implementer
+        >>> @implementer(I1)
+        ... class Root(object):
+        ...     pass
+        ...
+        >>> class Child(Root):
+        ...     pass
+        ...
+        >>> child = Child()
+        >>> isinstance(child, Root)
+        True
+        >>> from zope.interface import providedBy
+        >>> list(providedBy(child))
+        [<InterfaceClass __main__.I1>]
+
+    However, that's not the case with ABCs and ABC interfaces. Just
+    because ``isinstance(A(), AnABC)`` and ``isinstance(B(), AnABC)``
+    are both true, that doesn't mean there's any class hierarchy
+    relationship between ``A`` and ``B``, or between either of them
+    and ``AnABC``. Thus, if ``AnABC`` implemented ``IAnABC``, it would
+    not follow that either ``A`` or ``B`` implements ``IAnABC`` (nor
+    their instances provide it)::
+
+        >>> class SizedClass(object):
+        ...     def __len__(self): return 1
+        ...
+        >>> from collections.abc import Sized
+        >>> isinstance(SizedClass(), Sized)
+        True
+        >>> from zope.interface import classImplements
+        >>> classImplements(Sized, I1)
+        None
+        >>> list(providedBy(SizedClass()))
+        []
+
+    Thus, to avoid conflicting assumptions, ABCs should not be
+    declared to implement their parallel ABC interface. Only concrete
+    classes specifically registered with the ABC should be declared to
+    do so.
+
+    .. verisonadded:: 5.0
+    """
+
+    # If we could figure out invalidation, and used some special
+    # Specification/Declaration instances, and override the method ``providedBy`` here,
+    # perhaps we could more closely integrate with ABC virtual inheritance?
 
     def __init__(self, name, bases, attrs):
         # go ahead and give us a name to ease debugging.
@@ -100,26 +159,35 @@ class ABCInterfaceClass(InterfaceClass):
     def __register_classes(self):
         # Make the concrete classes already present in our ABC's registry
         # declare that they implement this interface.
+
+        for cls in self.getRegisteredConformers():
+            classImplements(cls, self)
+
+    def getABC(self):
+        """
+        Return the ABC this interface represents.
+        """
+        return self.__abc
+
+    def getRegisteredConformers(self):
+        """
+        Return an iterable of the classes that are directly
+        registered to conform to the ABC this interface
+        parallels.
+        """
         based_on = self.__abc
-        if based_on is None:
-            return
 
         try:
             registered = list(based_on._abc_registry)
         except AttributeError:
-            # Rewritten in C in Python 3.?.
+            # Rewritten in C in CPython 3.7.
             # These expose the underlying weakref.
             from abc import _get_dump
             registry = _get_dump(based_on)[0]
             registered = [x() for x in registry]
             registered = [x for x in registered if x is not None]
 
-        for cls in registered:
-            stdlib_classImplements(cls, self)
-
-    def getABC(self):
-        """Return the ABC this interface represents."""
-        return self.__abc
+        return registered
 
 
 ABCInterface = ABCInterfaceClass.__new__(ABCInterfaceClass, None, None, None)

--- a/src/zope/interface/common/__init__.py
+++ b/src/zope/interface/common/__init__.py
@@ -1,2 +1,126 @@
-#
-# This file is necessary to make this directory a package.
+from weakref import WeakKeyDictionary
+from types import FunctionType
+
+from zope.interface import classImplements
+from zope.interface import Interface
+from zope.interface.interface import fromFunction
+from zope.interface.interface import InterfaceClass
+from zope.interface.interface import _decorator_non_return
+
+__all__ = [
+    # Nothing public here.
+]
+
+# Map of standard library class to its primary
+# interface. We assume there's a simple linearization
+# so that each standard library class can be represented
+# by a single interface.
+# TODO: Maybe store this in the individual interfaces? We're
+# only really keeping this around for test purposes.
+stdlib_class_registry = WeakKeyDictionary()
+
+def stdlib_classImplements(cls, iface):
+    # Execute ``classImplements(cls, iface)`` and record
+    # that in the registry for validation by tests.
+    if cls in stdlib_class_registry:
+        raise KeyError(cls)
+    stdlib_class_registry[cls] = iface
+    classImplements(cls, iface)
+
+
+# pylint:disable=inherit-non-class,
+# pylint:disable=no-self-argument,no-method-argument
+# pylint:disable=unexpected-special-method-signature
+
+def optional(meth):
+    # Apply this decorator to a method definition to make it
+    # optional (remove it from the list of required names), overriding
+    # the definition inherited from the ABC.
+    return _decorator_non_return
+
+
+class ABCInterfaceClass(InterfaceClass):
+
+    def __init__(self, name, bases, attrs):
+        # go ahead and give us a name to ease debugging.
+        self.__name__ = name
+
+        based_on = attrs.pop('abc')
+        if based_on is None:
+            # An ABC from the future, not available to us.
+            methods = {
+                '__doc__': 'This ABC is not available.'
+            }
+        else:
+            assert name[1:] == based_on.__name__, (name, based_on)
+            methods = {
+                # Passing the name is important in case of aliases,
+                # e.g., ``__ror__ = __or__``.
+                k: self.__method_from_function(v, k)
+                for k, v in vars(based_on).items()
+                if isinstance(v, FunctionType) and not self.__is_private_name(k)
+                and not self.__is_reverse_protocol_name(k)
+            }
+            methods['__doc__'] = "See `%s.%s`" % (
+                based_on.__module__,
+                based_on.__name__,
+            )
+        # Anything specified in the body takes precedence.
+        # This lets us remove things that are rarely, if ever,
+        # actually implemented. For example, ``tuple`` is registered
+        # as an Sequence, but doesn't implement the required ``__reversed__``
+        # method, but that's OK, it still works with the ``reversed()`` builtin
+        # because it has ``__len__`` and ``__getitem__``.
+        methods.update(attrs)
+        InterfaceClass.__init__(self, name, bases, methods)
+        self.__abc = based_on
+        self.__register_classes()
+
+    @staticmethod
+    def __is_private_name(name):
+        if name.startswith('__') and name.endswith('__'):
+            return False
+        return name.startswith('_')
+
+    @staticmethod
+    def __is_reverse_protocol_name(name):
+        # The reverse names, like __rand__,
+        # aren't really part of the protocol. The interpreter has
+        # very complex behaviour around invoking those. PyPy
+        # doesn't always even expose them as attributes.
+        return name.startswith('__r') and name.endswith('__')
+
+    def __method_from_function(self, function, name):
+        method = fromFunction(function, self, name=name)
+        # Eliminate the leading *self*, which is implied in
+        # an interface, but explicit in an ABC.
+        method.positional = method.positional[1:]
+        return method
+
+    def __register_classes(self):
+        # Make the concrete classes already present in our ABC's registry
+        # declare that they implement this interface.
+        based_on = self.__abc
+        if based_on is None:
+            return
+
+        try:
+            registered = list(based_on._abc_registry)
+        except AttributeError:
+            # Rewritten in C in Python 3.?.
+            # These expose the underlying weakref.
+            from abc import _get_dump
+            registry = _get_dump(based_on)[0]
+            registered = [x() for x in registry]
+            registered = [x for x in registered if x is not None]
+
+        for cls in registered:
+            stdlib_classImplements(cls, self)
+
+    def getABC(self):
+        """Return the ABC this interface represents."""
+        return self.__abc
+
+
+ABCInterface = ABCInterfaceClass.__new__(ABCInterfaceClass, None, None, None)
+InterfaceClass.__init__(ABCInterface, 'ABCInterface', (Interface,), {})

--- a/src/zope/interface/common/__init__.py
+++ b/src/zope/interface/common/__init__.py
@@ -110,7 +110,7 @@ class ABCInterfaceClass(InterfaceClass):
     classes specifically registered with the ABC should be declared to
     do so.
 
-    .. verisonadded:: 5.0
+    .. versionadded:: 5.0.0
     """
 
     # If we could figure out invalidation, and used some special

--- a/src/zope/interface/common/builtins.py
+++ b/src/zope/interface/common/builtins.py
@@ -36,11 +36,20 @@ __all__ = [
     'IFile',
 ]
 
+# pylint:disable=no-self-argument
+
 class IList(collections.IMutableSequence):
     """
     Interface for :class:`list`
     """
     extra_classes = (list,)
+
+    def sort(key=None, reverse=False):
+        """
+        Sort the list in place and return None.
+
+        *key* and *reverse* must be passed by name only.
+        """
 
 
 class ITuple(collections.ISequence):

--- a/src/zope/interface/common/builtins.py
+++ b/src/zope/interface/common/builtins.py
@@ -1,0 +1,117 @@
+##############################################################################
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+##############################################################################
+"""
+Interface definitions for builtin types.
+
+After this module is imported, the standard library types will declare
+that they implement the appropriate interface.
+
+.. versionadded:: 5.0.0
+"""
+from __future__ import absolute_import
+
+from zope.interface import classImplements
+
+from zope.interface.common import collections
+from zope.interface.common import numbers
+from zope.interface.common import io
+
+__all__ = [
+    'IList',
+    'ITuple',
+    'ITextString',
+    'IByteString',
+    'INativeString',
+    'IBool',
+    'IDict',
+    'IFile',
+]
+
+class IList(collections.IMutableSequence):
+    """
+    Interface for :class:`list`
+    """
+    extra_classes = (list,)
+
+
+class ITuple(collections.ISequence):
+    """
+    Interface for :class:`tuple`
+    """
+    extra_classes = (tuple,)
+
+
+class ITextString(collections.ISequence):
+    """
+    Interface for text (unicode) strings.
+
+    On Python 2, this is :class:`unicode`. On Python 3,
+    this is :class:`str`
+    """
+    extra_classes = (type(u'unicode'),)
+
+
+class IByteString(collections.IByteString):
+    """
+    Interface for immutable byte strings.
+
+    On all Python versions this is :class:`bytes`.
+
+    Unlike :class:`zope.interface.common.collections.IByteString`
+    (the parent of this interface) this does *not* include
+    :class:`bytearray`.
+    """
+    extra_classes = (bytes,)
+
+
+class INativeString(IByteString if str is bytes else ITextString):
+    """
+    Interface for native strings.
+
+    On all Python versions, this is :class:`str`. On Python 2,
+    this extends :class:`IByteString`, while on Python 3 it extends
+    :class:`ITextString`.
+    """
+# We're not extending ABCInterface so extra_classes won't work
+classImplements(str, INativeString)
+
+
+class IBool(numbers.IIntegral):
+    """
+    Interface for :class:`bool`
+    """
+    extra_classes = (bool,)
+
+
+class IDict(collections.IMutableMapping):
+    """
+    Interface for :class:`dict`
+    """
+    extra_classes = (dict,)
+
+
+class IFile(io.IIOBase):
+    """
+    Interface for :class:`file`.
+
+    It is recommended to use the interfaces from :mod:`zope.interface.common.io`
+    instead of this interface.
+
+    On Python 3, there is no single implementation of this interface;
+    depending on the arguments, the :func:`open` builtin can return
+    many different classes that implement different interfaces from
+    :mod:`zope.interface.common.io`.
+    """
+    try:
+        extra_classes = (file,)
+    except NameError:
+        extra_classes = ()

--- a/src/zope/interface/common/collections.py
+++ b/src/zope/interface/common/collections.py
@@ -124,7 +124,7 @@ class IContainer(ABCInterface):
     def __contains__(other):
         """
         Optional method. If not provided, the interpreter will use
-        ``__iter__`` or the old ``__len__`` and ``__getitem__`` protocol
+        ``__iter__`` or the old ``__getitem__`` protocol
         to implement ``in``.
         """
 
@@ -133,6 +133,13 @@ class IHashable(ABCInterface):
 
 class IIterable(ABCInterface):
     abc = abc.Iterable
+
+    @optional
+    def __iter__():
+        """
+        Optional method. If not provided, the interpreter will
+        implement `iter` using the old ``__getitem__`` protocol.
+        """
 
 class IIterator(IIterable):
     abc = abc.Iterator
@@ -145,7 +152,7 @@ class IReversible(IIterable):
         """
         Optional method. If this isn't present, the interpreter
         will use ``__len__`` and ``__getitem__`` to implement the
-        `reversed` builtin.`
+        `reversed` builtin.
         """
 
 class IGenerator(IIterator):
@@ -176,9 +183,15 @@ class ISequence(IReversible,
         """
         Optional method. If this isn't present, the interpreter
         will use ``__len__`` and ``__getitem__`` to implement the
-        `reversed` builtin.`
+        `reversed` builtin.
         """
 
+    @optional
+    def __iter__():
+        """
+        Optional method. If not provided, the interpreter will
+        implement `iter` using the old ``__getitem__`` protocol.
+        """
 
 class IMutableSequence(ISequence):
     abc = abc.MutableSequence

--- a/src/zope/interface/common/collections.py
+++ b/src/zope/interface/common/collections.py
@@ -139,7 +139,6 @@ class ISized(ABCInterface):
 
 # ICallable is not defined because there's no standard signature.
 
-
 class ICollection(ISized,
                   IIterable,
                   IContainer):

--- a/src/zope/interface/common/collections.py
+++ b/src/zope/interface/common/collections.py
@@ -1,0 +1,211 @@
+##############################################################################
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+##############################################################################
+"""
+Interface definitions paralleling the abstract base classes defined in
+:mod:`collections.abc`.
+
+After this module is imported, the standard library types will declare
+that they implement the appropriate interface. While most standard
+library types will properly implement that interface (that
+is, ``verifyObject(ISequence, list()))`` will pass, for example), a few might not:
+
+    - `memoryview` doesn't feature all the defined methods of
+      ``ISequence`` such as ``count``; it is still declared to provide
+      ``ISequence`` though.
+
+    - `collections.deque.pop` doesn't accept the ``index`` argument of
+      `collections.abc.MutableSequence.pop`
+
+    - `range.index` does not accept the ``start`` and ``stop`` arguments.
+
+.. versionadded:: 5.0.0
+"""
+from __future__ import absolute_import
+
+import sys
+
+try:
+    from collections import abc
+except ImportError:
+    import collections as abc
+
+from zope.interface._compat import PYTHON2 as PY2
+from zope.interface.common import ABCInterface
+from zope.interface.common import optional
+
+# pylint:disable=inherit-non-class,
+# pylint:disable=no-self-argument,no-method-argument
+# pylint:disable=unexpected-special-method-signature
+
+PY35 = sys.version_info[:2] >= (3, 5)
+PY36 = sys.version_info[:2] >= (3, 6)
+
+def _new_in_ver(name, ver):
+    return getattr(abc, name) if ver else None
+
+__all__ = [
+    'IAsyncGenerator',
+    'IAsyncIterable',
+    'IAsyncIterator',
+    'IAwaitable',
+    'ICollection',
+    'IContainer',
+    'ICoroutine',
+    'IGenerator',
+    'IHashable',
+    'IItemsView',
+    'IIterable',
+    'IIterator',
+    'IKeysView',
+    'IMapping',
+    'IMappingView',
+    'IMutableMapping',
+    'IMutableSequence',
+    'IMutableSet',
+    'IReversible',
+    'ISequence',
+    'ISet',
+    'ISized',
+    'IValuesView',
+]
+
+class IContainer(ABCInterface):
+    abc = abc.Container
+
+    @optional
+    def __contains__(other):
+        """
+        Optional method. If not provided, the interpreter will use
+        ``__iter__`` or the old ``__len__`` and ``__getitem__`` protocol
+        to implement ``in``.
+        """
+
+class IHashable(ABCInterface):
+    abc = abc.Hashable
+
+class IIterable(ABCInterface):
+    abc = abc.Iterable
+
+class IIterator(IIterable):
+    abc = abc.Iterator
+
+class IReversible(IIterable):
+    abc = _new_in_ver('Reversible', PY36)
+
+    @optional
+    def __reversed__():
+        """
+        Optional method. If this isn't present, the interpreter
+        will use ``__len__`` and ``__getitem__`` to implement the
+        `reversed` builtin.`
+        """
+
+class IGenerator(IIterator):
+    # New in 3.5
+    abc = _new_in_ver('Generator', PY35)
+
+
+class ISized(ABCInterface):
+    abc = abc.Sized
+
+
+# ICallable is not defined because there's no standard signature.
+
+
+class ICollection(ISized,
+                  IIterable,
+                  IContainer):
+    abc = _new_in_ver('Collection', PY36)
+
+
+class ISequence(IReversible,
+                ICollection):
+    abc = abc.Sequence
+
+    @optional
+    def __reversed__():
+        """
+        Optional method. If this isn't present, the interpreter
+        will use ``__len__`` and ``__getitem__`` to implement the
+        `reversed` builtin.`
+        """
+
+
+class IMutableSequence(ISequence):
+    abc = abc.MutableSequence
+
+
+class ISet(ICollection):
+    abc = abc.Set
+
+
+class IMutableSet(ISet):
+    abc = abc.MutableSet
+
+
+class IMapping(ICollection):
+    abc = abc.Mapping
+
+    if PY2:
+        @optional
+        def __eq__(other):
+            """
+            The interpreter will supply one.
+            """
+
+        __ne__ = __eq__
+
+class IMutableMapping(IMapping):
+    abc = abc.MutableMapping
+
+
+class IMappingView(ISized):
+    abc = abc.MappingView
+
+
+class IItemsView(IMappingView, ISet):
+    abc = abc.ItemsView
+
+
+class IKeysView(IMappingView, ISet):
+    abc = abc.KeysView
+
+
+class IValuesView(IMappingView, ICollection):
+    abc = abc.ValuesView
+
+    @optional
+    def __contains__(other):
+        """
+        Optional method. If not provided, the interpreter will use
+        ``__iter__`` or the old ``__len__`` and ``__getitem__`` protocol
+        to implement ``in``.
+        """
+
+class IAwaitable(ABCInterface):
+    abc = _new_in_ver('Awaitable', PY35)
+
+
+class ICoroutine(IAwaitable):
+    abc = _new_in_ver('Coroutine', PY35)
+
+
+class IAsyncIterable(ABCInterface):
+    abc = _new_in_ver('AsyncIterable', PY35)
+
+
+class IAsyncIterator(IAsyncIterable):
+    abc = _new_in_ver('AsyncIterator', PY35)
+
+
+class IAsyncGenerator(IAsyncIterator):
+    abc = _new_in_ver('AsyncGenerator', PY36)

--- a/src/zope/interface/common/collections.py
+++ b/src/zope/interface/common/collections.py
@@ -34,10 +34,30 @@ from __future__ import absolute_import
 import sys
 
 from abc import ABCMeta
+# The collections imports are here, and not in
+# zope.interface._compat to avoid importing collections
+# unless requested. It's a big import.
 try:
     from collections import abc
 except ImportError:
     import collections as abc
+
+try:
+    # On Python 3, all of these extend the appropriate collection ABC,
+    # but on Python 2, UserDict does not (though it is registered as a
+    # MutableMapping). (Importantly, UserDict on Python 2 is *not*
+    # registered, because it's not iterable.) Extending the ABC is not
+    # taken into account for interface declarations, though, so we
+    # need to be explicit about it.
+    from collections import UserList
+    from collections import UserDict
+    from collections import UserString
+except ImportError:
+    # Python 2
+    from UserList import UserList
+    from UserDict import IterableUserDict as UserDict
+    from UserString import UserString
+
 
 from zope.interface._compat import PYTHON2 as PY2
 from zope.interface._compat import PYTHON3 as PY3
@@ -149,6 +169,7 @@ class ICollection(ISized,
 class ISequence(IReversible,
                 ICollection):
     abc = abc.Sequence
+    extra_classes = (UserString,)
 
     @optional
     def __reversed__():
@@ -161,6 +182,7 @@ class ISequence(IReversible,
 
 class IMutableSequence(ISequence):
     abc = abc.MutableSequence
+    extra_classes = (UserList,)
 
 
 class IByteString(ISequence):
@@ -192,8 +214,10 @@ class IMapping(ICollection):
 
         __ne__ = __eq__
 
+
 class IMutableMapping(IMapping):
     abc = abc.MutableMapping
+    extra_classes = (UserDict,)
 
 
 class IMappingView(ISized):

--- a/src/zope/interface/common/io.py
+++ b/src/zope/interface/common/io.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+##############################################################################
+"""
+Interface definitions paralleling the abstract base classes defined in
+:mod:`io`.
+
+After this module is imported, the standard library types will declare
+that they implement the appropriate interface.
+
+.. versionadded:: 5.0.0
+"""
+from __future__ import absolute_import
+
+import io as abc
+try:
+    import cStringIO
+    import StringIO
+except ImportError:
+    # Python 3
+    extra_buffered_io_base = ()
+else:
+    extra_buffered_io_base = (StringIO.StringIO, cStringIO.InputType, cStringIO.OutputType)
+
+from zope.interface.common import ABCInterface
+
+# pylint:disable=inherit-non-class,
+# pylint:disable=no-member
+
+class IIOBase(ABCInterface):
+    abc = abc.IOBase
+
+
+class IRawIOBase(IIOBase):
+    abc = abc.RawIOBase
+
+
+class IBufferedIOBase(IIOBase):
+    abc = abc.BufferedIOBase
+    extra_classes = extra_buffered_io_base
+
+
+class ITextIOBase(IIOBase):
+    abc = abc.TextIOBase

--- a/src/zope/interface/common/io.py
+++ b/src/zope/interface/common/io.py
@@ -21,14 +21,6 @@ that they implement the appropriate interface.
 from __future__ import absolute_import
 
 import io as abc
-try:
-    import cStringIO
-    import StringIO
-except ImportError:
-    # Python 3
-    extra_buffered_io_base = ()
-else:
-    extra_buffered_io_base = (StringIO.StringIO, cStringIO.InputType, cStringIO.OutputType)
 
 from zope.interface.common import ABCInterface
 
@@ -45,7 +37,16 @@ class IRawIOBase(IIOBase):
 
 class IBufferedIOBase(IIOBase):
     abc = abc.BufferedIOBase
-    extra_classes = extra_buffered_io_base
+    try:
+        import cStringIO
+    except ImportError:
+        # Python 3
+        extra_classes = ()
+    else:
+        import StringIO
+        extra_classes = (StringIO.StringIO, cStringIO.InputType, cStringIO.OutputType)
+        del cStringIO
+        del StringIO
 
 
 class ITextIOBase(IIOBase):

--- a/src/zope/interface/common/mapping.py
+++ b/src/zope/interface/common/mapping.py
@@ -11,13 +11,26 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""Mapping Interfaces.
+"""
+Mapping Interfaces.
 
-Importing this module does *not* mark any standard classes
-as implementing any of these interfaces.
+Importing this module does *not* mark any standard classes as
+implementing any of these interfaces.
+
+While this module is not deprecated, new code should generally use
+:mod:`zope.interface.common.collections`, specifically
+:class:`~zope.interface.common.collections.IMapping` and
+:class:`~zope.interface.common.collections.IMutableMapping`. This
+module is occasionally useful for its extremely fine grained breakdown
+of interfaces.
+
+The standard library :class:`dict` and :class:`collections.UserDict`
+implement ``IMutableMapping``, but *do not* implement any of the
+interfaces in this module.
 """
 from zope.interface import Interface
 from zope.interface._compat import PYTHON2 as PY2
+from zope.interface.common import collections
 
 class IItemMapping(Interface):
     """Simplest readable mapping object
@@ -30,8 +43,12 @@ class IItemMapping(Interface):
         """
 
 
-class IReadMapping(IItemMapping):
-    """Basic mapping interface
+class IReadMapping(IItemMapping, collections.IContainer):
+    """
+    Basic mapping interface.
+
+    .. versionchanged:: 5.0.0
+       Extend ``IContainer``
     """
 
     def get(key, default=None):
@@ -42,6 +59,7 @@ class IReadMapping(IItemMapping):
 
     def __contains__(key):
         """Tell if a key exists in the mapping."""
+        # Optional in IContainer, required by this interface.
 
 
 class IWriteMapping(Interface):
@@ -54,8 +72,12 @@ class IWriteMapping(Interface):
         """Set a new item in the mapping."""
 
 
-class IEnumerableMapping(IReadMapping):
-    """Mapping objects whose items can be enumerated.
+class IEnumerableMapping(IReadMapping, collections.ISized):
+    """
+    Mapping objects whose items can be enumerated.
+
+    .. versionchanged:: 5.0.0
+       Extend ``ISized``
     """
 
     def keys():
@@ -72,10 +94,6 @@ class IEnumerableMapping(IReadMapping):
 
     def items():
         """Return the items of the mapping object.
-        """
-
-    def __len__():
-        """Return the number of items.
         """
 
 class IMapping(IWriteMapping, IEnumerableMapping):
@@ -152,6 +170,15 @@ class IExtendedWriteMapping(IWriteMapping):
         2-tuple; but raise KeyError if mapping is empty"""
 
 class IFullMapping(
-    IExtendedReadMapping, IExtendedWriteMapping, IClonableMapping, IMapping):
-    ''' Full mapping interface ''' # IMapping included so tests for IMapping
-    # succeed with IFullMapping
+        collections.IMutableMapping,
+        IExtendedReadMapping, IExtendedWriteMapping, IClonableMapping, IMapping):
+    """
+    Full mapping interface.
+
+    Most uses of this interface should instead use
+    :class:`~zope.interface.commons.collections.IMutableMapping` (one of the
+    bases of this interface). The required methods are the same.
+
+    .. versionchanged:: 5.0.0
+       Extend ``IMutableMapping``
+    """

--- a/src/zope/interface/common/numbers.py
+++ b/src/zope/interface/common/numbers.py
@@ -1,0 +1,83 @@
+##############################################################################
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+##############################################################################
+"""
+Interface definitions paralleling the abstract base classes defined in
+:mod:`numbers`.
+
+After this module is imported, the standard library types will declare
+that they implement the appropriate interface.
+
+.. versionadded:: 5.0.0
+"""
+from __future__ import absolute_import
+
+import numbers as abc
+
+from zope.interface.common import ABCInterface
+from zope.interface.common import optional
+
+from zope.interface._compat import PYTHON2 as PY2
+
+# pylint:disable=inherit-non-class,
+# pylint:disable=no-self-argument,no-method-argument
+# pylint:disable=unexpected-special-method-signature
+# pylint:disable=no-value-for-parameter
+
+
+class INumber(ABCInterface):
+    abc = abc.Number
+
+
+class IComplex(INumber):
+    abc = abc.Complex
+
+    @optional
+    def __complex__():
+        """
+        Rarely implemented, even in builtin types.
+        """
+    if PY2:
+        @optional
+        def __eq__(other):
+            """
+            The interpreter may supply one through complicated rules.
+            """
+
+        __ne__ = __eq__
+
+class IReal(IComplex):
+    abc = abc.Real
+
+    @optional
+    def __complex__():
+        """
+        Rarely implemented, even in builtin types.
+        """
+
+    __floor__ = __ceil__ = __complex__
+
+    if PY2:
+        @optional
+        def __le__(other):
+            """
+            The interpreter may supply one through complicated rules.
+            """
+
+        __lt__ = __le__
+
+
+class IRational(IReal):
+    abc = abc.Rational
+
+
+class IIntegral(IRational):
+    abc = abc.Integral

--- a/src/zope/interface/common/numbers.py
+++ b/src/zope/interface/common/numbers.py
@@ -45,6 +45,7 @@ class IComplex(INumber):
         """
         Rarely implemented, even in builtin types.
         """
+
     if PY2:
         @optional
         def __eq__(other):

--- a/src/zope/interface/common/sequence.py
+++ b/src/zope/interface/common/sequence.py
@@ -11,17 +11,30 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""Sequence Interfaces
+"""
+Sequence Interfaces
 
-Importing this module does *not* mark any standard classes
-as implementing any of these interfaces.
+Importing this module does *not* mark any standard classes as
+implementing any of these interfaces.
+
+While this module is not deprecated, new code should generally use
+:mod:`zope.interface.common.collections`, specifically
+:class:`~zope.interface.common.collections.ISequence` and
+:class:`~zope.interface.common.collections.IMutableSequence`. This
+module is occasionally useful for its fine-grained breakdown of interfaces.
+
+The standard library :class:`list`, :class:`tuple` and
+:class:`collections.UserList`, among others, implement ``ISequence``
+or ``IMutableSequence`` but *do not* implement any of the interfaces
+in this module.
 """
 
 __docformat__ = 'restructuredtext'
 from zope.interface import Interface
+from zope.interface.common import collections
 from zope.interface._compat import PYTHON2 as PY2
 
-class IMinimalSequence(Interface):
+class IMinimalSequence(collections.IIterable):
     """Most basic sequence interface.
 
     All sequences are iterable.  This requires at least one of the
@@ -42,16 +55,30 @@ class IMinimalSequence(Interface):
         Declaring this interface does not specify whether `__getitem__`
         supports slice objects."""
 
-class IFiniteSequence(IMinimalSequence):
+class IFiniteSequence(collections.ISized, IMinimalSequence):
+    """
+    A sequence of bound size.
 
-    def __len__():
-        """``x.__len__() <==> len(x)``"""
+    .. versionchanged:: 5.0.0
+       Extend ``ISized``
+    """
 
-class IReadSequence(IFiniteSequence):
-    """read interface shared by tuple and list"""
+class IReadSequence(collections.IContainer, IFiniteSequence):
+    """
+    read interface shared by tuple and list
+
+    This interface is similar to
+    :class:`~zope.interface.common.collections.ISequence`, but
+    requires that all instances be totally ordered. Most users
+    should prefer ``ISequence``.
+
+    .. versionchanged:: 5.0.0
+       Extend ``IContainer``
+    """
 
     def __contains__(item):
         """``x.__contains__(item) <==> item in x``"""
+        # Optional in IContainer, required here.
 
     def __lt__(other):
         """``x.__lt__(other) <==> x < other``"""
@@ -166,4 +193,23 @@ class IWriteSequence(IUniqueMemberWriteSequence):
         """``x.__imul__(n) <==> x *= n``"""
 
 class ISequence(IReadSequence, IWriteSequence):
-    """Full sequence contract"""
+    """
+    Full sequence contract.
+
+    New code should prefer
+    :class:`~zope.interface.common.collections.IMutableSequence`.
+
+    Compared to that interface, which is implemented by :class:`list`
+    (:class:`~zope.interface.common.builtins.IList`), among others,
+    this interface is missing the following methods:
+
+        - clear
+
+        - count
+
+        - index
+
+    This interface adds the following methods:
+
+        - sort
+    """

--- a/src/zope/interface/common/tests/__init__.py
+++ b/src/zope/interface/common/tests/__init__.py
@@ -1,2 +1,58 @@
+##############################################################################
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
 #
-# This file is necessary to make this directory a package.
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+##############################################################################
+
+
+from zope.interface.common import ABCInterface
+from zope.interface.common import ABCInterfaceClass
+
+
+def iter_abc_interfaces(predicate=lambda iface: True):
+    # Iterate ``(iface, classes)``, where ``iface`` is a descendent of
+    # the ABCInterfaceClass passing the *predicate* and ``classes`` is
+    # an iterable of classes registered to conform to that interface.
+    #
+    # Note that some builtin classes are registered for two distinct
+    # parts of the ABC/interface tree. For example, bytearray is both ByteString
+    # and MutableSequence.
+    seen = set()
+    stack = list(ABCInterface.dependents) # subclasses, but also implementedBy objects
+    while stack:
+        iface = stack.pop(0)
+        if iface in seen or not isinstance(iface, ABCInterfaceClass):
+            continue
+        seen.add(iface)
+        stack.extend(list(iface.dependents))
+        if not predicate(iface):
+            continue
+
+        registered = list(iface.getRegisteredConformers())
+        if registered:
+            yield iface, registered
+
+
+def add_abc_interface_tests(cls, module):
+    def predicate(iface):
+        return iface.__module__ == module
+
+    for iface, registered_classes in iter_abc_interfaces(predicate):
+        for stdlib_class in registered_classes:
+
+            def test(self, stdlib_class=stdlib_class, iface=iface):
+                if stdlib_class in self.UNVERIFIABLE or stdlib_class.__name__ in self.UNVERIFIABLE:
+                    self.skipTest("Unable to verify %s" % stdlib_class)
+
+                self.assertTrue(self.verify(iface, stdlib_class))
+
+            name = 'test_auto_' + stdlib_class.__name__ + '_' + iface.__name__
+            test.__name__ = name
+            assert not hasattr(cls, name)
+            setattr(cls, name, test)

--- a/src/zope/interface/common/tests/__init__.py
+++ b/src/zope/interface/common/tests/__init__.py
@@ -10,6 +10,10 @@
 # FOR A PARTICULAR PURPOSE.
 ##############################################################################
 
+import unittest
+
+from zope.interface.verify import verifyClass
+from zope.interface.verify import verifyObject
 
 from zope.interface.common import ABCInterface
 from zope.interface.common import ABCInterfaceClass
@@ -56,3 +60,27 @@ def add_abc_interface_tests(cls, module):
             test.__name__ = name
             assert not hasattr(cls, name)
             setattr(cls, name, test)
+
+
+
+class VerifyClassMixin(unittest.TestCase):
+    verifier = staticmethod(verifyClass)
+    UNVERIFIABLE = ()
+
+    def _adjust_object_before_verify(self, iface, x):
+        return x
+
+    def verify(self, iface, klass, **kwargs):
+        return self.verifier(iface,
+                             self._adjust_object_before_verify(iface, klass),
+                             **kwargs)
+
+
+class VerifyObjectMixin(VerifyClassMixin):
+    verifier = staticmethod(verifyObject)
+    CONSTRUCTORS = {
+    }
+
+    def _adjust_object_before_verify(self, iface, x):
+        return self.CONSTRUCTORS.get(iface,
+                                     self.CONSTRUCTORS.get(x, x))()

--- a/src/zope/interface/common/tests/__init__.py
+++ b/src/zope/interface/common/tests/__init__.py
@@ -82,5 +82,14 @@ class VerifyObjectMixin(VerifyClassMixin):
     }
 
     def _adjust_object_before_verify(self, iface, x):
-        return self.CONSTRUCTORS.get(iface,
-                                     self.CONSTRUCTORS.get(x, x))()
+        constructor = self.CONSTRUCTORS.get(x)
+        if not constructor:
+            constructor = self.CONSTRUCTORS.get(iface)
+        if not constructor:
+            constructor = self.CONSTRUCTORS.get(x.__name__)
+        if not constructor:
+            constructor = x
+        if constructor is unittest.SkipTest:
+            self.skipTest("Cannot create " + str(x))
+
+        return constructor()

--- a/src/zope/interface/common/tests/__init__.py
+++ b/src/zope/interface/common/tests/__init__.py
@@ -46,8 +46,11 @@ def iter_abc_interfaces(predicate=lambda iface: True):
 def add_abc_interface_tests(cls, module):
     def predicate(iface):
         return iface.__module__ == module
+    add_verify_tests(cls, iter_abc_interfaces(predicate))
 
-    for iface, registered_classes in iter_abc_interfaces(predicate):
+
+def add_verify_tests(cls, iface_classes_iter):
+    for iface, registered_classes in iface_classes_iter:
         for stdlib_class in registered_classes:
 
             def test(self, stdlib_class=stdlib_class, iface=iface):
@@ -60,7 +63,6 @@ def add_abc_interface_tests(cls, module):
             test.__name__ = name
             assert not hasattr(cls, name)
             setattr(cls, name, test)
-
 
 
 class VerifyClassMixin(unittest.TestCase):
@@ -92,4 +94,7 @@ class VerifyObjectMixin(VerifyClassMixin):
         if constructor is unittest.SkipTest:
             self.skipTest("Cannot create " + str(x))
 
-        return constructor()
+        result = constructor()
+        if hasattr(result, 'close'):
+            self.addCleanup(result.close)
+        return result

--- a/src/zope/interface/common/tests/test_builtins.py
+++ b/src/zope/interface/common/tests/test_builtins.py
@@ -27,12 +27,6 @@ class TestVerifyClass(VerifyClassMixin,
     )
     FILE_IMPL = ()
     if PY2:
-        UNVERIFIABLE += (
-            # On both CPython and PyPy, there's no
-            # exposed __iter__ method for strings or unicode.
-            unicode,
-            str,
-        )
         FILE_IMPL = ((file, builtins.IFile),)
     @classmethod
     def create_tests(cls):

--- a/src/zope/interface/common/tests/test_builtins.py
+++ b/src/zope/interface/common/tests/test_builtins.py
@@ -1,0 +1,65 @@
+##############################################################################
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+##############################################################################
+from __future__ import absolute_import
+
+import unittest
+
+from zope.interface._compat import PYTHON2 as PY2
+from zope.interface.common import builtins
+
+from . import VerifyClassMixin
+from . import VerifyObjectMixin
+
+
+class TestVerifyClass(VerifyClassMixin,
+                      unittest.TestCase):
+    UNVERIFIABLE = (
+
+    )
+    FILE_IMPL = ()
+    if PY2:
+        UNVERIFIABLE += (
+            # On both CPython and PyPy, there's no
+            # exposed __iter__ method for strings or unicode.
+            unicode,
+            str,
+        )
+        FILE_IMPL = ((file, builtins.IFile),)
+    @classmethod
+    def create_tests(cls):
+        for klass, iface in (
+                (list, builtins.IList),
+                (tuple, builtins.ITuple),
+                (type(u'abc'), builtins.ITextString),
+                (bytes, builtins.IByteString),
+                (str, builtins.INativeString),
+                (bool, builtins.IBool),
+                (dict, builtins.IDict),
+        ) + cls.FILE_IMPL:
+            def test(self, klass=klass, iface=iface):
+                if klass in self.UNVERIFIABLE:
+                    self.skipTest("Cannot verify %s" % klass)
+
+                self.assertTrue(self.verify(iface, klass))
+
+            name = 'test_auto_' + klass.__name__ + '_' + iface.__name__
+            test.__name__ = name
+            setattr(cls, name, test)
+
+TestVerifyClass.create_tests()
+
+
+class TestVerifyObject(VerifyObjectMixin,
+                       TestVerifyClass):
+    CONSTRUCTORS = {
+        builtins.IFile: lambda: open(__file__)
+    }

--- a/src/zope/interface/common/tests/test_builtins.py
+++ b/src/zope/interface/common/tests/test_builtins.py
@@ -18,38 +18,24 @@ from zope.interface.common import builtins
 
 from . import VerifyClassMixin
 from . import VerifyObjectMixin
+from . import add_verify_tests
 
 
 class TestVerifyClass(VerifyClassMixin,
                       unittest.TestCase):
-    UNVERIFIABLE = (
+    pass
 
-    )
-    FILE_IMPL = ()
-    if PY2:
-        FILE_IMPL = ((file, builtins.IFile),)
-    @classmethod
-    def create_tests(cls):
-        for klass, iface in (
-                (list, builtins.IList),
-                (tuple, builtins.ITuple),
-                (type(u'abc'), builtins.ITextString),
-                (bytes, builtins.IByteString),
-                (str, builtins.INativeString),
-                (bool, builtins.IBool),
-                (dict, builtins.IDict),
-        ) + cls.FILE_IMPL:
-            def test(self, klass=klass, iface=iface):
-                if klass in self.UNVERIFIABLE:
-                    self.skipTest("Cannot verify %s" % klass)
 
-                self.assertTrue(self.verify(iface, klass))
-
-            name = 'test_auto_' + klass.__name__ + '_' + iface.__name__
-            test.__name__ = name
-            setattr(cls, name, test)
-
-TestVerifyClass.create_tests()
+add_verify_tests(TestVerifyClass, (
+    (builtins.IList, (list,)),
+    (builtins.ITuple, (tuple,)),
+    (builtins.ITextString, (type(u'abc'),)),
+    (builtins.IByteString, (bytes,)),
+    (builtins.INativeString, (str,)),
+    (builtins.IBool, (bool,)),
+    (builtins.IDict, (dict,)),
+    (builtins.IFile, (file,) if PY2 else ()),
+))
 
 
 class TestVerifyObject(VerifyObjectMixin,

--- a/src/zope/interface/common/tests/test_collections.py
+++ b/src/zope/interface/common/tests/test_collections.py
@@ -25,8 +25,7 @@ except ImportError:
     MappingProxyType = object()
 
 from zope.interface import Invalid
-from zope.interface.verify import verifyClass
-from zope.interface.verify import verifyObject
+
 
 # Note that importing z.i.c.collections does work on import.
 from zope.interface.common import collections
@@ -135,6 +134,21 @@ class TestVerifyObject(VerifyObjectMixin,
         range: lambda: range(10),
         MappingProxyType: lambda: MappingProxyType({}),
         collections.UserString: lambda: collections.UserString('abc'),
+        type(iter(bytearray())): lambda: iter(bytearray()),
+        type(iter(b'abc')): lambda: iter(b'abc'),
+        'coroutine': unittest.SkipTest,
+        type(iter({}.keys())): lambda: iter({}.keys()),
+        type(iter({}.items())): lambda: iter({}.items()),
+        type(iter({}.values())): lambda: iter({}.values()),
+        type((i for i in range(1))): lambda: (i for i in range(3)),
+        type(iter([])): lambda: iter([]),
+        type(reversed([])): lambda: reversed([]),
+        'longrange_iterator': unittest.SkipTest,
+        'range_iterator': lambda: iter(range(3)),
+        type(iter(set())): lambda: iter(set()),
+        type(iter('')): lambda: iter(''),
+        'async_generator': unittest.SkipTest,
+        type(iter(tuple())): lambda: iter(tuple()),
     }
 
     if PY2:

--- a/src/zope/interface/common/tests/test_collections.py
+++ b/src/zope/interface/common/tests/test_collections.py
@@ -1,0 +1,145 @@
+##############################################################################
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+##############################################################################
+
+
+import unittest
+try:
+    import collections.abc as abc
+except ImportError:
+    import collections as abc
+from collections import deque
+
+try:
+    from types import MappingProxyType
+except ImportError:
+    MappingProxyType = object()
+
+from zope.interface.verify import verifyClass
+from zope.interface.verify import verifyObject
+# Note that importing z.i.c.collections does work on import.
+from zope.interface.common import collections
+from zope.interface.common import stdlib_class_registry
+
+from zope.interface._compat import PYPY
+from zope.interface._compat import PYTHON2 as PY2
+
+class TestVerifyClass(unittest.TestCase):
+
+    verifier = staticmethod(verifyClass)
+
+    def _adjust_object_before_verify(self, iface, x):
+        return x
+
+    def verify(self, iface, klass, **kwargs):
+        return self.verifier(iface,
+                             self._adjust_object_before_verify(iface, klass),
+                             **kwargs)
+
+
+    # Here we test some known builtin classes that are defined to implement
+    # various collection interfaces as a quick sanity test.
+    def test_frozenset(self):
+        self.assertIsInstance(frozenset(), abc.Set)
+        self.assertTrue(self.verify(collections.ISet, frozenset))
+        self.assertIn(frozenset, stdlib_class_registry)
+
+    def test_list(self):
+        self.assertIsInstance(list(), abc.MutableSequence)
+        self.assertTrue(self.verify(collections.IMutableSequence, list))
+        self.assertIn(list, stdlib_class_registry)
+
+    # Now we go through the registry, which should have several things,
+    # mostly builtins, but if we've imported other libraries already,
+    # it could contain things from outside of there too. We aren't concerned
+    # about third-party code here, just standard library types. We start with a
+    # blacklist of things to exclude, but if that gets out of hand we can figure
+    # out a better whitelisting.
+    _UNVERIFIABLE = {
+        # This is declared to be an ISequence, but is missing lots of methods,
+        # including some that aren't part of a language protocol, such as
+        # ``index`` and ``count``.
+        memoryview,
+        # 'pkg_resources._vendor.pyparsing.ParseResults' is registered as a
+        # MutableMapping but is missing methods like ``popitem`` and ``setdefault``.
+        # It's imported due to namespace packages.
+        'ParseResults',
+        # sqlite3.Row claims ISequence but also misses ``index`` and ``count``.
+        # It's imported because...? Coverage imports it, but why do we have it without
+        # coverage?
+        'Row',
+    }
+
+    if PYPY:
+        _UNVERIFIABLE.update({
+            # collections.deque.pop() doesn't support the index= argument to
+            # MutableSequence.pop(). We can't verify this on CPython because we can't
+            # get the signature, but on PyPy we /can/ get the signature, and of course
+            # it doesn't match.
+            deque,
+            # Likewise for index
+            range,
+        })
+    if PY2:
+        # pylint:disable=undefined-variable,no-member
+        # There are a lot more types that are fundamentally unverifiable on Python 2.
+        _UNVERIFIABLE.update({
+            # Missing several key methods like __getitem__
+            basestring,
+            # Missing __iter__ and __contains__, hard to construct.
+            buffer,
+            # Missing ``__contains__``, ``count`` and ``index``.
+            xrange,
+            # These two are missing Set.isdisjoint()
+            type({}.viewitems()),
+            type({}.viewkeys()),
+            # str is missing __iter__!
+            str,
+        })
+
+    @classmethod
+    def gen_tests(cls):
+        for stdlib_class, iface in stdlib_class_registry.items():
+            if stdlib_class in cls._UNVERIFIABLE or stdlib_class.__name__ in cls._UNVERIFIABLE:
+                continue
+
+            def test(self, stdlib_class=stdlib_class, iface=iface):
+                self.assertTrue(self.verify(iface, stdlib_class))
+
+            name = 'test_auto_' + stdlib_class.__name__
+            test.__name__ = name
+            assert not hasattr(cls, name)
+            setattr(cls, name, test)
+
+TestVerifyClass.gen_tests()
+
+
+class TestVerifyObject(TestVerifyClass):
+    verifier = staticmethod(verifyObject)
+
+    _CONSTRUCTORS = {
+        collections.IValuesView: {}.values,
+        collections.IItemsView: {}.items,
+        collections.IKeysView: {}.keys,
+        memoryview: lambda: memoryview(b'abc'),
+        range: lambda: range(10),
+        MappingProxyType: lambda: MappingProxyType({})
+    }
+
+    if PY2:
+        # pylint:disable=undefined-variable,no-member
+        _CONSTRUCTORS.update({
+            collections.IValuesView: {}.viewvalues,
+        })
+
+    def _adjust_object_before_verify(self, iface, x):
+        return self._CONSTRUCTORS.get(iface,
+                                      self._CONSTRUCTORS.get(x, x))()

--- a/src/zope/interface/common/tests/test_collections.py
+++ b/src/zope/interface/common/tests/test_collections.py
@@ -117,8 +117,6 @@ class TestVerifyClass(VerifyClassMixin, unittest.TestCase):
             # These two are missing Set.isdisjoint()
             type({}.viewitems()),
             type({}.viewkeys()),
-            # str is missing __iter__!
-            str,
         })
 
 add_abc_interface_tests(TestVerifyClass, collections.ISet.__module__)
@@ -145,6 +143,7 @@ class TestVerifyObject(VerifyObjectMixin,
         type(reversed([])): lambda: reversed([]),
         'longrange_iterator': unittest.SkipTest,
         'range_iterator': lambda: iter(range(3)),
+        'rangeiterator': lambda: iter(range(3)),
         type(iter(set())): lambda: iter(set()),
         type(iter('')): lambda: iter(''),
         'async_generator': unittest.SkipTest,

--- a/src/zope/interface/common/tests/test_io.py
+++ b/src/zope/interface/common/tests/test_io.py
@@ -12,10 +12,10 @@
 
 
 import unittest
-import numbers as abc
+import io as abc
 
-# Note that importing z.i.c.numbers does work on import.
-from zope.interface.common import numbers
+# Note that importing z.i.c.io does work on import.
+from zope.interface.common import io
 
 from . import add_abc_interface_tests
 from . import VerifyClassMixin
@@ -24,18 +24,28 @@ from . import VerifyObjectMixin
 
 class TestVerifyClass(VerifyClassMixin,
                       unittest.TestCase):
+    pass
 
-    def test_int(self):
-        self.assertIsInstance(int(), abc.Integral)
-        self.assertTrue(self.verify(numbers.IIntegral, int))
-
-    def test_float(self):
-        self.assertIsInstance(float(), abc.Real)
-        self.assertTrue(self.verify(numbers.IReal, float))
-
-add_abc_interface_tests(TestVerifyClass, numbers.INumber.__module__)
+add_abc_interface_tests(TestVerifyClass, io.IIOBase.__module__)
 
 
 class TestVerifyObject(VerifyObjectMixin,
                        TestVerifyClass):
-    pass
+    CONSTRUCTORS = {
+        abc.BufferedWriter: lambda: abc.BufferedWriter(abc.StringIO()),
+        abc.BufferedReader: lambda: abc.BufferedReader(abc.StringIO()),
+        abc.TextIOWrapper: lambda: abc.TextIOWrapper(abc.BytesIO()),
+        abc.BufferedRandom: lambda: abc.BufferedRandom(abc.BytesIO()),
+        abc.BufferedRWPair: lambda: abc.BufferedRWPair(abc.BytesIO(), abc.BytesIO()),
+        abc.FileIO: lambda: abc.FileIO(__file__),
+    }
+
+    try:
+        import cStringIO
+    except ImportError:
+        pass
+    else:
+        CONSTRUCTORS.update({
+            cStringIO.InputType: lambda cStringIO=cStringIO: cStringIO.StringIO('abc'),
+            cStringIO.OutputType: cStringIO.StringIO,
+        })

--- a/src/zope/interface/common/tests/test_io.py
+++ b/src/zope/interface/common/tests/test_io.py
@@ -38,6 +38,7 @@ class TestVerifyObject(VerifyObjectMixin,
         abc.BufferedRandom: lambda: abc.BufferedRandom(abc.BytesIO()),
         abc.BufferedRWPair: lambda: abc.BufferedRWPair(abc.BytesIO(), abc.BytesIO()),
         abc.FileIO: lambda: abc.FileIO(__file__),
+        'WindowsConsoleIO': unittest.SkipTest,
     }
 
     try:

--- a/src/zope/interface/common/tests/test_io.py
+++ b/src/zope/interface/common/tests/test_io.py
@@ -38,7 +38,7 @@ class TestVerifyObject(VerifyObjectMixin,
         abc.BufferedRandom: lambda: abc.BufferedRandom(abc.BytesIO()),
         abc.BufferedRWPair: lambda: abc.BufferedRWPair(abc.BytesIO(), abc.BytesIO()),
         abc.FileIO: lambda: abc.FileIO(__file__),
-        'WindowsConsoleIO': unittest.SkipTest,
+        '_WindowsConsoleIO': unittest.SkipTest,
     }
 
     try:

--- a/src/zope/interface/common/tests/test_numbers.py
+++ b/src/zope/interface/common/tests/test_numbers.py
@@ -1,0 +1,53 @@
+##############################################################################
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+##############################################################################
+
+
+import unittest
+import numbers as abc
+
+from zope.interface.verify import verifyClass
+from zope.interface.verify import verifyObject
+
+# Note that importing z.i.c.numbers does work on import.
+from zope.interface.common import numbers
+
+from . import add_abc_interface_tests
+
+
+class TestVerifyClass(unittest.TestCase):
+    verifier = staticmethod(verifyClass)
+    UNVERIFIABLE = ()
+
+    def _adjust_object_before_verify(self, iface, x):
+        return x
+
+    def verify(self, iface, klass, **kwargs):
+        return self.verifier(iface,
+                             self._adjust_object_before_verify(iface, klass),
+                             **kwargs)
+
+    def test_int(self):
+        self.assertIsInstance(int(), abc.Integral)
+        self.assertTrue(self.verify(numbers.IIntegral, int))
+
+    def test_float(self):
+        self.assertIsInstance(float(), abc.Real)
+        self.assertTrue(self.verify(numbers.IReal, float))
+
+add_abc_interface_tests(TestVerifyClass, numbers.INumber.__module__)
+
+
+class TestVerifyObject(TestVerifyClass):
+    verifier = staticmethod(verifyObject)
+
+    def _adjust_object_before_verify(self, iface, x):
+        return x()

--- a/src/zope/interface/tests/test_verify.py
+++ b/src/zope/interface/tests/test_verify.py
@@ -21,11 +21,8 @@ class Test_verifyClass(unittest.TestCase):
 
     verifier = None
 
-    @classmethod
-    def setUpClass(cls):
-        # zope.testrunner doesn't call setUpClass, so if you get
-        # 'NoneType is not callable', that's why.
-        cls.verifier = staticmethod(cls._get_FUT())
+    def setUp(self):
+        self.verifier = self._get_FUT()
 
     @classmethod
     def _get_FUT(cls):


### PR DESCRIPTION
Derived automatically from Python stdlib ABCs.

When done, this will fix #138. 

So far, its just the collection classes. Remaining items:

- [x] Whoops, I missed `ByteString`
- [x] The `numbers` ABCs
- [x] Other common non-ABC types, like `IText` and whatever else is missing from `dolmen.builtins`
- [x] What happens to the "legacy" interfaces in mapping.py and sequence.py? Are they left completely alone? They are probably badly out of date. Do we docs-deprecate them? Maybe they can slot-in as super-classes