### PR TITLE
Make Interface.getTaggedValue follow the __iro__.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,16 +5,6 @@
 5.0.0 (unreleased)
 ==================
 
-- Adopt Python's standard `C3 resolution order
-  <https://www.python.org/download/releases/2.3/mro/>`_ for interface
-  linearization, with tweaks to support additional cases that are
-  common in interfaces but disallowed for Python classes.
-
-  In complex multiple-inheritance like scenerios, this may change the
-  interface resolution order, resulting in finding different adapters.
-  However, the results should make more sense. See `issue 21
-  <https://github.com/zopefoundation/zope.interface/issues/21>`_.
-
 - Make an internal singleton object returned by APIs like
   ``implementedBy`` and ``directlyProvidedBy`` immutable. Previously,
   it was fully mutable and allowed changing its ``__bases___``. That
@@ -56,6 +46,12 @@
 
   The changes in this release resulted in a 7% memory reduction after
   loading about 6,000 modules that define about 2,200 interfaces.
+
+  .. caution::
+
+     Details of many private attributes have changed, and external use
+     of those private attributes may break. In particular, the
+     lifetime and default value of ``_v_attrs`` has changed.
 
 - Remove support for hashing uninitialized interfaces. This could only
   be done by subclassing ``InterfaceClass``. This has generated a
@@ -162,9 +158,12 @@
 - Fix a potential interpreter crash in the low-level adapter
   registry lookup functions. See issue 11.
 
-- Use Python's standard C3 resolution order to compute the
-  ``__iro___`` and ``__sro___`` of interfaces. Previously, an ad-hoc
-  ordering that made no particular guarantees was used.
+- Adopt Python's standard `C3 resolution order
+  <https://www.python.org/download/releases/2.3/mro/>`_ to compute the
+  ``__iro___`` and ``__sro___`` of interfaces, with tweaks to support
+  additional cases that are common in interfaces but disallowed for
+  Python classes. Previously, an ad-hoc ordering that made no
+  particular guarantees was used.
 
   This has many beneficial properties, including the fact that base
   interface and base classes tend to appear near the end of the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -195,6 +195,17 @@
   the future). For details, see the documentation for
   ``zope.interface.ro``.
 
+- Make inherited tagged values in interfaces respect the resolution
+  order (``__iro__``), as method and attribute lookup does. Previously
+  tagged values could give inconsistent results. See `issue 190
+  <https://github.com/zopefoundation/zope.interface/issues/190>`_.
+
+- Add ``getDirectTaggedValue`` (and related methods) to interfaces to
+  allow accessing tagged values irrespective of inheritance. See
+  `issue 190
+  <https://github.com/zopefoundation/zope.interface/issues/190>`_.
+
+
 4.7.2 (2020-03-10)
 ==================
 
@@ -214,9 +225,12 @@
 
 - Drop support for Python 3.4.
 
-- Fix ``queryTaggedValue``, ``getTaggedValue``, ``getTaggedValueTags``
-  subclass inheritance. See `PR 144
+- Change ``queryTaggedValue``, ``getTaggedValue``,
+  ``getTaggedValueTags`` in interfaces. They now include inherited
+  values by following ``__bases__``. See `PR 144
   <https://github.com/zopefoundation/zope.interface/pull/144>`_.
+
+  .. caution:: This may be a breaking change.
 
 - Add support for Python 3.8.
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -736,6 +736,28 @@ Tagged values can also be defined from within an interface definition:
   >>> IWithTaggedValues.getTaggedValue('squish')
   'squash'
 
+Tagged values are inherited in the same way that attribute and method
+descriptions are. Inheritance can be ignored by using the "direct"
+versions of functions.
+
+.. doctest::
+
+   >>> class IExtendsIWithTaggedValues(IWithTaggedValues):
+   ...     zope.interface.taggedValue('child', True)
+   >>> IExtendsIWithTaggedValues.getTaggedValue('child')
+   True
+   >>> IExtendsIWithTaggedValues.getDirectTaggedValue('child')
+   True
+   >>> IExtendsIWithTaggedValues.getTaggedValue('squish')
+   'squash'
+   >>> print(IExtendsIWithTaggedValues.queryDirectTaggedValue('squish'))
+   None
+   >>> IExtendsIWithTaggedValues.setTaggedValue('squish', 'SQUASH')
+   >>> IExtendsIWithTaggedValues.getTaggedValue('squish')
+   'SQUASH'
+   >>> IExtendsIWithTaggedValues.getDirectTaggedValue('squish')
+   'SQUASH'
+
 Invariants
 ==========
 

