### PR TITLE
Make @implementer and classImplements not add redundant interfaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,14 @@
 5.1.0 (unreleased)
 ==================
 
+- Make ``@implementer(*iface)`` and ``classImplements(cls, *iface)``
+  ignore redundant interfaces. If the class already implements an
+  interface through inheritance, it is no longer redeclared
+  specifically for *cls*. This solves many instances of inconsistent
+  resolution orders, while still allowing the interface to be declared
+  for readability and maintenance purposes. See `issue 199
+  <https://github.com/zopefoundation/zope.interface/issues/199>`_.
+
 - Remove all bare ``except:`` statements. Previously, when accessing
   special attributes such as ``__provides__``, ``__providedBy__``,
   ``__class__`` and ``__conform__``, this package wrapped such access

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -518,7 +518,7 @@ declarations. Here's a silly example:
   ...     zope.interface.implementedBy(Foo),
   ...     ISpecial,
   ... )
-  ... class Special2(Foo):
+  ... class Special2(object):
   ...     reason = 'I just am'
   ...     def brag(self):
   ...         return "I'm special because %s" % self.reason

--- a/docs/api/declarations.rst
+++ b/docs/api/declarations.rst
@@ -208,31 +208,34 @@ interfaces instances of ``A`` and ``B`` provide.
 
 Instances of ``C`` now also provide ``I5``. Notice how ``I5`` was
 added to the *beginning* of the list of things provided directly by
-``C``. Unlike `classImplements`, this ignores inheritance and other
-factors and does not attempt to ensure a consistent resolution order.
+``C``. Unlike `classImplements`, this ignores interface inheritance
+and does not attempt to ensure a consistent resolution order (except
+that it continues to elide interfaces already implemented through
+class inheritance)::
 
 .. doctest::
 
-   >>> class IBA(IB, IA): pass
+   >>> class IBA(IB, IA):
+   ...     pass
    >>> classImplementsFirst(C, IBA)
    >>> classImplementsFirst(C, IA)
    >>> [i.getName() for i in implementedBy(C)]
-   ['IA', 'IBA', 'I5', 'I1', 'I2', 'IB']
+   ['IBA', 'I5', 'I1', 'I2', 'IA', 'IB']
 
 This cannot be used to introduce duplicates.
 
 .. doctest::
 
    >>> len(implementedBy(C).declared)
-   5
+   4
    >>> classImplementsFirst(C, IA)
    >>> classImplementsFirst(C, IBA)
    >>> classImplementsFirst(C, IA)
    >>> classImplementsFirst(C, IBA)
    >>> [i.getName() for i in implementedBy(C)]
-   ['IBA', 'IA', 'I5', 'I1', 'I2', 'IB']
+   ['IBA', 'I5', 'I1', 'I2', 'IA', 'IB']
    >>> len(implementedBy(C).declared)
-   5
+   4
 
 
 directlyProvides

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -431,8 +431,13 @@ def classImplementsOnly(cls, *interfaces):
     in *interfaces*. This can be used to alter the interface resolution order.
     """
     spec = implementedBy(cls)
+    # Clear out everything inherited. It's important to
+    # also clear the bases right now so that we don't improperly discard
+    # interfaces that are already implemented by *old* bases that we're
+    # about to get rid of.
     spec.declared = ()
     spec.inherit = None
+    spec.__bases__ = ()
     _classImplements_ordered(spec, interfaces, ())
 
 

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -890,6 +890,25 @@ class Test_classImplements(unittest.TestCase):
             pass
         self.__check_implementer_redundant(Foo)
 
+    def test_redundant_implementer_Interface(self):
+        from zope.interface import Interface
+        from zope.interface import implementedBy
+        from zope.interface import ro
+        from zope.interface.tests.test_ro import C3Setting
+
+        class Foo(object):
+            pass
+
+        with C3Setting(ro.C3.STRICT_IRO, False):
+            self._callFUT(Foo, Interface)
+            self.assertEqual(list(implementedBy(Foo)), [Interface])
+
+            class Baz(Foo):
+                pass
+
+            self._callFUT(Baz, Interface)
+            self.assertEqual(list(implementedBy(Baz)), [Interface])
+
     def _order_for_two(self, applied_first, applied_second):
         return (applied_first, applied_second)
 

--- a/src/zope/interface/tests/test_registry.py
+++ b/src/zope/interface/tests/test_registry.py
@@ -873,7 +873,7 @@ class ComponentsTests(unittest.TestCase):
         ibar = IFoo('IBar')
         _info = u'info'
         _name = u'name'
-        _to_reg = object()
+
         class _Factory(object):
             pass
 


### PR DESCRIPTION
The plone buildout.coredev tests all pass, with the exception of 8 tests from `plone.app.caching.tests.test_etags`. They all fail like this:

```
Error in test test_Roles_member (plone.app.caching.tests.test_etags.TestETags)
Traceback (most recent call last):
  File "//2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "//plone.app.caching-2.0.4-py2.7.egg/plone/app/caching/tests/test_etags.py", line 144, in test_Roles_member
    provideAdapter(DummyPortalState, name=u'plone_portal_state')
  File "//zope.component-4.5-py2.7.egg/zope/component/globalregistry.py", line 73, in provideAdapter
    base.registerAdapter(factory, adapts, provides, name, event=False)
  File "//src/zope.interface/src/zope/interface/registry.py", line 305, in registerAdapter
    provided = _getAdapterProvided(factory)
  File "//src/zope.interface/src/zope/interface/registry.py", line 528, in _getAdapterProvided
    "The adapter factory doesn't implement a single interface "
TypeError: The adapter factory doesn't implement a single interface and no provided interface was specified.
```

That's with code like this:

```python
       @implementer(Interface)
       @adapter(DummyContext, Interface)
        class DummyPortalState(object):

            def __init__(self, context, request):
                pass

            def language(self):
                return 'en'

        provideAdapter(DummyPortalState, name=u'plone_portal_state')
```

Something is going wrong with `@implementer(Interface)`...