### PR TITLE
Let subclasses of BaseAdapterRegistry customize the data structures.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,27 @@
  Changes
 =========
 
-5.2.1 (unreleased)
+5.3.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Allow subclasses of ``BaseAdapterRegistry`` (including
+  ``AdapterRegistry`` and ``VerifyingAdapterRegistry``) to have
+  control over the data structures. This allows persistent
+  implementations such as those based on ZODB to choose more scalable
+  options (e.g., BTrees instead of dicts). See `issue 224
+  <https://github.com/zopefoundation/zope.interface/issues/224>`_.
 
+- Fix a reference counting issue in ``BaseAdapterRegistry`` that could
+  lead to references to interfaces being kept around even when all
+  utilities/adapters/subscribers providing that interface have been
+  removed. This is mostly an issue for persistent implementations.
+  Note that this only corrects the issue moving forward, it does not
+  solve any already corrupted reference counts. See `issue 227
+  <https://github.com/zopefoundation/zope.interface/issues/227>`_.
+
+- Add the method ``BaseAdapterRegistry.rebuild()``. This can be used
+  to fix the reference counting issue mentioned above, as well as to
+  update the data structures when custom data types have changed.
 
 5.2.0 (2020-11-05)
 ==================

--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -8,7 +8,7 @@ Usage of the adapter registry is documented in :ref:`adapter-registry`.
 The adapter registry's API is defined by
 :class:`zope.interface.interfaces.IAdapterRegistry`:
 
-.. autointerface:: zope.interface.adapter.IAdapterRegistry
+.. autointerface:: zope.interface.interfaces.IAdapterRegistry
    :members:
    :member-order: bysource
 

--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -11,3 +11,17 @@ The adapter registry's API is defined by
 .. autointerface:: zope.interface.adapter.IAdapterRegistry
    :members:
    :member-order: bysource
+
+
+The concrete implementations of ``IAdapterRegistry`` provided by this
+package allows for some customization opportunities.
+
+.. autoclass:: zope.interface.adapter.BaseAdapterRegistry
+   :members:
+   :private-members:
+
+.. autoclass:: zope.interface.adapter.AdapterRegistry
+   :members:
+
+.. autoclass:: zope.interface.adapter.VerifyingAdapterRegistry
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -262,7 +262,11 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'https://docs.python.org/': None,
+    'https://persistent.readthedocs.io/en/latest/': None,
+    'https://btrees.readthedocs.io/en/latest/': None,
+}
 
 # Sphinx 1.8+ prefers this to `autodoc_default_flags`. It's documented that
 # either True or None mean the same thing as just setting the flag, but

--- a/src/zope/interface/tests/test_adapter.py
+++ b/src/zope/interface/tests/test_adapter.py
@@ -47,10 +47,70 @@ def _makeInterfaces():
     return IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1
 
 
+# Custom types to use as part of the AdapterRegistry data structures.
+# Our custom types do strict type checking to make sure
+# types propagate through the data tree as expected.
+class CustomDataTypeBase(object):
+    _data = None
+    def __getitem__(self, name):
+        return self._data[name]
+
+    def __setitem__(self, name, value):
+        self._data[name] = value
+
+    def __delitem__(self, name):
+        del self._data[name]
+
+    def __len__(self):
+        return len(self._data)
+
+    def __contains__(self, name):
+        return name in self._data
+
+    def __eq__(self, other):
+        if other is self:
+            return True
+        # pylint:disable=unidiomatic-typecheck
+        if type(other) != type(self):
+            return False
+        return other._data == self._data
+
+    def __repr__(self):
+        return repr(self._data)
+
+class CustomMapping(CustomDataTypeBase):
+    def __init__(self, other=None):
+        self._data = {}
+        if other:
+            self._data.update(other)
+        self.get = self._data.get
+        self.items = self._data.items
+
+
+class CustomSequence(CustomDataTypeBase):
+    def __init__(self, other=None):
+        self._data = []
+        if other:
+            self._data.extend(other)
+        self.append = self._data.append
+
+class CustomLeafSequence(CustomSequence):
+    pass
+
+class CustomProvided(CustomMapping):
+    pass
+
+
 class BaseAdapterRegistryTests(unittest.TestCase):
 
