### PR TITLE
Make sure to call each invariant only once when validating invariants.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.pyo
 *.so
+*.swp
 __pycache__
 .coverage
 .coverage.*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,9 +12,11 @@
   that argument. See `issue 208
   <https://github.com/zopefoundation/zope.interface/issues/208>`_.
 
-- Make sure to call each invariant only once when validating invariants. 
-  Previously, invariants could be called multiple times because when an invariant is defined in an interface, it's found by in all interfaces inheriting from that interface.
-   See `pull request 215 <https://github.com/zopefoundation/zope.interface/pull/215/>`_.
+- Make sure to call each invariant only once when validating invariants.
+  Previously, invariants could be called multiple times because when an
+  invariant is defined in an interface, it's found by in all interfaces
+  inheriting from that interface.  See `pull request 215
+  <https://github.com/zopefoundation/zope.interface/pull/215/>`_.
 
 5.1.0 (2020-04-08)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,9 +12,9 @@
   that argument. See `issue 208
   <https://github.com/zopefoundation/zope.interface/issues/208>`_.
 
-- When an invariant is defined in an interface, it's found by
-  `validateInvariants` in all interfaces inheriting from that interface.
-  Make sure to call each invariant only once when validating invariants.
+- Make sure to call each invariant only once when validating invariants. 
+  Previously, invariants could be called multiple times because when an invariant is defined in an interface, it's found by in all interfaces inheriting from that interface.
+   See `pull request 215 <https://github.com/zopefoundation/zope.interface/pull/215/>`_.
 
 5.1.0 (2020-04-08)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@
   that argument. See `issue 208
   <https://github.com/zopefoundation/zope.interface/issues/208>`_.
 
+- When an invariant is defined in an interface, it's found by
+  `validateInvariants` in all interfaces inheriting from that interface.
+  Make sure to call each invariant only once when validating invariants.
 
 5.1.0 (2020-04-08)
 ==================

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -875,29 +875,21 @@ class InterfaceClass(_InterfaceClassBase):
     def queryDescriptionFor(self, name, default=None):
         return self.get(name, default)
 
-    def __validateInvariants(self, obj, errors, seen):
-        for call in self.queryTaggedValue('invariants', []):
-            if call in seen:
-                continue
-            seen.add(call)
-            try:
-                call(obj)
-            except Invalid as e:
-                if errors is None:
-                    raise
-                errors.append(e)
-        for base in self.__bases__:
-            try:
-                base.__validateInvariants(obj, errors, seen)
-            except Invalid:
-                if errors is None:
-                    raise
-        if errors:
-            raise Invalid(errors)
-
     def validateInvariants(self, obj, errors=None):
         """validate object to defined invariants."""
-        self.__validateInvariants(obj, errors, set())
+
+        for iface in self.__iro__:
+            for invariant in iface.queryDirectTaggedValue('invariants', ()):
+                try:
+                    invariant(obj)
+                except Invalid as error:
+                     if errors is not None:
+                         errors.append(error)
+                     else:
+                         raise
+
+        if errors:
+            raise Invalid(errors)
 
     def queryTaggedValue(self, tag, default=None):
         """

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -875,9 +875,14 @@ class InterfaceClass(_InterfaceClassBase):
     def queryDescriptionFor(self, name, default=None):
         return self.get(name, default)
 
-    def validateInvariants(self, obj, errors=None):
+    def validateInvariants(self, obj, errors=None, seen=None):
         """validate object to defined invariants."""
+        if seen is None:
+            seen = set()
         for call in self.queryTaggedValue('invariants', []):
+            if call in seen:
+                continue
+            seen.add(call)
             try:
                 call(obj)
             except Invalid as e:
@@ -886,7 +891,7 @@ class InterfaceClass(_InterfaceClassBase):
                 errors.append(e)
         for base in self.__bases__:
             try:
-                base.validateInvariants(obj, errors)
+                base.validateInvariants(obj, errors, seen=seen)
             except Invalid:
                 if errors is None:
                     raise

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -875,10 +875,7 @@ class InterfaceClass(_InterfaceClassBase):
     def queryDescriptionFor(self, name, default=None):
         return self.get(name, default)
 
-    def validateInvariants(self, obj, errors=None, seen=None):
-        """validate object to defined invariants."""
-        if seen is None:
-            seen = set()
+    def __validateInvariants(self, obj, errors, seen):
         for call in self.queryTaggedValue('invariants', []):
             if call in seen:
                 continue
@@ -891,12 +888,16 @@ class InterfaceClass(_InterfaceClassBase):
                 errors.append(e)
         for base in self.__bases__:
             try:
-                base.validateInvariants(obj, errors, seen=seen)
+                base.__validateInvariants(obj, errors, seen)
             except Invalid:
                 if errors is None:
                     raise
         if errors:
             raise Invalid(errors)
+
+    def validateInvariants(self, obj, errors=None):
+        """validate object to defined invariants."""
+        self.__validateInvariants(obj, errors, set())
 
     def queryTaggedValue(self, tag, default=None):
         """

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -1014,6 +1014,20 @@ class InterfaceClassTests(unittest.TestCase):
         self.assertEqual(len(_errors), 1)
         self.assertTrue(isinstance(_errors[0], Invalid))
 
+    def test_validateInvariants_inherited_not_called_multiple_times(self):
+        _passable_called_with = []
+
+        def _passable(*args, **kw):
+            _passable_called_with.append((args, kw))
+            return True
+
+        obj = object()
+        base = self._makeOne('IBase')
+        base.setTaggedValue('invariants', [_passable])
+        derived = self._makeOne('IDerived', (base,))
+        derived.validateInvariants(obj)
+        self.assertEqual(1, len(_passable_called_with))
+
     def test___reduce__(self):
         iface = self._makeOne('PickleMe')
         self.assertEqual(iface.__reduce__(), 'PickleMe')


### PR DESCRIPTION
When an invariant is defined in an interface, it's found by `validateInvariants` in all interfaces inheriting from that interface.
