### PR TITLE
performance: store cached hashvalue in slot

### DIFF
--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -277,6 +277,7 @@ typedef struct {
     PyObject* _v_attrs;
     PyObject* __iro__;
     PyObject* __sro__;
+    PyObject* _hashvalue;
 } Spec;
 
 /*
@@ -291,6 +292,7 @@ Spec_traverse(Spec* self, visitproc visit, void* arg)
     Py_VISIT(self->_v_attrs);
     Py_VISIT(self->__iro__);
     Py_VISIT(self->__sro__);
+    Py_VISIT(self->_hashvalue);
     return 0;
 }
 
@@ -302,6 +304,7 @@ Spec_clear(Spec* self)
     Py_CLEAR(self->_v_attrs);
     Py_CLEAR(self->__iro__);
     Py_CLEAR(self->__sro__);
+    Py_CLEAR(self->_hashvalue);
     return 0;
 }
 
@@ -413,6 +416,7 @@ static PyMemberDef Spec_members[] = {
   {"_v_attrs", T_OBJECT_EX, offsetof(Spec, _v_attrs), 0, ""},
   {"__iro__", T_OBJECT_EX, offsetof(Spec, __iro__), 0, ""},
   {"__sro__", T_OBJECT_EX, offsetof(Spec, __sro__), 0, ""},
+  {"_hashvalue", T_OBJECT_EX, offsetof(Spec, _hashvalue), 0, ""},
   {NULL},
 };
 

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -180,6 +180,8 @@ class _ImmutableDeclaration(Declaration):
         # object, and that includes a method.)
         return _ImmutableDeclaration
 
+    _hashvalue = hash((__module__, '_empty'))
+
 
 ##############################################################################
 #

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -131,6 +131,8 @@ class SpecificationBase(object):
         '__iro__',
         '__sro__',
         '__weakref__',
+        # Things used in InterfaceClass.
+        '_hashvalue',
     )
 
     def providedBy(self, ob):
@@ -598,10 +600,10 @@ class InterfaceClass(Element, InterfaceBase, Specification):
 
     def __hash__(self):
         try:
-            return self._v_cached_hash
+            return self._hashvalue
         except AttributeError:
-            self._v_cached_hash = hash((self.__name__, self.__module__))
-        return self._v_cached_hash
+            self._hashvalue = hash((self.__name__, self.__module__))
+        return self._hashvalue
 
     def __eq__(self, other):
         c = self.__cmp(other)


### PR DESCRIPTION
Micro-optimizations. In fact this does only save a few percent: 
- Py-Spy on Plone, running all tests.
- 20k samples (200sec)
- with current master `__hash__` takes 2.6% of time
- with this branch `__hash__` takes 1.6% of time

I did not found much information on slots, Python C-extensions and inheritance. I hope I got it right.