-    def _getTargetClass(self):
+    maxDiff = None
+
+    def _getBaseAdapterRegistry(self):
         from zope.interface.adapter import BaseAdapterRegistry
+        return BaseAdapterRegistry
+
+    def _getTargetClass(self):
+        BaseAdapterRegistry = self._getBaseAdapterRegistry()
         class _CUT(BaseAdapterRegistry):
             class LookupClass(object):
                 _changed = _extendors = ()
@@ -70,12 +130,23 @@ class BaseAdapterRegistryTests(unittest.TestCase):
     def _makeOne(self):
         return self._getTargetClass()()
 
+    def _getMappingType(self):
+        return dict
+
+    def _getProvidedType(self):
+        return dict
+
+    def _getMutableListType(self):
+        return list
+
+    def _getLeafSequenceType(self):
+        return tuple
+
     def test_lookup_delegation(self):
         CUT = self._getTargetClass()
         registry = CUT()
         for name in CUT._delegated:
-            self.assertTrue(
-                getattr(registry, name) is getattr(registry._v_lookup, name))
+            self.assertIs(getattr(registry, name), getattr(registry._v_lookup, name))
 
     def test__generation_on_first_creation(self):
         registry = self._makeOne()
@@ -97,13 +168,153 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         registry.__bases__ = (_Base,)
         self.assertEqual(registry._generation, 2)
 
