### PR TITLE
Remove the bare except: statements.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,30 @@
  Changes
 =========
 
-5.0.3 (unreleased)
+5.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Remove all bare ``except:`` statements. Previously, when accessing
+  special attributes such as ``__provides__``, ``__providedBy__``,
+  ``__class__`` and ``__conform__``, this package wrapped such access
+  in a bare ``except:`` statement, meaning that many errors could pass
+  silently; typically this would result in a fallback path being taken
+  and sometimes (like with ``providedBy()``) the result would be
+  non-sensical. This is especially true when those attributes are
+  implemented with descriptors. Now, only ``AttributeError`` is
+  caught. This makes errors more obvious.
+
+  Obviously, this means that some exceptions will be propagated
+  differently than before. In particular, ``RuntimeError`` raised by
+  Acquisition in the case of circular containment will now be
+  propagated. Previously, when adapting such a broken object, a
+  ``TypeError`` would be the common result, but now it will be a more
+  informative ``RuntimeError``.
+
+  In addition, ZODB errors like ``POSKeyError`` could now be
+  propagated where previously they would ignored by this package.
+
+  See `issue 200 <https://github.com/zopefoundation/zope.interface/issues/200>`_.
 
 
 5.0.2 (2020-03-30)

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -799,9 +799,9 @@ static PyObject *
 ib_call(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   PyObject *conform, *obj, *alternate, *adapter;
+  static char *kwlist[] = {"obj", "alternate", NULL};
   conform = obj = alternate = adapter = NULL;
 
-  static char *kwlist[] = {"obj", "alternate", NULL};
 
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O", kwlist,
                                    &obj, &alternate))

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -984,6 +984,7 @@ def moduleProvides(*interfaces):
 
 # XXX:  is this a fossil?  Nobody calls it, no unit tests exercise it, no
 #       doctests import it, and the package __init__ doesn't import it.
