### PR TITLE
Implement _lookup in C-extension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,10 @@
   Like the above, this will break consumers depending on the exact
   output of error messages if more than one error is present.
 
+- Implement ``adapter._lookup`` in C. In a Plone test run measured with
+  Py-Spy the function is 1.7x faster than before. See `PR xxx
+  <https://github.com/zopefoundation/zope.interface/pull/xxx>`_.
+
 
 4.7.1 (2019-11-11)
 ==================

--- a/src/zope/interface/adapter.py
+++ b/src/zope/interface/adapter.py
@@ -661,6 +661,7 @@ def _convert_None_to_Interface(x):
     else:
         return x
 
+@_use_c_impl
 def _lookup(components, specs, provided, name, i, l):
     # this function is called very often.
     # The components.get in loops is executed 100 of 1000s times.


### PR DESCRIPTION
At the moment this is tested only with Python 3.7 and may fail on other versions.

Speed-up is only ~1.7x, I would have expected more. 
A 200s sample with Py-Spy running the all Plone tests comes down from 11.1s for _lookup to 6.5s.

Todo: 
- [ ] Make it work with all here supported Python versions.
- [ ] Better performance checking code than using Py-Spy
- [ ] Optimize code if possible
- [ ] Review reference-counting.

Feedback appreciated, my C is a bit rusty (not much used the last 20 years) and I never wrote C-extension code before.