--- a/docs/api/declarations.rst
+++ b/docs/api/declarations.rst
@@ -16,7 +16,7 @@ carefully at each object it documents, including providing examples.
 .. autointerface:: zope.interface.interfaces.IInterfaceDeclaration
 
 
-.. currentmodule:: zope.interface.declarations
+.. currentmodule:: zope.interface
 
 Declaring The Interfaces of Objects
 ===================================
@@ -536,7 +536,7 @@ You'll notice that an ``IDeclaration`` is a type of
 implementedBy
 -------------
 
-.. autofunction:: implementedByFallback
+.. autofunction:: implementedBy
 
 
 Consider the following example:
@@ -774,7 +774,7 @@ Exmples for :meth:`Declaration.__add__`:
 ProvidesClass
 -------------
 
-.. autoclass:: ProvidesClass
+.. autoclass:: zope.interface.declarations.ProvidesClass
 
 
 Descriptor semantics (via ``Provides.__get__``):
@@ -851,7 +851,7 @@ collect function to help with this:
 ObjectSpecification
 -------------------
 
-.. autofunction:: ObjectSpecification
+.. autofunction:: zope.interface.declarations.ObjectSpecification
 
 
 For example:
@@ -924,7 +924,7 @@ For example:
 ObjectSpecificationDescriptor
 -----------------------------
 
-.. autoclass:: ObjectSpecificationDescriptor
+.. autoclass:: zope.interface.declarations.ObjectSpecificationDescriptor
 
 For example:
 

--- a/docs/api/specifications.rst
+++ b/docs/api/specifications.rst
@@ -23,6 +23,7 @@ Specification objects implement the API defined by
    :member-order: bysource
 
 .. autoclass:: zope.interface.interface.Specification
+   :no-members:
 
 For example:
 
@@ -172,7 +173,22 @@ first is that of an "element", which provides us a simple way to query
 for information generically (this is important because we'll see that
 ``IInterface`` implements this interface):
 
+..
+  IElement defines __doc__ to be an Attribute, so the docstring
+  in the class isn't used._
+
 .. autointerface:: IElement
+
+   Objects that have basic documentation and tagged values.
+
+   Known derivatives include :class:`IAttribute` and its derivative
+   :class:`IMethod`; these have no notion of inheritance.
+   :class:`IInterface` is also a derivative, and it does have a
+   notion of inheritance, expressed through its ``__bases__`` and
+   ordered in its ``__iro__`` (both defined by
+   :class:`ISpecification`).
+
+
 .. autoclass:: zope.interface.interface.Element
    :no-members:
 

--- a/docs/api/specifications.rst
+++ b/docs/api/specifications.rst
@@ -197,14 +197,17 @@ content, or body, of an ``Interface``.
 
 .. autointerface:: zope.interface.interfaces.IAttribute
 .. autoclass:: zope.interface.interface.Attribute
+   :no-members:
 
-.. autoclass:: IMethod
+.. autointerface:: IMethod
+.. autoclass:: zope.interface.interface.Method
+   :no-members:
 
 Finally we can look at the definition of ``IInterface``.
 
 .. autointerface:: IInterface
 
-.. autoclass:: zope.interface.Interface
+.. autointerface:: zope.interface.Interface
 
 Usage
 -----

--- a/src/zope/interface/interfaces.py
+++ b/src/zope/interface/interfaces.py
@@ -150,25 +150,26 @@ class IMethod(IAttribute):
     def getSignatureInfo():
         """Returns the signature information.
 
-        This method returns a dictionary with the following keys:
+        This method returns a dictionary with the following string keys:
 
-        o `positional` - All positional arguments.
-
-        o `required` - A list of all required arguments.
-
-        o `optional` - A list of all optional arguments.
-
-        o `varargs` - The name of the varargs argument.
-
-        o `kwargs` - The name of the kwargs argument.
+        - positional
+            A sequence of the names of positional arguments.
+        - required
+            A sequence of the names of required arguments.
+        - optional
+            A dictionary mapping argument names to their default values.
+        - varargs
+            The name of the varargs argument (or None).
+        - kwargs
+            The name of the kwargs argument (or None).
         """
 
     def getSignatureString():
         """Return a signature string suitable for inclusion in documentation.
 
         This method returns the function signature string. For example, if you
-        have `func(a, b, c=1, d='f')`, then the signature string is `(a, b,
-        c=1, d='f')`.
+        have ``def func(a, b, c=1, d='f')``, then the signature string is ``"(a, b,
+        c=1, d='f')"``.
         """
 
 class ISpecification(Interface):


### PR DESCRIPTION
Previously it manually walked up __bases__, meaning the answers could be inconsistent.

Fixes #190.

Also fixes several minor issues in the documentation, mostly cross-reference related.