### PR TITLE
Ensure Interface is the last item in the __sro__.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -160,7 +160,7 @@
 
 - Adopt Python's standard `C3 resolution order
   <https://www.python.org/download/releases/2.3/mro/>`_ to compute the
-  ``__iro___`` and ``__sro___`` of interfaces, with tweaks to support
+  ``__iro__`` and ``__sro__`` of interfaces, with tweaks to support
   additional cases that are common in interfaces but disallowed for
   Python classes. Previously, an ad-hoc ordering that made no
   particular guarantees was used.
@@ -203,6 +203,12 @@
   allow accessing tagged values irrespective of inheritance. See
   `issue 190
   <https://github.com/zopefoundation/zope.interface/issues/190>`_.
+
+- Ensure that ``Interface`` is always the last item in the ``__iro__``
+  and ``__sro__``. This is usually the case, but if classes that do
+  not implement any interfaces are part of a class inheritance
+  hierarchy, ``Interface`` could be assigned too high a priority.
+  See `issue 8 <https://github.com/zopefoundation/zope.interface/issues/8>`_.
 
 
 4.7.2 (2020-03-10)

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -689,9 +689,22 @@ that lists the specification and all of it's ancestors:
    <InterfaceClass builtins.IBaz>,
    <InterfaceClass builtins.IFoo>,
    <InterfaceClass builtins.IBlat>,
-   <InterfaceClass zope.interface.Interface>,
-   <implementedBy ...object>)
-
+   <implementedBy ...object>,
+   <InterfaceClass zope.interface.Interface>)
+  >>> class IBiz(zope.interface.Interface):
+  ...    pass
+  >>> @zope.interface.implementer(IBiz)
+  ... class Biz(Baz):
+  ...    pass
+  >>> pprint(zope.interface.implementedBy(Biz).__sro__)
+  (<implementedBy builtins.Biz>,
+   <InterfaceClass builtins.IBiz>,
+   <implementedBy builtins.Baz>,
+   <InterfaceClass builtins.IBaz>,
+   <InterfaceClass builtins.IFoo>,
+   <InterfaceClass builtins.IBlat>,
+   <implementedBy ...object>,
+   <InterfaceClass zope.interface.Interface>)
 
 Tagged Values
 =============

--- a/src/zope/interface/tests/test_ro.py
+++ b/src/zope/interface/tests/test_ro.py
@@ -375,6 +375,27 @@ Object <InterfaceClass zope.interface.tests.test_ro.A> has different legacy and 
         self.assertEqual(iro, legacy_iro)
 
 
+class TestC3(unittest.TestCase):
+    def _makeOne(self, C, strict=False, base_mros=None):
+        from zope.interface.ro import C3
+        return C3.resolver(C, strict, base_mros)
+
+    def test_base_mros_given(self):
+        c3 = self._makeOne(type(self), base_mros={unittest.TestCase: unittest.TestCase.__mro__})
+        memo = c3.memo
+        self.assertIn(unittest.TestCase, memo)
+        # We used the StaticMRO class
+        self.assertIsNone(memo[unittest.TestCase].had_inconsistency)
+
+    def test_one_base_optimization(self):
+        c3 = self._makeOne(type(self))
+        # Even though we didn't call .mro() yet, the MRO has been
+        # computed.
+        self.assertIsNotNone(c3._C3__mro) # pylint:disable=no-member
+        c3._merge = None
+        self.assertEqual(c3.mro(), list(type(self).__mro__))
+
+
 class Test_ROComparison(unittest.TestCase):
 
     class MockC3(object):


### PR DESCRIPTION
None of the elegant solutions mentioned in the issue worked out, so I had to brute force it.

Fixes #8

Plone's buildout.coredev tests show no new regressions.