### PR TITLE
Move Interface hashing and comparison to C; 2.5 to 15x speedup in micro benchmarks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -158,12 +158,18 @@
 - Fix a potential interpreter crash in the low-level adapter
   registry lookup functions. See issue 11.
 
+<<<<<<< HEAD
 - Adopt Python's standard `C3 resolution order
   <https://www.python.org/download/releases/2.3/mro/>`_ to compute the
   ``__iro__`` and ``__sro__`` of interfaces, with tweaks to support
   additional cases that are common in interfaces but disallowed for
   Python classes. Previously, an ad-hoc ordering that made no
   particular guarantees was used.
+=======
+- Use Python's standard C3 resolution order to compute the
+  ``__iro__`` and ``__sro__`` of interfaces. Previously, an ad-hoc
+  ordering that made no particular guarantees was used.
+>>>>>>> Add tests for comparing InterfaceClass/Implements objects to things without the required attributes.
 
   This has many beneficial properties, including the fact that base
   interface and base classes tend to appear near the end of the
@@ -209,6 +215,17 @@
   not implement any interfaces are part of a class inheritance
   hierarchy, ``Interface`` could be assigned too high a priority.
   See `issue 8 <https://github.com/zopefoundation/zope.interface/issues/8>`_.
+
+- Implement sorting, equality, and hashing in C for ``Interface``
+  objects. In micro benchmarks, this makes those operations 40% to 80%
+  faster. This translates to a 20% speed up in querying adapters.
+
+  Note that this changes certain implementation details. In
+  particular, ``InterfaceClass`` now has a non-default metaclass, and
+  it is enforced that ``__module__`` in instances of
+  ``InterfaceClass`` is read-only.
+
+  See `PR 183 <https://github.com/zopefoundation/zope.interface/pull/183>`_.
 
 
 4.7.2 (2020-03-10)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -158,18 +158,12 @@
 - Fix a potential interpreter crash in the low-level adapter
   registry lookup functions. See issue 11.
 
-<<<<<<< HEAD
 - Adopt Python's standard `C3 resolution order
   <https://www.python.org/download/releases/2.3/mro/>`_ to compute the
   ``__iro__`` and ``__sro__`` of interfaces, with tweaks to support
   additional cases that are common in interfaces but disallowed for
   Python classes. Previously, an ad-hoc ordering that made no
   particular guarantees was used.
-=======
-- Use Python's standard C3 resolution order to compute the
-  ``__iro__`` and ``__sro__`` of interfaces. Previously, an ad-hoc
-  ordering that made no particular guarantees was used.
->>>>>>> Add tests for comparing InterfaceClass/Implements objects to things without the required attributes.
 
   This has many beneficial properties, including the fact that base
   interface and base classes tend to appear near the end of the

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,3 +18,4 @@ global-exclude coverage.xml
 global-exclude appveyor.yml
 
 prune docs/_build
+prune benchmarks

--- a/benchmarks/micro.py
+++ b/benchmarks/micro.py
@@ -1,14 +1,33 @@
 import pyperf
 
 from zope.interface import Interface
+from zope.interface import classImplements
 from zope.interface.interface import InterfaceClass
+from zope.interface.registry import Components
 
+# Long, mostly similar names are a worst case for equality
+# comparisons.
 ifaces = [
-    InterfaceClass('I' + str(i), (Interface,), {})
+    InterfaceClass('I' + ('0' * 20) + str(i), (Interface,), {})
     for i in range(100)
 ]
 
-INNER = 1000
+def make_implementer(iface):
+    c = type('Implementer' + iface.__name__, (object,), {})
+    classImplements(c, iface)
+    return c
+
+implementers = [
+    make_implementer(iface)
+    for iface in ifaces
+]
+
+providers = [
+    implementer()
+    for implementer in implementers
+]
+
+INNER = 10
 
 def bench_in(loops, o):
     t0 = pyperf.perf_counter()
@@ -18,7 +37,46 @@ def bench_in(loops, o):
 
     return pyperf.perf_counter() - t0
 
+def bench_query_adapter(loops, components):
+    # One time through to prime the caches
+    for iface in ifaces:
+        for provider in providers:
+            components.queryAdapter(provider, iface)
+
+    t0 = pyperf.perf_counter()
+    for _ in range(loops):
+        for iface in ifaces:
+            for provider in providers:
+                components.queryAdapter(provider, iface)
+    return pyperf.perf_counter() - t0
+
 runner = pyperf.Runner()
