### PR TITLE
Fix repr of "Attribute" to look like before

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,7 @@
   Like the above, this will break consumers depending on the exact
   output of error messages if more than one error is present.
 
+
 4.7.1 (2019-11-11)
 ==================
 

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -651,7 +651,7 @@ class Attribute(Element):
         return of + self.__name__ + self._get_str_info()
 
     def __repr__(self):
-        return "<%s.%s at 0x%x %s>" % (
+        return "<%s.%s object at 0x%x %s>" % (
             type(self).__module__,
             type(self).__name__,
             id(self),

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -1861,13 +1861,13 @@ class AttributeTests(ElementTests):
         method = self._makeOne()
         method.interface = type(self)
         r = repr(method)
-        self.assertTrue(r.startswith('<zope.interface.interface.Attribute at'), r)
+        self.assertTrue(r.startswith('<zope.interface.interface.Attribute object at'), r)
         self.assertTrue(r.endswith(' AttributeTests.TestAttribute>'), r)
 
     def test__repr__wo_interface(self):
         method = self._makeOne()
         r = repr(method)
-        self.assertTrue(r.startswith('<zope.interface.interface.Attribute at'), r)
+        self.assertTrue(r.startswith('<zope.interface.interface.Attribute object at'), r)
         self.assertTrue(r.endswith(' TestAttribute>'), r)
 
     def test__str__w_interface(self):
@@ -1948,14 +1948,14 @@ class MethodTests(AttributeTests):
         method.kwargs = 'kw'
         method.interface = type(self)
         r = repr(method)
-        self.assertTrue(r.startswith('<zope.interface.interface.Method at'), r)
+        self.assertTrue(r.startswith('<zope.interface.interface.Method object at'), r)
         self.assertTrue(r.endswith(' MethodTests.TestMethod(**kw)>'), r)
 
     def test__repr__wo_interface(self):
         method = self._makeOne()
         method.kwargs = 'kw'
         r = repr(method)
-        self.assertTrue(r.startswith('<zope.interface.interface.Method at'), r)
+        self.assertTrue(r.startswith('<zope.interface.interface.Method object at'), r)
         self.assertTrue(r.endswith(' TestMethod(**kw)>'), r)
 
     def test__str__w_interface(self):


### PR DESCRIPTION
and as usual in Python.

It broke tons of tests in Plone and related. Also the repr looks like it's usual in Python.