### PR TITLE
Make Provides and ClassProvides ignore redundant interfaces like @implementer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,14 @@
   object itself (this might happen to persistent ``Components``
   implementations in the face of bugs).
 
+- Fix the ``Provides`` and ``ClassProvides`` descriptors to stop
+  allowing redundant interfaces (those already implemented by the
+  underlying class or meta class) to produce an inconsistent
+  resolution order. This is similar to the change in ``@implementer``
+  in 5.1.0, and resolves inconsistent resolution orders with
+  ``zope.proxy`` and ``zope.location``. See `issue 207
+  <https://github.com/zopefoundation/zope.interface/issues/207>`_.
+
 5.2.0 (2020-11-05)
 ==================
 

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -413,6 +413,13 @@ class Specification(SpecificationBase):
         __setBases,
         )
 
+    # This method exists for tests to override the way we call
+    # ro.calculate_ro(), usually by adding extra kwargs. We don't
+    # want to have a mutable dictionary as a class member that we pass
+    # ourself because mutability is bad, and passing **kw is slower than
+    # calling the bound function.
+    _do_calculate_ro = calculate_ro
+
     def _calculate_sro(self):
         """
         Calculate and return the resolution order for this object, using its ``__bases__``.
@@ -448,7 +455,7 @@ class Specification(SpecificationBase):
         # This requires that by the time this method is invoked, our bases
         # have settled their SROs. Thus, ``changed()`` must first
         # update itself before telling its descendents of changes.
-        sro = calculate_ro(self, base_mros={
+        sro = self._do_calculate_ro(base_mros={
             b: b.__sro__
             for b in self.__bases__
         })


### PR DESCRIPTION
This is the last PR I'm hoping to merge before making a release.

cf #207