### PR TITLE
Make ZOPE_INTERFACE_STRICT_IRO imply ZOPE_INTERFACE_LOG_CHANGED_IRO.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,14 @@
 5.3.0 (unreleased)
 ==================
 
+- Make the debug environment variable ``ZOPE_INTERFACE_STRICT_IRO``
+  imply ``ZOPE_INTERFACE_LOG_CHANGED_IRO``. See
+  `issue 229 <https://github.com/zopefoundation/zope.interface/issues/229>`_.
+
+- Improve the repr of ``zope.interface.Provides`` to remove ambiguity
+  about what is being provided. This is especially helpful diagnosing
+  IRO issues.
+
 - Allow subclasses of ``BaseAdapterRegistry`` (including
   ``AdapterRegistry`` and ``VerifyingAdapterRegistry``) to have
   control over the data structures. This allows persistent

--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -750,10 +750,11 @@ class Provides(Declaration):  # Really named ProvidesClass
         Declaration.__init__(self, *(interfaces + (implementedBy(cls), )))
 
     def __repr__(self):
-        return "<%s.%s for %s>" % (
+        return "<%s.%s for instances of %s providing %s>" % (
             self.__class__.__module__,
             self.__class__.__name__,
             self._cls,
+            self.__args[1:]
         )
 
     def __reduce__(self):

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -1305,10 +1305,16 @@ class ProvidesClassTests(unittest.TestCase):
         self.assertRaises(AttributeError, _test)
 
     def test__repr__(self):
-        inst = self._makeOne(type(self))
+        from zope.interface.interface import InterfaceClass
+        IFoo = InterfaceClass("IFoo")
+
+        inst = self._makeOne(type(self), IFoo)
         self.assertEqual(
             repr(inst),
-            "<zope.interface.Provides for %r>"  % type(self)
+            "<zope.interface.Provides for instances of %r providing %s>"  % (
+                type(self),
+                (IFoo,)
+            )
         )
 
 

--- a/src/zope/interface/tests/test_ro.py
+++ b/src/zope/interface/tests/test_ro.py
@@ -221,6 +221,9 @@ class Test_c3_ro(Test_ro):
         if hasattr(A, 'mro'):
             self.assertEqual(A.mro(), self._callFUT(A))
 
+        # Clear anything the ro module logged by default,
+        # which might depend on environment variables.
+        self.log_handler.clear()
         return A
 
     def test_complex_diamond_interface(self):
@@ -251,6 +254,27 @@ class Test_c3_ro(Test_ro):
         # It matches, of course, but we did log a warning.
         self.assertEqual(tuple(computed_A_iro), A.__iro__)
         self._check_handler_complex_diamond()
+
+    def test_complex_diamond_strict_argument(self):
+        from zope.interface import Interface
+
+        A = self.test_complex_diamond(Interface)
+        computed_A_iro = self._callFUT(A, strict=True)
+        # It matches, of course, but strict mode implies
+        # that we also log changes.
+        self.assertEqual(tuple(computed_A_iro), A.__iro__)
+        self._check_handler_complex_diamond()
+
+    def test_complex_diamond_strict_and_log_arguments(self):
+        from zope.interface import Interface
+
+        A = self.test_complex_diamond(Interface)
+        computed_A_iro = self._callFUT(A, strict=True, log_changed_ro=False)
+        # It matches, of course...
+        self.assertEqual(tuple(computed_A_iro), A.__iro__)
+        # ...but because we explicitly set log_changed_ro to False,
+        # nothing is logged
+        self.assertFalse(self.log_handler.records)
 
     def _check_handler_complex_diamond(self):
         handler = self.log_handler


### PR DESCRIPTION
This helps diagnosing problems when just strict mode isn't enough, and strict mode is the one that's being used most of the time.

Fixes #229