+
+runner.bench_time_func(
+    'query adapter (no registrations)',
+    bench_query_adapter,
+    Components(),
+    inner_loops=1
+)
+
+def populate_components():
+
+    def factory(o):
+        return 42
+
+    pop_components = Components()
+    for iface in ifaces:
+        for other_iface in ifaces:
+            pop_components.registerAdapter(factory, (iface,), other_iface, event=False)
+
+    return pop_components
+
+runner.bench_time_func(
+    'query adapter (all trivial registrations)',
+    bench_query_adapter,
+    populate_components(),
+    inner_loops=1
+)
 
 runner.bench_time_func(
     'contains (empty dict)',

--- a/benchmarks/micro.py
+++ b/benchmarks/micro.py
@@ -1,0 +1,42 @@
+import pyperf
+
+from zope.interface import Interface
+from zope.interface.interface import InterfaceClass
+
+ifaces = [
+    InterfaceClass('I' + str(i), (Interface,), {})
+    for i in range(100)
+]
+
+INNER = 1000
+
+def bench_in(loops, o):
+    t0 = pyperf.perf_counter()
+    for _ in range(loops):
+        for _ in range(INNER):
+            o.__contains__(Interface)
+
+    return pyperf.perf_counter() - t0
+
+runner = pyperf.Runner()
+
+runner.bench_time_func(
+    'contains (empty dict)',
+    bench_in,
+    {},
+    inner_loops=INNER
+)
+
+runner.bench_time_func(
+    'contains (populated dict)',
+    bench_in,
+    {k: k for k in ifaces},
+    inner_loops=INNER
+)
+
+runner.bench_time_func(
+    'contains (populated list)',
+    bench_in,
+    ifaces,
+    inner_loops=INNER
+)

--- a/src/zope/interface/_compat.py
+++ b/src/zope/interface/_compat.py
@@ -166,4 +166,5 @@ def _use_c_impl(py_impl, name=None, globs=None):
     # name (for testing and documentation)
     globs[name + 'Py'] = py_impl
     globs[name + 'Fallback'] = py_impl
+
     return c_impl

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -330,6 +330,9 @@ Spec_clear(Spec* self)
 static void
 Spec_dealloc(Spec* self)
 {
+    /* PyType_GenericAlloc that you get when you don't
+       specify a tp_alloc always tracks the object. */
+    PyObject_GC_UnTrack((PyObject *)self);
     if (self->weakreflist != NULL) {
         PyObject_ClearWeakRefs(OBJECT(self));
     }
@@ -562,7 +565,7 @@ CPB_traverse(CPB* self, visitproc visit, void* arg)
 {
     Py_VISIT(self->_cls);
     Py_VISIT(self->_implements);
-    return 0;
+    return Spec_traverse((Spec*)self, visit, arg);
 }
 
 static int
@@ -570,14 +573,16 @@ CPB_clear(CPB* self)
 {
     Py_CLEAR(self->_cls);
     Py_CLEAR(self->_implements);
+    Spec_clear((Spec*)self);
     return 0;
 }
 
 static void
 CPB_dealloc(CPB* self)
 {
+    PyObject_GC_UnTrack((PyObject *)self);
     CPB_clear(self);
-    Py_TYPE(self)->tp_free(OBJECT(self));
+    Spec_dealloc((Spec*)self);
 }
 
 static PyMemberDef CPB_members[] = {
@@ -798,7 +803,7 @@ IB_traverse(IB* self, visitproc visit, void* arg)
 {
     Py_VISIT(self->__name__);
     Py_VISIT(self->__module__);
-    return 0;
+    return Spec_traverse((Spec*)self, visit, arg);
 }
 
 static int
@@ -806,14 +811,15 @@ IB_clear(IB* self)
 {
     Py_CLEAR(self->__name__);
     Py_CLEAR(self->__module__);
-    return 0;
+    return Spec_clear((Spec*)self);
 }
 
 static void
 IB_dealloc(IB* self)
 {
+    PyObject_GC_UnTrack((PyObject *)self);
     IB_clear(self);
-    Py_TYPE(self)->tp_free(OBJECT(self));
+    Spec_dealloc((Spec*)self);
 }
 
 static PyMemberDef IB_members[] = {

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -603,13 +603,11 @@ class _InterfaceMetaClass(type):
     # make people's heads hurt. (But still less than the descriptor-is-string, I think.)
 
     def __new__(cls, name, bases, attrs):
-        try:
-            # Figure out what module defined the interface.
-            # This is how cPython figures out the module of
-            # a class, but of course it does it in C. :-/
-            __module__ = sys._getframe(1).f_globals['__name__']
-        except (AttributeError, KeyError): # pragma: no cover
-            pass
+        # Figure out what module defined the interface.
+        # This is copied from ``InterfaceClass.__init__``;
+        # reviewers aren't sure how AttributeError or KeyError
+        # could be raised.
+        __module__ = sys._getframe(1).f_globals['__name__']
         # Get the C optimized __module__ accessor and give it
         # to the new class.
         moduledescr = InterfaceBase.__dict__['__module__']

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -169,6 +169,7 @@ class SpecificationBase(object):
 
     __call__ = isOrExtends
 
+
 class NameAndModuleComparisonMixin(object):
     # Internal use. Implement the basic sorting operators (but not (in)equality
     # or hashing). Subclasses must provide ``__name__`` and ``__module__``
@@ -182,6 +183,7 @@ class NameAndModuleComparisonMixin(object):
 
     # pylint:disable=assigning-non-slot
     __slots__ = ()
+
     def _compare(self, other):
         """
         Compare *self* to *other* based on ``__name__`` and ``__module__``.
@@ -193,6 +195,14 @@ class NameAndModuleComparisonMixin(object):
         If *other* does not have ``__name__`` or ``__module__``, then
         return ``NotImplemented``.
 
+        .. caution::
+           This allows comparison to things well outside the type hierarchy,
+           perhaps not symmetrically.
+
+           For example, ``class Foo(object)`` and ``class Foo(Interface)``
+           in the same file would compare equal, depending on the order of
+           operands. Writing code like this by hand would be unusual, but it could
+           happen with dynamic creation of types and interfaces.
 
         None is treated as a pseudo interface that implies the loosest
         contact possible, no contract. For that reason, all interfaces

--- a/src/zope/interface/tests/__init__.py
+++ b/src/zope/interface/tests/__init__.py
@@ -31,3 +31,25 @@ class OptimizationTestMixin(object):
             self.assertIsNot(used, fallback)
         else:
             self.assertIs(used, fallback)
+
+# Be sure cleanup functionality is available; classes that use the adapter hook
+# need to be sure to subclass ``CleanUp``.
+#
+# If zope.component is installed and imported when we run our tests
+# (import chain:
+# zope.testrunner->zope.security->zope.location->zope.component.api)
+# it adds an adapter hook that uses its global site manager. That can cause
+# leakage from one test to another unless its cleanup hooks are run. The symptoms can
+# be odd, especially if one test used C objects and the next used the Python
+# implementation. (For example, you can get strange TypeErrors or find inexplicable
+# comparisons being done.)
+try:
+    from zope.testing import cleanup
+except ImportError:
+    class CleanUp(object):
+        def cleanUp(self):
+            pass
+
+        setUp = tearDown = cleanUp
+else:
+    CleanUp = cleanup.CleanUp

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -17,6 +17,7 @@ import unittest
 
 from zope.interface._compat import _skip_under_py3k
 from zope.interface.tests import OptimizationTestMixin
+from zope.interface.tests.test_interface import NameAndModuleComparisonTestsMixin
 
 
 class _Py3ClassAdvice(object):
@@ -296,7 +297,8 @@ class TestImmutableDeclaration(unittest.TestCase):
         self.assertIsNone(self._getEmpty().get('name'))
         self.assertEqual(self._getEmpty().get('name', 42), 42)
 
-class TestImplements(unittest.TestCase):
+class TestImplements(NameAndModuleComparisonTestsMixin,
+                     unittest.TestCase):
 
     def _getTargetClass(self):
         from zope.interface.declarations import Implements
@@ -304,6 +306,13 @@ class TestImplements(unittest.TestCase):
 
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
+
+    def _makeOneToCompare(self):
+        from zope.interface.declarations import implementedBy
+        class A(object):
+            pass
+
+        return implementedBy(A)
 
     def test_ctor_no_bases(self):
         impl = self._makeOne()

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -25,6 +25,7 @@ import unittest
 
 from zope.interface._compat import _skip_under_py3k
 from zope.interface.tests import OptimizationTestMixin
+from zope.interface.tests import CleanUp
 
 _marker = object()
 
@@ -254,7 +255,7 @@ class SpecificationBasePyTests(GenericSpecificationBaseTests):
             self.assertTrue(sb.providedBy(object()))
 
 
-class InterfaceBaseTestsMixin(object):
+class InterfaceBaseTestsMixin(CleanUp):
     # Tests for both C and Python implementation
 
     def _getTargetClass(self):

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -1121,6 +1121,13 @@ class InterfaceClassTests(unittest.TestCase):
         ISpam.__class__ = MyInterfaceClass
         self.assertEqual(ISpam(1), (1,))
 
+    def test__module__is_readonly(self):
+        inst = self._makeOne()
+        with self.assertRaises((AttributeError, TypeError)):
+            # CPython 2.7 raises TypeError. Everything else
+            # raises AttributeError.
+            inst.__module__ = 'different.module'
+
 
 class InterfaceTests(unittest.TestCase):
 

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -284,7 +284,6 @@ class GenericInterfaceBaseTests(unittest.TestCase):
         self.assertRaises(TypeError, ib, adapted)
 
 
-
 class InterfaceBaseTests(GenericInterfaceBaseTests,
                          OptimizationTestMixin):
     # Tests that work with the C implementation
@@ -1049,6 +1048,7 @@ class InterfaceTests(unittest.TestCase):
 
         self.assertTrue(ICurrent.implementedBy(Current))
         self.assertFalse(IOther.implementedBy(Current))
+        self.assertEqual(ICurrent, ICurrent)
         self.assertTrue(ICurrent in implementedBy(Current))
         self.assertFalse(IOther in implementedBy(Current))
         self.assertTrue(ICurrent in providedBy(current))

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -536,7 +536,7 @@ class InterfaceClassTests(unittest.TestCase):
         self.assertEqual(inst.__name__, 'ITesting')
         self.assertEqual(inst.__doc__, '')
         self.assertEqual(inst.__bases__, ())
-        self.assertEqual(inst.names(), ATTRS.keys())
+        self.assertEqual(list(inst.names()), [])
 
     def test_ctor_attrs_w___annotations__(self):
         ATTRS = {'__annotations__': {}}
@@ -545,7 +545,7 @@ class InterfaceClassTests(unittest.TestCase):
         self.assertEqual(inst.__name__, 'ITesting')
         self.assertEqual(inst.__doc__, '')
         self.assertEqual(inst.__bases__, ())
-        self.assertEqual(inst.names(), ATTRS.keys())
+        self.assertEqual(list(inst.names()), [])
 
     def test_ctor_attrs_w__decorator_non_return(self):
         from zope.interface.interface import _decorator_non_return

--- a/src/zope/interface/tests/test_registry.py
+++ b/src/zope/interface/tests/test_registry.py
@@ -2343,9 +2343,10 @@ class UtilityRegistrationTests(unittest.TestCase):
     def _makeOne(self, component=None, factory=None):
         from zope.interface.declarations import InterfaceClass
 
-        class IFoo(InterfaceClass):
+        class InterfaceClassSubclass(InterfaceClass):
             pass
-        ifoo = IFoo('IFoo')
+
+        ifoo = InterfaceClassSubclass('IFoo')
         class _Registry(object):
             def __repr__(self):
                 return '_REGISTRY'

--- a/src/zope/interface/tests/test_sorting.py
+++ b/src/zope/interface/tests/test_sorting.py
@@ -45,3 +45,20 @@ class Test(unittest.TestCase):
         l = [I1, m1_I1]
         l.sort()
         self.assertEqual(l, [m1_I1, I1])
+
+    def test_I1_I2(self):
+        self.assertLess(I1.__name__, I2.__name__)
+        self.assertEqual(I1.__module__, I2.__module__)
+        self.assertEqual(I1.__module__, __name__)
+        self.assertLess(I1, I2)
+
+    def _makeI1(self):
+        class I1(Interface):
+            pass
+        return I1
+
+    def test_nested(self):
+        nested_I1 = self._makeI1()
+        self.assertEqual(I1, nested_I1)
+        self.assertEqual(nested_I1, I1)
+        self.assertEqual(hash(I1), hash(nested_I1))


### PR DESCRIPTION
Included benchmark numbers:

Current master, Python 3.8:

```
.....................
contains (empty dict): Mean +- std dev: 198 ns +- 5 ns
.....................
contains (populated dict): Mean +- std dev: 197 ns +- 6 ns
.....................
contains (populated list): Mean +- std dev: 53.1 us +- 1.2 us
```
This code:
```
.....................
contains (empty dict): Mean +- std dev: 77.9 ns +- 2.3 ns
.....................
contains (populated dict): Mean +- std dev: 78.4 ns +- 3.1 ns
.....................
contains (populated list): Mean +- std dev: 3.69 us +- 0.08 us
```

So anywhere from 2.5 to 15x faster. Not sure how that will translate to larger (macro) benchmarks, but I'm hopeful. I also need to do some sorting benchmarks (e.g., using interfaces as keys in BTrees).

To make this work, `InterfaceBase` had to extend `SpecificationBase` to get a consistent class layout, and that's where the attributes for `__name__` and `__module__` moved. Neither of those are a public classes, I think.

It turns out that messing with ``__module__`` is nasty, tricky business, especially when you do it from C. Every time you define a new subclass, the descriptors that you set get overridden by the type machinery (PyType_Ready), and there are differences between Python 2 and 3. I'm using a data descriptor and a meta class right now to avoid that but I'm not super happy with that and would like to find a better way. (At least, maybe the data part of the descriptor isn't necessary?) It may be needed to move more code into C, I don't want a slowdown accessing ``__module__`` either; copying around the standard PyGetSet or PyMember descriptors isn't enough because they don't work on the class object (so ``classImplements(InterfaceClass, IInterface)`` fails).

There's currently one example doctest failure due to a changed class name.