+#       (Answer: Versions of zope.container prior to 4.4.0 called this.)
 def ObjectSpecification(direct, cls):
     """Provide object specifications
 
@@ -994,16 +995,17 @@ def ObjectSpecification(direct, cls):
 @_use_c_impl
 def getObjectSpecification(ob):
     try:
-        provides = getattr(ob, '__provides__', None)
-    except:
+        provides = ob.__provides__
+    except AttributeError:
         provides = None
+
     if provides is not None:
         if isinstance(provides, SpecificationBase):
             return provides
 
     try:
         cls = ob.__class__
-    except:
+    except AttributeError:
         # We can't get the class, so just consider provides
         return _empty
     return implementedBy(cls)
@@ -1028,7 +1030,7 @@ def providedBy(ob):
             return implementedBy(ob)
 
         r = ob.__providedBy__
-    except:
+    except AttributeError:
         # Not set yet. Fall back to lower-level thing that computes it
         return getObjectSpecification(ob)
 

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -275,16 +275,10 @@ class InterfaceBase(NameAndModuleComparisonMixin, SpecificationBasePy):
         """Adapt an object to the interface
         """
         try:
-            conform = getattr(obj, '__conform__', None)
-        # XXX: Ideally, we don't want to catch BaseException. Things
-        # like MemoryError, KeyboardInterrupt, and other BaseExceptions should
-        # get through. Here, and everywhere we have bare ``except:`` clauses.
-        # The bare ``except:`` clauses exist for compatibility with the C code in
-        # ``_zope_interface_coptimizations.c`` (``ib_call()`` in this case). Both
-        # implementations would need to change. But beware of things like proxies and
-        # Acquisition wrappers. See https://github.com/zopefoundation/zope.interface/issues/163
-        except: # pylint:disable=bare-except
+            conform = obj.__conform__
+        except AttributeError:
             conform = None
+
         if conform is not None:
             adapter = self._call_conform(conform)
             if adapter is not None:

--- a/src/zope/interface/tests/__init__.py
+++ b/src/zope/interface/tests/__init__.py
@@ -32,6 +32,66 @@ class OptimizationTestMixin(object):
         else:
             self.assertIs(used, fallback)
 
+
+class MissingSomeAttrs(object):
+    """
+    Helper for tests that raises a specific exception
+    for attributes that are missing. This is usually not
+    an AttributeError, and this object is used to test that
+    those errors are not improperly caught and treated like
+    an AttributeError.
+    """
+
+    def __init__(self, exc_kind, **other_attrs):
+        self.__exc_kind = exc_kind
+        d = object.__getattribute__(self, '__dict__')
+        d.update(other_attrs)
+
+    def __getattribute__(self, name):
+        # Note that we ignore objects found in the class dictionary.
+        d = object.__getattribute__(self, '__dict__')
+        try:
+            return d[name]
+        except KeyError:
+            raise d['_MissingSomeAttrs__exc_kind'](name)
+
+    EXCEPTION_CLASSES = (
+        TypeError,
+        RuntimeError,
+        BaseException,
+        ValueError,
+    )
+
+    @classmethod
+    def test_raises(cls, unittest, test_func, expected_missing, **other_attrs):
+        """
+        Loop through various exceptions, calling *test_func* inside a ``assertRaises`` block.
+
+        :param test_func: A callable of one argument, the instance of this
+            class.
+        :param str expected_missing: The attribute that should fail with the exception.
+           This is used to ensure that we're testing the path we think we are.
+        :param other_attrs: Attributes that should be provided on the test object.
+           Must not contain *expected_missing*.
+        """
+        assert isinstance(expected_missing, str)
+        assert expected_missing not in other_attrs
+        for exc in cls.EXCEPTION_CLASSES:
+            ob = cls(exc, **other_attrs)
+            with unittest.assertRaises(exc) as ex:
+                test_func(ob)
+
+            unittest.assertEqual(ex.exception.args[0], expected_missing)
+
+        # Now test that the AttributeError for that expected_missing is *not* raised.
+        ob = cls(AttributeError, **other_attrs)
+        try:
+            test_func(ob)
+        except AttributeError as e:
+            unittest.assertNotIn(expected_missing, str(e))
+        except Exception: # pylint:disable=broad-except
+            pass
+
 # Be sure cleanup functionality is available; classes that use the adapter hook
 # need to be sure to subclass ``CleanUp``.
 #

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -17,21 +17,32 @@ import unittest
 
 from zope.interface.tests import OptimizationTestMixin
 
+# pylint:disable=inherit-non-class,protected-access,too-many-lines
+# pylint:disable=attribute-defined-outside-init,blacklisted-name
 
 def _makeInterfaces():
     from zope.interface import Interface
 
-    class IB0(Interface): pass
-    class IB1(IB0): pass
-    class IB2(IB0): pass
-    class IB3(IB2, IB1): pass
-    class IB4(IB1, IB2): pass
+    class IB0(Interface):
+        pass
+    class IB1(IB0):
+        pass
+    class IB2(IB0):
+        pass
+    class IB3(IB2, IB1):
+        pass
+    class IB4(IB1, IB2):
+        pass
 
-    class IF0(Interface): pass
-    class IF1(IF0): pass
+    class IF0(Interface):
+        pass
+    class IF1(IF0):
+        pass
 
-    class IR0(Interface): pass
-    class IR1(IR0): pass
+    class IR0(Interface):
+        pass
+    class IR1(IR0):
+        pass
 
     return IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1
 
@@ -51,7 +62,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
                     self._extendors += (provided,)
                 def remove_extendor(self, provided):
                     self._extendors = tuple([x for x in self._extendors
-                                                    if x != provided])
+                                             if x != provided])
         for name in BaseAdapterRegistry._delegated:
             setattr(_CUT.LookupClass, name, object())
         return _CUT
@@ -80,13 +91,14 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(registry._v_lookup._changed, (registry, orig,))
 
     def test__generation_after_changing___bases__(self):
-        class _Base(object): pass
+        class _Base(object):
+            pass
         registry = self._makeOne()
         registry.__bases__ = (_Base,)
         self.assertEqual(registry._generation, 2)
 
     def test_register(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.register([IB0], IR0, '', 'A1')
         self.assertEqual(registry.registered([IB0], IR0, ''), 'A1')
@@ -94,20 +106,20 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(registry._generation, 2)
 
     def test_register_with_invalid_name(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         with self.assertRaises(ValueError):
             registry.register([IB0], IR0, object(), 'A1')
 
     def test_register_with_value_None_unregisters(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.register([None], IR0, '', 'A1')
         registry.register([None], IR0, '', None)
         self.assertEqual(len(registry._adapters), 0)
 
     def test_register_with_same_value(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         _value = object()
         registry.register([None], IR0, '', _value)
@@ -120,7 +132,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(registry.registered([None], None, ''), None)
 
     def test_registered_non_empty_miss(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.register([IB1], None, '', 'A1')
         self.assertEqual(registry.registered([IB2], None, ''), None)
@@ -136,21 +148,21 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(registry.registered([None], None, ''), None)
 
     def test_unregister_non_empty_miss_on_required(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.register([IB1], None, '', 'A1')
         registry.unregister([IB2], None, '') #doesn't raise
         self.assertEqual(registry.registered([IB1], None, ''), 'A1')
 
     def test_unregister_non_empty_miss_on_name(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.register([IB1], None, '', 'A1')
         registry.unregister([IB1], None, 'nonesuch') #doesn't raise
         self.assertEqual(registry.registered([IB1], None, ''), 'A1')
 
     def test_unregister_with_value_not_None_miss(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         orig = object()
         nomatch = object()
@@ -159,7 +171,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertTrue(registry.registered([IB1], None, '') is orig)
 
     def test_unregister_hit_clears_empty_subcomponents(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         one = object()
         another = object()
@@ -177,7 +189,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(registry.registered([None], None, ''), None)
 
     def test_unsubscribe_hit(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         orig = object()
         registry.subscribe([IB1], None, orig)
@@ -185,7 +197,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(len(registry._subscribers), 0)
 
     def test_unsubscribe_after_multiple(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         first = object()
         second = object()
@@ -202,18 +214,18 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(len(registry._subscribers), 0)
 
     def test_unsubscribe_w_None_after_multiple(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         first = object()
         second = object()
-        third = object()
+
         registry.subscribe([IB1], None, first)
         registry.subscribe([IB1], None, second)
         registry.unsubscribe([IB1], None)
         self.assertEqual(len(registry._subscribers), 0)
 
     def test_unsubscribe_non_empty_miss_on_required(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.subscribe([IB1], None, 'A1')
         self.assertEqual(len(registry._subscribers), 2)
@@ -221,7 +233,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(len(registry._subscribers), 2)
 
     def test_unsubscribe_non_empty_miss_on_value(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.subscribe([IB1], None, 'A1')
         self.assertEqual(len(registry._subscribers), 2)
@@ -229,7 +241,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(len(registry._subscribers), 2)
 
     def test_unsubscribe_with_value_not_None_miss(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         orig = object()
         nomatch = object()
@@ -241,7 +253,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.fail("Example method, not intended to be called.")
 
     def test_unsubscribe_instance_method(self):
-        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces()
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         self.assertEqual(len(registry._subscribers), 0)
         registry.subscribe([IB1], None, self._instance_method_notify_target)
@@ -252,13 +264,14 @@ class BaseAdapterRegistryTests(unittest.TestCase):
 class LookupBaseFallbackTests(unittest.TestCase):
 
     def _getFallbackClass(self):
-        from zope.interface.adapter import LookupBaseFallback
+        from zope.interface.adapter import LookupBaseFallback # pylint:disable=no-name-in-module
         return LookupBaseFallback
 
     _getTargetClass = _getFallbackClass
 
     def _makeOne(self, uc_lookup=None, uc_lookupAll=None,
                  uc_subscriptions=None):
+        # pylint:disable=function-redefined
         if uc_lookup is None:
             def uc_lookup(self, required, provided, name):
                 pass
@@ -285,7 +298,7 @@ class LookupBaseFallbackTests(unittest.TestCase):
         _called_with = []
         def _lookup(self, required, provided, name):
             _called_with.append((required, provided, name))
-            return None
+
         lb = self._makeOne(uc_lookup=_lookup)
         found = lb.lookup(('A',), 'B', 'C')
         self.assertTrue(found is None)
@@ -296,7 +309,7 @@ class LookupBaseFallbackTests(unittest.TestCase):
         _default = object()
         def _lookup(self, required, provided, name):
             _called_with.append((required, provided, name))
-            return None
+
         lb = self._makeOne(uc_lookup=_lookup)
         found = lb.lookup(('A',), 'B', 'C', _default)
         self.assertTrue(found is _default)
@@ -384,7 +397,7 @@ class LookupBaseFallbackTests(unittest.TestCase):
         _called_with = []
         def _lookup(self, required, provided, name):
             _called_with.append((required, provided, name))
-            return None
+
         lb = self._makeOne(uc_lookup=_lookup)
         found = lb.lookup1('A', 'B', 'C')
         self.assertTrue(found is None)
@@ -395,7 +408,7 @@ class LookupBaseFallbackTests(unittest.TestCase):
         _default = object()
         def _lookup(self, required, provided, name):
             _called_with.append((required, provided, name))
-            return None
+
         lb = self._makeOne(uc_lookup=_lookup)
         found = lb.lookup1('A', 'B', 'C', _default)
         self.assertTrue(found is _default)
@@ -406,7 +419,7 @@ class LookupBaseFallbackTests(unittest.TestCase):
         _default = object()
         def _lookup(self, required, provided, name):
             _called_with.append((required, provided, name))
-            return None
+
         lb = self._makeOne(uc_lookup=_lookup)
         found = lb.lookup1('A', 'B', 'C', _default)
         self.assertTrue(found is _default)
@@ -479,7 +492,7 @@ class LookupBaseFallbackTests(unittest.TestCase):
         _f_called_with = []
         def _factory(context):
             _f_called_with.append(context)
-            return None
+
         def _lookup(self, required, provided, name):
             return _factory
         req, prv, _default = object(), object(), object()
@@ -588,13 +601,14 @@ class LookupBaseTests(LookupBaseFallbackTests,
 class VerifyingBaseFallbackTests(unittest.TestCase):
 
     def _getFallbackClass(self):
-        from zope.interface.adapter import VerifyingBaseFallback
+        from zope.interface.adapter import VerifyingBaseFallback # pylint:disable=no-name-in-module
         return VerifyingBaseFallback
 
     _getTargetClass = _getFallbackClass
 
     def _makeOne(self, registry, uc_lookup=None, uc_lookupAll=None,
                  uc_subscriptions=None):
+        # pylint:disable=function-redefined
         if uc_lookup is None:
             def uc_lookup(self, required, provided, name):
                 raise NotImplementedError()
@@ -641,7 +655,7 @@ class VerifyingBaseFallbackTests(unittest.TestCase):
         found = lb.lookup(('A',), 'B', 'C')
         self.assertTrue(found is b)
         self.assertEqual(_called_with,
-                        [(('A',), 'B', 'C'), (('A',), 'B', 'C')])
+                         [(('A',), 'B', 'C'), (('A',), 'B', 'C')])
         self.assertEqual(_results, [c])
 
     def test_lookup1(self):
@@ -662,7 +676,7 @@ class VerifyingBaseFallbackTests(unittest.TestCase):
         found = lb.lookup1('A', 'B', 'C')
         self.assertTrue(found is b)
         self.assertEqual(_called_with,
-                        [(('A',), 'B', 'C'), (('A',), 'B', 'C')])
+                         [(('A',), 'B', 'C'), (('A',), 'B', 'C')])
         self.assertEqual(_results, [c])
 
     def test_adapter_hook(self):
@@ -815,8 +829,7 @@ class AdapterLookupBaseTests(unittest.TestCase):
             def __init__(self, here):
                 self._here = here
             def __call__(self):
-                if self._here:
-                    return self
+                return self if self._here else None
             def unsubscribe(self, target):
                 self._unsub = target
         gone = FauxWeakref(False)
@@ -939,7 +952,7 @@ class AdapterLookupBaseTests(unittest.TestCase):
         IBar = InterfaceClass('IBar', IFoo)
         registry = self._makeRegistry(IFoo, IBar)
         subr = self._makeSubregistry()
-        irrelevant = object()
+
         wrongname = object()
         subr._adapters = [ #utilities, single adapters
             {},
@@ -1012,22 +1025,27 @@ class AdapterLookupBaseTests(unittest.TestCase):
         self.assertTrue(result is _default)
 
     def test_queryMultiAdapter_errors_on_attribute_access(self):
-        # Which leads to using the _empty singleton as "requires"
-        # argument. See https://github.com/zopefoundation/zope.interface/issues/162
+        # Any error on attribute access previously lead to using the _empty singleton as "requires"
+        # argument (See https://github.com/zopefoundation/zope.interface/issues/162)
+        # but after https://github.com/zopefoundation/zope.interface/issues/200
+        # they get propagated.
         from zope.interface.interface import InterfaceClass
+        from zope.interface.tests import MissingSomeAttrs
+
         IFoo = InterfaceClass('IFoo')
         registry = self._makeRegistry()
         alb = self._makeOne(registry)
         alb.lookup = alb._uncached_lookup
-        class UnexpectedErrorsLikeAcquisition(object):
 
-            def __getattribute__(self, name):
-                raise RuntimeError("Acquisition does this. Ha-ha!")
+        def test(ob):
+            return alb.queryMultiAdapter(
+                (ob,),
+                IFoo,
+            )
 
-        result = alb.queryMultiAdapter(
-            (UnexpectedErrorsLikeAcquisition(),),
-            IFoo,
-        )
+        PY3 = str is not bytes
+        MissingSomeAttrs.test_raises(self, test,
+                                     expected_missing='__class__' if PY3 else '__providedBy__')
 
     def test_queryMultiAdaptor_factory_miss(self):
         from zope.interface.declarations import implementer
@@ -1044,7 +1062,7 @@ class AdapterLookupBaseTests(unittest.TestCase):
         _called_with = []
         def _factory(context):
             _called_with.append(context)
-            return None
+
         subr._adapters = [ #utilities, single adapters
             {},
             {IFoo: {IBar: {'': _factory}}},
@@ -1343,7 +1361,7 @@ class AdapterLookupBaseTests(unittest.TestCase):
             return _exp2
         def _side_effect_only(context):
             _called.setdefault('_side_effect_only', []).append(context)
-            return None
+
         subr._subscribers = [ #utilities, single adapters
             {},
             {IFoo: {IBar: {'': (_factory1, _factory2, _side_effect_only)}}},
@@ -1441,13 +1459,12 @@ class Test_utils(unittest.TestCase):
         self.assertTrue(_convert_None_to_Interface(other) is other)
 
     def test__normalize_name_str(self):
-        import sys
         from zope.interface.adapter import _normalize_name
         STR = b'str'
-        if sys.version_info[0] < 3:
-            self.assertEqual(_normalize_name(STR), unicode(STR))
-        else:
-            self.assertEqual(_normalize_name(STR), str(STR, 'ascii'))
+        UNICODE = u'str'
+        norm = _normalize_name(STR)
+        self.assertEqual(norm, UNICODE)
+        self.assertIsInstance(norm, type(UNICODE))
 
     def test__normalize_name_unicode(self):
         from zope.interface.adapter import _normalize_name

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -24,6 +24,7 @@
 import unittest
 
 from zope.interface._compat import _skip_under_py3k
+from zope.interface.tests import MissingSomeAttrs
 from zope.interface.tests import OptimizationTestMixin
 from zope.interface.tests import CleanUp
 
@@ -396,8 +397,13 @@ class InterfaceBaseTestsMixin(NameAndModuleComparisonTestsMixin):
 
     def test___call___w___conform___ob_no_provides_wo_alternate(self):
         ib = self._makeOne(False)
-        adapted = object()
-        self.assertRaises(TypeError, ib, adapted)
+        with self.assertRaises(TypeError) as exc:
+            ib(object())
+
+        self.assertIn('Could not adapt', str(exc.exception))
+
+    def test___call___w_no_conform_catches_only_AttributeError(self):
+        MissingSomeAttrs.test_raises(self, self._makeOne(), expected_missing='__conform__')
 
 
 class InterfaceBaseTests(InterfaceBaseTestsMixin,


### PR DESCRIPTION
Only catch AttributeError instead of everything.

Fixes #200

Note that this does break a doctest in five.intid (it's expecting a TypeError but it now gets Acquisition's RuntimeError).