### PR TITLE
Documentation clarifications.

### DIFF
--- a/src/zope/interface/interfaces.py
+++ b/src/zope/interface/interfaces.py
@@ -269,7 +269,7 @@ class IInterface(ISpecification, IElement):
     def names(all=False):
         """Get the interface attribute names
 
-        Return a sequence of the names of the attributes, including
+        Return a collection of the names of the attributes, including
         methods, included in the interface definition.
 
         Normally, only directly defined attributes are included. If
@@ -280,7 +280,7 @@ class IInterface(ISpecification, IElement):
     def namesAndDescriptions(all=False):
         """Get the interface attribute names and descriptions
 
-        Return a sequence of the names and descriptions of the
+        Return a collection of the names and descriptions of the
         attributes, including methods, as name-value pairs, included
         in the interface definition.
 


### PR DESCRIPTION
- docs/adapter.rst
  Subscriptions are returned from least to most specific, not the other way around; the docs were incorrect.

  Add additional examples, and use more verbose names in current examples, to clarify this. Fixes #136.
- interfaces.py
  names() and namesAndDescriptions() just return a collection, not a sequence. Fixes #134.