### PR TITLE
Make provided/implementedBy and adapter registries respect super().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,6 @@ jobs:
         - sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
       after_success:
 
-    - name: PyPy C Extensions
-      env: PURE_PYTHON=0
-      python: pypy
-
     - name: CPython No C Extension
       env: PURE_PYTHON=1
       python: 3.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,6 +134,23 @@
   `dolmen.builtins <https://pypi.org/project/dolmen.builtins/>`_.
   See `issue 138 <https://github.com/zopefoundation/zope.interface/issues/138>`_.
 
+- Make ``providedBy()`` and ``implementedBy()`` respect ``super``
+  objects. For instance, if class ``Derived`` implements ``IDerived``
+  and extends ``Base`` which in turn implements ``IBase``, then
+  ``providedBy(super(Derived, derived))`` will return ``[IBase]``.
+  Previously it would have returned ``[IDerived]`` (in general, it
+  would previously have returned whatever would have been returned
+  without ``super``).
+
+  Along with this change, adapter registries will unpack ``super``
+  objects into their ``__self___`` before passing it to the factory.
+  Together, this means that ``component.getAdapter(super(Derived,
+  self), ITarget)`` is now meaningful.
+
+  See `issue 11 <https://github.com/zopefoundation/zope.interface/issues/11>`_.
+
+- Fix a potential interpreter crash in the low-level adapter
+  registry lookup functions. See issue 11.
 
 4.7.1 (2019-11-11)
 ==================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,9 @@ import os
 import pkg_resources
 sys.path.append(os.path.abspath('../src'))
 rqmt = pkg_resources.require('zope.interface')[0]
-
+# Import and document the pure-python versions of things; they tend to have better
+# docstrings and signatures.
+os.environ['PURE_PYTHON'] = '1'
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/setup.py
+++ b/setup.py
@@ -69,10 +69,12 @@ codeoptimization = [
 ]
 
 is_jython = 'java' in sys.platform
+is_pypy = hasattr(sys, 'pypy_version_info')
 
-# Jython cannot build the C optimizations. Everywhere else,
-# including PyPy, defer the decision to runtime.
-if is_jython:
+# Jython cannot build the C optimizations. Nor, as of 7.3, can PyPy (
+# it doesn't have PySuper_Type) Everywhere else, defer the decision to
+# runtime.
+if is_jython or is_pypy:
     ext_modules = []
 else:
     ext_modules = codeoptimization

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -38,16 +38,12 @@
 static PyObject *str__dict__, *str__implemented__, *strextends;
 static PyObject *BuiltinImplementationSpecifications, *str__provides__;
 static PyObject *str__class__, *str__providedBy__;
-static PyObject *empty, *fallback, *str_implements;
+static PyObject *empty, *fallback;
 static PyObject *str__conform__, *str_call_conform, *adapter_hooks;
 static PyObject *str_uncached_lookup, *str_uncached_lookupAll;
 static PyObject *str_uncached_subscriptions;
 static PyObject *str_registry, *strro, *str_generation, *strchanged;
-static PyObject *str__get__;
 static PyObject *str__self__;
-static PyObject *str__thisclass__;
-static PyObject *str__self_class__;
-static PyObject *str__mro__;
 
 static PyTypeObject *Implements;
 
@@ -1045,7 +1041,7 @@ lookup_lookup(lookup *self, PyObject *args, PyObject *kwds)
   static char *kwlist[] = {"required", "provided", "name", "default", NULL};
   PyObject *required, *provided, *name=NULL, *default_=NULL;
 
-  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
+  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO:LookupBase.lookup", kwlist,
                                     &required, &provided, &name, &default_))
     return NULL;
 
@@ -1117,7 +1113,7 @@ lookup_lookup1(lookup *self, PyObject *args, PyObject *kwds)
   static char *kwlist[] = {"required", "provided", "name", "default", NULL};
   PyObject *required, *provided, *name=NULL, *default_=NULL;
 
-  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
+  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO:LookupBase.lookup1", kwlist,
                                     &required, &provided, &name, &default_))
     return NULL;
 
@@ -1133,6 +1129,8 @@ lookup_lookup1(lookup *self, PyObject *args, PyObject *kwds)
             factory = self.lookup((required, ), provided, name)
 
         if factory is not None:
+            if isinstance(object, super):
+                object = object.__self__
             result = factory(object)
             if result is not None:
                 return result
@@ -1201,7 +1199,7 @@ lookup_adapter_hook(lookup *self, PyObject *args, PyObject *kwds)
   static char *kwlist[] = {"provided", "object", "name", "default", NULL};
   PyObject *object, *provided, *name=NULL, *default_=NULL;
 
-  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
+  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO:LookupBase.adapter_hook", kwlist,
                                     &provided, &object, &name, &default_))
     return NULL;
 
@@ -1214,7 +1212,7 @@ lookup_queryAdapter(lookup *self, PyObject *args, PyObject *kwds)
   static char *kwlist[] = {"object", "provided", "name", "default", NULL};
   PyObject *object, *provided, *name=NULL, *default_=NULL;
 
-  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO", kwlist,
+  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO:LookupBase.queryAdapter", kwlist,
                                     &object, &provided, &name, &default_))
     return NULL;
 
@@ -1285,7 +1283,7 @@ lookup_lookupAll(lookup *self, PyObject *args, PyObject *kwds)
   static char *kwlist[] = {"required", "provided", NULL};
   PyObject *required, *provided;
 
-  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist,
+  if (! PyArg_ParseTupleAndKeywords(args, kwds, "OO:LookupBase.lookupAll", kwlist,
                                     &required, &provided))
     return NULL;
 
@@ -1752,7 +1750,6 @@ init(void)
   DEFINE_STRING(__class__);
   DEFINE_STRING(__providedBy__);
   DEFINE_STRING(extends);
-  DEFINE_STRING(_implements);
   DEFINE_STRING(__conform__);
   DEFINE_STRING(_call_conform);
   DEFINE_STRING(_uncached_lookup);
@@ -1763,10 +1760,6 @@ init(void)
   DEFINE_STRING(ro);
   DEFINE_STRING(changed);
   DEFINE_STRING(__self__);
-  DEFINE_STRING(__get__);
-  DEFINE_STRING(__thisclass__);
-  DEFINE_STRING(__self_class__);
-  DEFINE_STRING(__mro__);
 #undef DEFINE_STRING
   adapter_hooks = PyList_New(0);
   if (adapter_hooks == NULL)


### PR DESCRIPTION
The query functions now start by looking at the next class in the MRO (interfaces directly provided by the underlying object are not found).

Adapter registries automatically pick up providedBy change to start finding the correct implementations of adapters, but to make that really useful they needed to change to unpack super() arguments and pass `__self__` to the factory.

Fixes #11

Unfortunately, this makes PyPy unable to build the C extensions.