+    def _check_basic_types_of_adapters(self, registry, expected_order=2):
+        self.assertEqual(len(registry._adapters), expected_order) # order 0 and order 1
+        self.assertIsInstance(registry._adapters, self._getMutableListType())
+        MT = self._getMappingType()
+        for mapping in registry._adapters:
+            self.assertIsInstance(mapping, MT)
+        self.assertEqual(registry._adapters[0], MT())
+        self.assertIsInstance(registry._adapters[1], MT)
+        self.assertEqual(len(registry._adapters[expected_order - 1]), 1)
+
+    def _check_basic_types_of_subscribers(self, registry, expected_order=2):
+        self.assertEqual(len(registry._subscribers), expected_order) # order 0 and order 1
+        self.assertIsInstance(registry._subscribers, self._getMutableListType())
+        MT = self._getMappingType()
+        for mapping in registry._subscribers:
+            self.assertIsInstance(mapping, MT)
+        if expected_order:
+            self.assertEqual(registry._subscribers[0], MT())
+            self.assertIsInstance(registry._subscribers[1], MT)
+            self.assertEqual(len(registry._subscribers[expected_order - 1]), 1)
+
     def test_register(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.register([IB0], IR0, '', 'A1')
         self.assertEqual(registry.registered([IB0], IR0, ''), 'A1')
-        self.assertEqual(len(registry._adapters), 2) #order 0 and order 1
         self.assertEqual(registry._generation, 2)
+        self._check_basic_types_of_adapters(registry)
+        MT = self._getMappingType()
+        self.assertEqual(registry._adapters[1], MT({
+            IB0: MT({
+                IR0: MT({'': 'A1'})
+            })
+        }))
+        PT = self._getProvidedType()
+        self.assertEqual(registry._provided, PT({
+            IR0: 1
+        }))
+
+        registered = list(registry.allRegistrations())
+        self.assertEqual(registered, [(
+            (IB0,), # required
+            IR0, # provided
+            '', # name
+            'A1' # value
+        )])
+
+    def test_register_multiple_allRegistrations(self):
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
+        registry = self._makeOne()
+        # Use several different depths and several different names
+        registry.register([], IR0, '', 'A1')
+        registry.register([], IR0, 'name1', 'A2')
+
+        registry.register([IB0], IR0, '', 'A1')
+        registry.register([IB0], IR0, 'name2', 'A2')
+        registry.register([IB0], IR1, '', 'A3')
+        registry.register([IB0], IR1, 'name3', 'A4')
+
+        registry.register([IB0, IB1], IR0, '', 'A1')
+        registry.register([IB0, IB2], IR0, 'name2', 'A2')
+        registry.register([IB0, IB2], IR1, 'name4', 'A4')
+        registry.register([IB0, IB3], IR1, '', 'A3')
+
+        def build_adapters(L, MT):
+            return L([
+                # 0
+                MT({
+                    IR0: MT({
+                        '': 'A1',
+                        'name1': 'A2'
+                    })
+                }),
+                # 1
+                MT({
+                    IB0: MT({
+                        IR0: MT({
+                            '': 'A1',
+                            'name2': 'A2'
+                        }),
+                        IR1: MT({
+                            '': 'A3',
+                            'name3': 'A4'
+                        })
+                    })
+                }),
+                # 3
+                MT({
+                    IB0: MT({
+                        IB1: MT({
+                            IR0: MT({'': 'A1'})
+                        }),
+                        IB2: MT({
+                            IR0: MT({'name2': 'A2'}),
+                            IR1: MT({'name4': 'A4'}),
+                        }),
+                        IB3: MT({
+                            IR1: MT({'': 'A3'})
+                        })
+                    }),
+                }),
+            ])
+
+        self.assertEqual(registry._adapters,
+                         build_adapters(L=self._getMutableListType(),
+                                        MT=self._getMappingType()))
+
+        registered = sorted(registry.allRegistrations())
+        self.assertEqual(registered, [
+            ((), IR0, '', 'A1'),
+            ((), IR0, 'name1', 'A2'),
+            ((IB0,), IR0, '', 'A1'),
+            ((IB0,), IR0, 'name2', 'A2'),
+            ((IB0,), IR1, '', 'A3'),
+            ((IB0,), IR1, 'name3', 'A4'),
+            ((IB0, IB1), IR0, '', 'A1'),
+            ((IB0, IB2), IR0, 'name2', 'A2'),
+            ((IB0, IB2), IR1, 'name4', 'A4'),
+            ((IB0, IB3), IR1, '', 'A3')
+        ])
+
+        # We can duplicate to another object.
+        registry2 = self._makeOne()
+        for args in registered:
+            registry2.register(*args)
+
+        self.assertEqual(registry2._adapters, registry._adapters)
+        self.assertEqual(registry2._provided, registry._provided)
+
+        # We can change the types and rebuild the data structures.
+        registry._mappingType = CustomMapping
+        registry._leafSequenceType = CustomLeafSequence
+        registry._sequenceType = CustomSequence
+        registry._providedType = CustomProvided
+        def addValue(existing, new):
+            existing = existing if existing is not None else CustomLeafSequence()
+            existing.append(new)
+            return existing
+        registry._addValueToLeaf = addValue
+
+        registry.rebuild()
+
+        self.assertEqual(registry._adapters,
+                         build_adapters(
+                             L=CustomSequence,
+                             MT=CustomMapping
+                         ))
 
     def test_register_with_invalid_name(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
@@ -117,8 +328,12 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         registry.register([None], IR0, '', 'A1')
         registry.register([None], IR0, '', None)
         self.assertEqual(len(registry._adapters), 0)
+        self.assertIsInstance(registry._adapters, self._getMutableListType())
+        registered = list(registry.allRegistrations())
+        self.assertEqual(registered, [])
 
     def test_register_with_same_value(self):
+        from zope.interface import Interface
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         _value = object()
@@ -126,10 +341,31 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         _before = registry._generation
         registry.register([None], IR0, '', _value)
         self.assertEqual(registry._generation, _before) # skipped changed()
+        self._check_basic_types_of_adapters(registry)
+        MT = self._getMappingType()
+        self.assertEqual(registry._adapters[1], MT(
+            {
+                Interface: MT(
+                    {
+                        IR0: MT({'': _value})
+                    }
+                )
+            }
+        ))
+        registered = list(registry.allRegistrations())
+        self.assertEqual(registered, [(
+            (Interface,), # required
+            IR0, # provided
+            '', # name
+            _value # value
+        )])
+
 
     def test_registered_empty(self):
         registry = self._makeOne()
         self.assertEqual(registry.registered([None], None, ''), None)
+        registered = list(registry.allRegistrations())
+        self.assertEqual(registered, [])
 
     def test_registered_non_empty_miss(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
@@ -144,22 +380,53 @@ class BaseAdapterRegistryTests(unittest.TestCase):
 
     def test_unregister_empty(self):
         registry = self._makeOne()
-        registry.unregister([None], None, '') #doesn't raise
+        registry.unregister([None], None, '') # doesn't raise
         self.assertEqual(registry.registered([None], None, ''), None)
+        self.assertEqual(len(registry._provided), 0)
 
     def test_unregister_non_empty_miss_on_required(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.register([IB1], None, '', 'A1')
-        registry.unregister([IB2], None, '') #doesn't raise
+        registry.unregister([IB2], None, '') # doesn't raise
         self.assertEqual(registry.registered([IB1], None, ''), 'A1')
+        self._check_basic_types_of_adapters(registry)
+        MT = self._getMappingType()
+        self.assertEqual(registry._adapters[1], MT(
+            {
+                IB1: MT(
+                    {
+                        None: MT({'': 'A1'})
+                    }
+                )
+            }
+        ))
+        PT = self._getProvidedType()
+        self.assertEqual(registry._provided, PT({
+            None: 1
+        }))
 
     def test_unregister_non_empty_miss_on_name(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.register([IB1], None, '', 'A1')
-        registry.unregister([IB1], None, 'nonesuch') #doesn't raise
+        registry.unregister([IB1], None, 'nonesuch') # doesn't raise
         self.assertEqual(registry.registered([IB1], None, ''), 'A1')
+        self._check_basic_types_of_adapters(registry)
+        MT = self._getMappingType()
+        self.assertEqual(registry._adapters[1], MT(
+            {
+                IB1: MT(
+                    {
+                        None: MT({'': 'A1'})
+                    }
+                )
+            }
+        ))
+        PT = self._getProvidedType()
+        self.assertEqual(registry._provided, PT({
+            None: 1
+        }))
 
     def test_unregister_with_value_not_None_miss(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
@@ -177,24 +444,79 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         another = object()
         registry.register([IB1, IB2], None, '', one)
         registry.register([IB1, IB3], None, '', another)
+        self._check_basic_types_of_adapters(registry, expected_order=3)
         self.assertIn(IB2, registry._adapters[2][IB1])
         self.assertIn(IB3, registry._adapters[2][IB1])
+        MT = self._getMappingType()
+        self.assertEqual(registry._adapters[2], MT(
+            {
+                IB1: MT(
+                    {
+                        IB2: MT({None: MT({'': one})}),
+                        IB3: MT({None: MT({'': another})})
+                    }
+                )
+            }
+        ))
+        PT = self._getProvidedType()
+        self.assertEqual(registry._provided, PT({
+            None: 2
+        }))
+
         registry.unregister([IB1, IB3], None, '', another)
         self.assertIn(IB2, registry._adapters[2][IB1])
         self.assertNotIn(IB3, registry._adapters[2][IB1])
+        self.assertEqual(registry._adapters[2], MT(
+            {
+                IB1: MT(
+                    {
+                        IB2: MT({None: MT({'': one})}),
+                    }
+                )
+            }
+        ))
+        self.assertEqual(registry._provided, PT({
+            None: 1
+        }))
 
     def test_unsubscribe_empty(self):
         registry = self._makeOne()
         registry.unsubscribe([None], None, '') #doesn't raise
         self.assertEqual(registry.registered([None], None, ''), None)
+        self._check_basic_types_of_subscribers(registry, expected_order=0)
 
     def test_unsubscribe_hit(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         orig = object()
         registry.subscribe([IB1], None, orig)
+        MT = self._getMappingType()
+        L = self._getLeafSequenceType()
+        PT = self._getProvidedType()
+        self._check_basic_types_of_subscribers(registry)
+        self.assertEqual(registry._subscribers[1], MT({
+            IB1: MT({
+                None: MT({
+                    '': L((orig,))
+                })
+            })
+        }))
+        self.assertEqual(registry._provided, PT({}))
         registry.unsubscribe([IB1], None, orig) #doesn't raise
         self.assertEqual(len(registry._subscribers), 0)
+        self.assertEqual(registry._provided, PT({}))
+
+    def assertLeafIdentity(self, leaf1, leaf2):
+        """
+        Implementations may choose to use new, immutable objects
+        instead of mutating existing subscriber leaf objects, or vice versa.
+
+        The default implementation uses immutable tuples, so they are never
+        the same. Other implementations may use persistent lists so they should be
+        the same and mutated in place. Subclasses testing this behaviour need to
+        override this method.
+        """
+        self.assertIsNot(leaf1, leaf2)
 
     def test_unsubscribe_after_multiple(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
@@ -207,11 +529,97 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         registry.subscribe([IB1], None, second)
         registry.subscribe([IB1], IR0, third)
         registry.subscribe([IB1], IR0, fourth)
-        registry.unsubscribe([IB1], IR0, fourth)
-        registry.unsubscribe([IB1], IR0, third)
-        registry.unsubscribe([IB1], None, second)
+        self._check_basic_types_of_subscribers(registry, expected_order=2)
+        MT = self._getMappingType()
+        L = self._getLeafSequenceType()
+        PT = self._getProvidedType()
+        self.assertEqual(registry._subscribers[1], MT({
+            IB1: MT({
+                None: MT({'': L((first, second))}),
+                IR0: MT({'': L((third, fourth))}),
+            })
+        }))
+        self.assertEqual(registry._provided, PT({
+            IR0: 2
+        }))
+        # The leaf objects may or may not stay the same as they are unsubscribed,
+        # depending on the implementation
+        IR0_leaf_orig = registry._subscribers[1][IB1][IR0]['']
+        Non_leaf_orig = registry._subscribers[1][IB1][None]['']
+
         registry.unsubscribe([IB1], None, first)
+        registry.unsubscribe([IB1], IR0, third)
+
+        self.assertEqual(registry._subscribers[1], MT({
+            IB1: MT({
+                None: MT({'': L((second,))}),
+                IR0: MT({'': L((fourth,))}),
+            })
+        }))
+        self.assertEqual(registry._provided, PT({
+            IR0: 1
+        }))
+        IR0_leaf_new = registry._subscribers[1][IB1][IR0]['']
+        Non_leaf_new = registry._subscribers[1][IB1][None]['']
+
+        self.assertLeafIdentity(IR0_leaf_orig, IR0_leaf_new)
+        self.assertLeafIdentity(Non_leaf_orig, Non_leaf_new)
+
+        registry.unsubscribe([IB1], None, second)
+        registry.unsubscribe([IB1], IR0, fourth)
         self.assertEqual(len(registry._subscribers), 0)
+        self.assertEqual(len(registry._provided), 0)
+
+    def test_subscribe_unsubscribe_identical_objects_provided(self):
+        # https://github.com/zopefoundation/zope.interface/issues/227
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
+        registry = self._makeOne()
+        first = object()
+        registry.subscribe([IB1], IR0, first)
+        registry.subscribe([IB1], IR0, first)
+
+        MT = self._getMappingType()
+        L = self._getLeafSequenceType()
+        PT = self._getProvidedType()
+        self.assertEqual(registry._subscribers[1], MT({
+            IB1: MT({
+                IR0: MT({'': L((first, first))}),
+            })
+        }))
+        self.assertEqual(registry._provided, PT({
+            IR0: 2
+        }))
+
+        registry.unsubscribe([IB1], IR0, first)
+        registry.unsubscribe([IB1], IR0, first)
+        self.assertEqual(len(registry._subscribers), 0)
+        self.assertEqual(registry._provided, PT())
+
+    def test_subscribe_unsubscribe_nonequal_objects_provided(self):
+        # https://github.com/zopefoundation/zope.interface/issues/227
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
+        registry = self._makeOne()
+        first = object()
+        second = object()
+        registry.subscribe([IB1], IR0, first)
+        registry.subscribe([IB1], IR0, second)
+
+        MT = self._getMappingType()
+        L = self._getLeafSequenceType()
+        PT = self._getProvidedType()
+        self.assertEqual(registry._subscribers[1], MT({
+            IB1: MT({
+                IR0: MT({'': L((first, second))}),
+            })
+        }))
+        self.assertEqual(registry._provided, PT({
+            IR0: 2
+        }))
+
+        registry.unsubscribe([IB1], IR0, first)
+        registry.unsubscribe([IB1], IR0, second)
+        self.assertEqual(len(registry._subscribers), 0)
+        self.assertEqual(registry._provided, PT())
 
     def test_unsubscribe_w_None_after_multiple(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
@@ -221,6 +629,7 @@ class BaseAdapterRegistryTests(unittest.TestCase):
 
         registry.subscribe([IB1], None, first)
         registry.subscribe([IB1], None, second)
+        self._check_basic_types_of_subscribers(registry, expected_order=2)
         registry.unsubscribe([IB1], None)
         self.assertEqual(len(registry._subscribers), 0)
 
@@ -228,17 +637,31 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.subscribe([IB1], None, 'A1')
+        self._check_basic_types_of_subscribers(registry, expected_order=2)
+        registry.unsubscribe([IB2], None, '') # doesn't raise
         self.assertEqual(len(registry._subscribers), 2)
-        registry.unsubscribe([IB2], None, '') #doesn't raise
-        self.assertEqual(len(registry._subscribers), 2)
+        MT = self._getMappingType()
+        L = self._getLeafSequenceType()
+        self.assertEqual(registry._subscribers[1], MT({
+            IB1: MT({
+                None: MT({'': L(('A1',))}),
+            })
+        }))
 
     def test_unsubscribe_non_empty_miss_on_value(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         registry.subscribe([IB1], None, 'A1')
+        self._check_basic_types_of_subscribers(registry, expected_order=2)
+        registry.unsubscribe([IB1], None, 'A2') # doesn't raise
         self.assertEqual(len(registry._subscribers), 2)
-        registry.unsubscribe([IB1], None, 'A2') #doesn't raise
-        self.assertEqual(len(registry._subscribers), 2)
+        MT = self._getMappingType()
+        L = self._getLeafSequenceType()
+        self.assertEqual(registry._subscribers[1], MT({
+            IB1: MT({
+                None: MT({'': L(('A1',))}),
+            })
+        }))
 
     def test_unsubscribe_with_value_not_None_miss(self):
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
@@ -253,12 +676,169 @@ class BaseAdapterRegistryTests(unittest.TestCase):
         self.fail("Example method, not intended to be called.")
 
     def test_unsubscribe_instance_method(self):
+        # Checking that the values are compared by equality, not identity
         IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
         registry = self._makeOne()
         self.assertEqual(len(registry._subscribers), 0)
         registry.subscribe([IB1], None, self._instance_method_notify_target)
         registry.unsubscribe([IB1], None, self._instance_method_notify_target)
         self.assertEqual(len(registry._subscribers), 0)
+
+    def test_subscribe_multiple_allRegistrations(self):
+        IB0, IB1, IB2, IB3, IB4, IF0, IF1, IR0, IR1 = _makeInterfaces() # pylint:disable=unused-variable
+        registry = self._makeOne()
+        # Use several different depths and several different values
+        registry.subscribe([], IR0, 'A1')
+        registry.subscribe([], IR0, 'A2')
+
+        registry.subscribe([IB0], IR0, 'A1')
+        registry.subscribe([IB0], IR0, 'A2')
+        registry.subscribe([IB0], IR1, 'A3')
+        registry.subscribe([IB0], IR1, 'A4')
+
+        registry.subscribe([IB0, IB1], IR0, 'A1')
+        registry.subscribe([IB0, IB2], IR0, 'A2')
+        registry.subscribe([IB0, IB2], IR1, 'A4')
+        registry.subscribe([IB0, IB3], IR1, 'A3')
+
+
+        def build_subscribers(L, F, MT):
+            return L([
+                # 0
+                MT({
+                    IR0: MT({
+                        '': F(['A1', 'A2'])
+                    })
+                }),
+                # 1
+                MT({
+                    IB0: MT({
+                        IR0: MT({
+                            '': F(['A1', 'A2'])
+                        }),
+                        IR1: MT({
+                            '': F(['A3', 'A4'])
+                        })
+                    })
+                }),
+                # 3
+                MT({
+                    IB0: MT({
+                        IB1: MT({
+                            IR0: MT({'': F(['A1'])})
+                        }),
+                        IB2: MT({
+                            IR0: MT({'': F(['A2'])}),
+                            IR1: MT({'': F(['A4'])}),
+                        }),
+                        IB3: MT({
+                            IR1: MT({'': F(['A3'])})
+                        })
+                    }),
+                }),
+            ])
+
+        self.assertEqual(registry._subscribers,
+                         build_subscribers(
+                             L=self._getMutableListType(),
+                             F=self._getLeafSequenceType(),
+                             MT=self._getMappingType()
+                         ))
+
+        def build_provided(P):
+            return P({
+                IR0: 6,
+                IR1: 4,
+            })
+
+
+        self.assertEqual(registry._provided,
+                         build_provided(P=self._getProvidedType()))
+
+        registered = sorted(registry.allSubscriptions())
+        self.assertEqual(registered, [
+            ((), IR0, 'A1'),
+            ((), IR0, 'A2'),
+            ((IB0,), IR0, 'A1'),
+            ((IB0,), IR0, 'A2'),
+            ((IB0,), IR1, 'A3'),
+            ((IB0,), IR1, 'A4'),
+            ((IB0, IB1), IR0, 'A1'),
+            ((IB0, IB2), IR0, 'A2'),
+            ((IB0, IB2), IR1, 'A4'),
+            ((IB0, IB3), IR1, 'A3')
+        ])
+
+        # We can duplicate this to another object
+        registry2 = self._makeOne()
+        for args in registered:
+            registry2.subscribe(*args)
+
+        self.assertEqual(registry2._subscribers, registry._subscribers)
+        self.assertEqual(registry2._provided, registry._provided)
+
+        # We can change the types and rebuild the data structures.
+        registry._mappingType = CustomMapping
+        registry._leafSequenceType = CustomLeafSequence
+        registry._sequenceType = CustomSequence
+        registry._providedType = CustomProvided
+        def addValue(existing, new):
+            existing = existing if existing is not None else CustomLeafSequence()
+            existing.append(new)
+            return existing
+        registry._addValueToLeaf = addValue
+
+        registry.rebuild()
+
+        self.assertEqual(registry._subscribers,
+                         build_subscribers(
+                             L=CustomSequence,
+                             F=CustomLeafSequence,
+                             MT=CustomMapping
+                         ))
+
+
+class CustomTypesBaseAdapterRegistryTests(BaseAdapterRegistryTests):
+
+    def _getMappingType(self):
+        return CustomMapping
+
+    def _getProvidedType(self):
+        return CustomProvided
+
+    def _getMutableListType(self):
+        return CustomSequence
+
+    def _getLeafSequenceType(self):
+        return CustomLeafSequence
+
+    def _getBaseAdapterRegistry(self):
+        from zope.interface.adapter import BaseAdapterRegistry
+        class CustomAdapterRegistry(BaseAdapterRegistry):
+            _mappingType = self._getMappingType()
+            _sequenceType = self._getMutableListType()
+            _leafSequenceType = self._getLeafSequenceType()
+            _providedType = self._getProvidedType()
+
+            def _addValueToLeaf(self, existing_leaf_sequence, new_item):
+                if not existing_leaf_sequence:
+                    existing_leaf_sequence = self._leafSequenceType()
+                existing_leaf_sequence.append(new_item)
+                return existing_leaf_sequence
+
+            def _removeValueFromLeaf(self, existing_leaf_sequence, to_remove):
+                without_removed = BaseAdapterRegistry._removeValueFromLeaf(
+                    self,
+                    existing_leaf_sequence,
+                    to_remove)
+                existing_leaf_sequence[:] = without_removed
+                assert to_remove not in existing_leaf_sequence
+                return existing_leaf_sequence
+
+        return CustomAdapterRegistry
+
+    def assertLeafIdentity(self, leaf1, leaf2):
+        self.assertIs(leaf1, leaf2)
 
 
 class LookupBaseFallbackTests(unittest.TestCase):


### PR DESCRIPTION
Add extensive tests for this. Fixes #224.

Also adds test for, and fixes #227

Based on #226 so that CI runs. The first two commits aren't relevant to this PR.

I'd like to add a migration method to help existing persistent utilities convert to new data structures, but before that's done I'll open this as a draft so the general approach can be looked at.