### PR TITLE
Update repr() and str() of some common objects.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,16 @@
  Changes
 =========
 
+5.4.0 (unreleased)
+==================
+
+- Update the ``repr()`` and ``str()`` of various objects to be shorter
+  and more informative. In many cases, the ``repr()`` is now something
+  that can be evaluated to produce an equal object. For example, what
+  was previously printed as ``<implementedBy builtins.list>`` is now
+  shown as ``classImplements(list, IMutableSequence, IIterable)``. See
+  `issue 236 <https://github.com/zopefoundation/zope.interface/issues/236>`_.
+
 5.3.0 (2020-03-21)
 ==================
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -677,7 +677,7 @@ interfaces that they declare:
 
   >>> baz_implements = zope.interface.implementedBy(Baz)
   >>> baz_implements.__bases__
-  (<InterfaceClass builtins.IBaz>, <implementedBy ...object>)
+  (<InterfaceClass builtins.IBaz>, classImplements(object))
 
   >>> baz_implements.extends(IFoo)
   True
@@ -694,11 +694,11 @@ that lists the specification and all of it's ancestors:
 
   >>> from pprint import pprint
   >>> pprint(baz_implements.__sro__)
-  (<implementedBy builtins.Baz>,
+  (classImplements(Baz, IBaz),
    <InterfaceClass builtins.IBaz>,
    <InterfaceClass builtins.IFoo>,
    <InterfaceClass builtins.IBlat>,
-   <implementedBy ...object>,
+   classImplements(object),
    <InterfaceClass zope.interface.Interface>)
   >>> class IBiz(zope.interface.Interface):
   ...    pass
@@ -706,13 +706,13 @@ that lists the specification and all of it's ancestors:
   ... class Biz(Baz):
   ...    pass
   >>> pprint(zope.interface.implementedBy(Biz).__sro__)
-  (<implementedBy builtins.Biz>,
+  (classImplements(Biz, IBiz),
    <InterfaceClass builtins.IBiz>,
-   <implementedBy builtins.Baz>,
+   classImplements(Baz, IBaz),
    <InterfaceClass builtins.IBaz>,
    <InterfaceClass builtins.IFoo>,
    <InterfaceClass builtins.IBlat>,
-   <implementedBy ...object>,
+   classImplements(object),
    <InterfaceClass zope.interface.Interface>)
 
 Tagged Values

--- a/docs/api/declarations.rst
+++ b/docs/api/declarations.rst
@@ -624,7 +624,7 @@ an instance:
    ...     def __call__(self):
    ...         return self
    >>> implementedBy(Callable())
-   <implementedBy builtins.?>
+   classImplements(builtins.?)
 
 Note that the name of the spec ends with a '?', because the ``Callable``
 instance does not have a ``__name__`` attribute.

--- a/docs/verify.rst
+++ b/docs/verify.rst
@@ -49,7 +49,7 @@ defined.
 .. doctest::
 
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>:
+   The object <Foo...> has failed to implement interface ...IFoo:
        Does not declaratively implement the interface
        The base.IBase.x attribute was not provided
        The module.IFoo.y attribute was not provided
@@ -61,7 +61,7 @@ declaring the correct interface.
 
    >>> Foo.x = Foo.y = 42
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: Does not declaratively implement the interface.
+   The object <Foo...> has failed to implement interface ...IFoo: Does not declaratively implement the interface.
 
 If we want to only check the structure of the object, without examining
 its declarations, we can use the ``tentative`` argument.
@@ -119,13 +119,13 @@ exception.
    ... class Foo(object):
    ...     x = 1
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: The module.IFoo.y attribute was not provided.
+   The object <Foo...> has failed to implement interface ...IFoo: The module.IFoo.y attribute was not provided.
    >>> @implementer(IFoo)
    ... class Foo(object):
    ...     def __init__(self):
    ...         self.y = 2
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: The base.IBase.x attribute was not provided.
+   The object <Foo...> has failed to implement interface ...IFoo: The base.IBase.x attribute was not provided.
 
 If both attributes are missing, an exception is raised reporting
 both errors.
@@ -136,7 +136,7 @@ both errors.
     ... class Foo(object):
     ...     pass
     >>> verify_foo()
-    The object <Foo ...> has failed to implement interface <...IFoo>:
+    The object <Foo ...> has failed to implement interface ...IFoo:
         The base.IBase.x attribute was not provided
         The module.IFoo.y attribute was not provided
 
@@ -155,7 +155,7 @@ when trying to get its value, the attribute is considered missing:
    ...     def x(self):
    ...         raise AttributeError
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: The module.IFoo.x attribute was not provided.
+   The object <Foo...> has failed to implement interface ...IFoo: The module.IFoo.x attribute was not provided.
 
 
 Any other exception raised by a property will propagate to the caller of
@@ -203,7 +203,7 @@ that takes one argument. If we don't provide it, we get an error.
    ... class Foo(object):
    ...    pass
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: The module.IFoo.simple(arg1) attribute was not provided.
+   The object <Foo...> has failed to implement interface ...IFoo: The module.IFoo.simple(arg1) attribute was not provided.
 
 Once they exist, they are checked to be callable, and for compatible signatures.
 
@@ -213,7 +213,7 @@ Not being callable is an error.
 
    >>> Foo.simple = 42
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: The contract of module.IFoo.simple(arg1) is violated because '42' is not a method.
+   The object <Foo...> has failed to implement interface ...IFoo: The contract of module.IFoo.simple(arg1) is violated because '42' is not a method.
 
 Taking too few arguments is an error. (Recall that the ``self``
 argument is implicit.)
@@ -222,7 +222,7 @@ argument is implicit.)
 
    >>> Foo.simple = lambda self: "I take no arguments"
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: The contract of module.IFoo.simple(arg1) is violated because '<lambda>()' doesn't allow enough arguments.
+   The object <Foo...> has failed to implement interface ...IFoo: The contract of module.IFoo.simple(arg1) is violated because '<lambda>()' doesn't allow enough arguments.
 
 Requiring too many arguments is an error.
 
@@ -230,7 +230,7 @@ Requiring too many arguments is an error.
 
    >>> Foo.simple = lambda self, a, b: "I require two arguments"
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: The contract of module.IFoo.simple(arg1) is violated because '<lambda>(a, b)' requires too many arguments.
+   The object <Foo...> has failed to implement interface ...IFoo: The contract of module.IFoo.simple(arg1) is violated because '<lambda>(a, b)' requires too many arguments.
 
 Variable arguments can be used to implement the required number, as
 can arguments with defaults.
@@ -257,7 +257,7 @@ variable keyword arguments, the implementation must also accept them.
    ... class Foo(object):
    ...     def needs_kwargs(self, a=1, b=2): pass
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: The contract of module.IFoo.needs_kwargs(**kwargs) is violated because 'Foo.needs_kwargs(a=1, b=2)' doesn't support keyword arguments.
+   The object <Foo...> has failed to implement interface ...IFoo: The contract of module.IFoo.needs_kwargs(**kwargs) is violated because 'Foo.needs_kwargs(a=1, b=2)' doesn't support keyword arguments.
 
    >>> oname, __name__ = __name__, 'module'
    >>> class IFoo(Interface):
@@ -267,7 +267,7 @@ variable keyword arguments, the implementation must also accept them.
    ... class Foo(object):
    ...     def needs_varargs(self, **kwargs): pass
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>: The contract of module.IFoo.needs_varargs(*args) is violated because 'Foo.needs_varargs(**kwargs)' doesn't support variable arguments.
+   The object <Foo...> has failed to implement interface ...IFoo: The contract of module.IFoo.needs_varargs(*args) is violated because 'Foo.needs_varargs(**kwargs)' doesn't support variable arguments.
 
 Of course, missing attributes are also found and reported, and the
 source interface of the missing attribute is included. Similarly, when
@@ -288,7 +288,7 @@ the failing method is from a parent class, that is also reported.
    ... class Foo(Base):
    ...    pass
    >>> verify_foo()
-   The object <Foo...> has failed to implement interface <...IFoo>:
+   The object <Foo...> has failed to implement interface ...IFoo:
        The contract of base.IBase.method(arg1) is violated because 'Base.method()' doesn't allow enough arguments
        The module.IFoo.x attribute was not provided
 
@@ -313,4 +313,4 @@ attributes, cannot be verified.
     ...        print(e)
 
     >>> verify_foo_class()
-    The object <class 'Foo'> has failed to implement interface <...IFoo>: The contract of base.IBase.method(arg1) is violated because 'Base.method(self)' doesn't allow enough arguments.
+    The object <class 'Foo'> has failed to implement interface ...IFoo: The contract of base.IBase.method(arg1) is violated because 'Base.method(self)' doesn't allow enough arguments.

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -890,10 +890,10 @@ class InterfaceClass(_InterfaceClassBase):
                 try:
                     invariant(obj)
                 except Invalid as error:
-                     if errors is not None:
-                         errors.append(error)
-                     else:
-                         raise
+                    if errors is not None:
+                        errors.append(error)
+                    else:
+                        raise
 
         if errors:
             raise Invalid(errors)
@@ -925,17 +925,21 @@ class InterfaceClass(_InterfaceClassBase):
             keys.update(base.getDirectTaggedValueTags())
         return keys
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         try:
             return self._v_repr
         except AttributeError:
-            name = self.__name__
-            m = self.__ibmodule__
-            if m:
-                name = '%s.%s' % (m, name)
+            name = str(self)
             r = "<%s %s>" % (self.__class__.__name__, name)
             self._v_repr = r # pylint:disable=attribute-defined-outside-init
             return r
+
+    def __str__(self):
+        name = self.__name__
+        m = self.__ibmodule__
+        if m:
+            name = '%s.%s' % (m, name)
+        return name
 
     def _call_conform(self, conform):
         try:

--- a/src/zope/interface/tests/test_exceptions.py
+++ b/src/zope/interface/tests/test_exceptions.py
@@ -36,7 +36,7 @@ class DoesNotImplementTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             "An object has failed to implement interface "
-            "<InterfaceClass zope.interface.tests.test_exceptions.IDummy>: "
+            "zope.interface.tests.test_exceptions.IDummy: "
             "Does not declaratively implement the interface."
         )
 
@@ -45,7 +45,7 @@ class DoesNotImplementTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             "The object 'candidate' has failed to implement interface "
-            "<InterfaceClass zope.interface.tests.test_exceptions.IDummy>: "
+            "zope.interface.tests.test_exceptions.IDummy: "
             "Does not declaratively implement the interface."
         )
 
@@ -65,7 +65,7 @@ class BrokenImplementationTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             'An object has failed to implement interface '
-            '<InterfaceClass zope.interface.tests.test_exceptions.IDummy>: '
+            'zope.interface.tests.test_exceptions.IDummy: '
             "The 'missing' attribute was not provided.")
 
     def test___str__w_candidate(self):
@@ -73,7 +73,7 @@ class BrokenImplementationTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             'The object \'candidate\' has failed to implement interface '
-            '<InterfaceClass zope.interface.tests.test_exceptions.IDummy>: '
+            'zope.interface.tests.test_exceptions.IDummy: '
             "The 'missing' attribute was not provided.")
 
 
@@ -161,7 +161,7 @@ class MultipleInvalidTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             "The object 'target' has failed to implement interface "
-            "<InterfaceClass zope.interface.tests.test_exceptions.IDummy>:\n"
+            "zope.interface.tests.test_exceptions.IDummy:\n"
             "    The contract of 'aMethod' is violated because I said so\n"
             "    Regular exception"
         )

--- a/src/zope/interface/tests/test_ro.py
+++ b/src/zope/interface/tests/test_ro.py
@@ -259,16 +259,16 @@ class Test_c3_ro(Test_ro):
 
         self.assertEqual('\n'.join(l.rstrip() for l in record.getMessage().splitlines()), """\
 Object <InterfaceClass zope.interface.tests.test_ro.A> has different legacy and C3 MROs:
-  Legacy RO (len=7)                                  C3 RO (len=7; inconsistent=no)
-  ====================================================================================================
-    <InterfaceClass zope.interface.tests.test_ro.A>    <InterfaceClass zope.interface.tests.test_ro.A>
-    <InterfaceClass zope.interface.tests.test_ro.B>    <InterfaceClass zope.interface.tests.test_ro.B>
-  - <InterfaceClass zope.interface.tests.test_ro.E>
-    <InterfaceClass zope.interface.tests.test_ro.C>    <InterfaceClass zope.interface.tests.test_ro.C>
-    <InterfaceClass zope.interface.tests.test_ro.D>    <InterfaceClass zope.interface.tests.test_ro.D>
-                                                     + <InterfaceClass zope.interface.tests.test_ro.E>
-    <InterfaceClass zope.interface.tests.test_ro.F>    <InterfaceClass zope.interface.tests.test_ro.F>
-    <InterfaceClass zope.interface.Interface>          <InterfaceClass zope.interface.Interface>""")
+  Legacy RO (len=7)                 C3 RO (len=7; inconsistent=no)
+  ==================================================================
+    zope.interface.tests.test_ro.A    zope.interface.tests.test_ro.A
+    zope.interface.tests.test_ro.B    zope.interface.tests.test_ro.B
+  - zope.interface.tests.test_ro.E
+    zope.interface.tests.test_ro.C    zope.interface.tests.test_ro.C
+    zope.interface.tests.test_ro.D    zope.interface.tests.test_ro.D
+                                    + zope.interface.tests.test_ro.E
+    zope.interface.tests.test_ro.F    zope.interface.tests.test_ro.F
+    zope.interface.Interface          zope.interface.Interface""")
 
     def test_ExtendedPathIndex_implement_thing_implementedby_super(self):
         # See https://github.com/zopefoundation/zope.interface/pull/182#issuecomment-598754056


### PR DESCRIPTION
Only InterfaceClass got a str, so it now has a distinction. Other objects only got updated reprs.

Note: This may potentially break some doctests.

In many cases, the ``repr()`` is now something that can be evaluated to produce an equal object. For example, what was previously printed as ``<implementedBy builtins.list>`` is now shown as ``classImplements(list, IMutableSequence, IIterable)``.

Fixes #236

Here's a before with ZOPE_INTERFACE_LOG_CHANGED_IRO=1 in BTrees:
```
Object <implementedBy builtins.list> has different legacy and C3 MROs:
  Legacy RO (len=11)                                                        C3 RO (len=11; inconsistent=no)
  ==================================================================================================================================================
    <implementedBy builtins.list>                                             <implementedBy builtins.list>
    <ABCInterfaceClass zope.interface.common.collections.IMutableSequence>    <ABCInterfaceClass zope.interface.common.collections.IMutableSequence>
    <ABCInterfaceClass zope.interface.common.collections.ISequence>           <ABCInterfaceClass zope.interface.common.collections.ISequence>
    <ABCInterfaceClass zope.interface.common.collections.IReversible>         <ABCInterfaceClass zope.interface.common.collections.IReversible>
    <ABCInterfaceClass zope.interface.common.collections.ICollection>         <ABCInterfaceClass zope.interface.common.collections.ICollection>
    <ABCInterfaceClass zope.interface.common.collections.ISized>              <ABCInterfaceClass zope.interface.common.collections.ISized>
                                                                            + <ABCInterfaceClass zope.interface.common.collections.IIterable>
    <ABCInterfaceClass zope.interface.common.collections.IContainer>          <ABCInterfaceClass zope.interface.common.collections.IContainer>
  - <ABCInterfaceClass zope.interface.common.collections.IIterable>
    <ABCInterfaceClass zope.interface.common.ABCInterface>                    <ABCInterfaceClass zope.interface.common.ABCInterface>
                                                                            + <implementedBy builtins.object>
    <InterfaceClass zope.interface.Interface>                                 <InterfaceClass zope.interface.Interface>
  - <implementedBy builtins.object>
Object <ABCInterfaceClass zope.interface.common.mapping.IFullMapping> has different legacy and C3 MROs:
  Legacy RO (len=18)                                                       C3 RO (len=18; inconsistent=no)
  ================================================================================================================================================
    <ABCInterfaceClass zope.interface.common.mapping.IFullMapping>           <ABCInterfaceClass zope.interface.common.mapping.IFullMapping>
    <ABCInterfaceClass zope.interface.common.collections.IMutableMapping>    <ABCInterfaceClass zope.interface.common.collections.IMutableMapping>
    <ABCInterfaceClass zope.interface.common.collections.IMapping>           <ABCInterfaceClass zope.interface.common.collections.IMapping>
    <ABCInterfaceClass zope.interface.common.collections.ICollection>        <ABCInterfaceClass zope.interface.common.collections.ICollection>
  - <ABCInterfaceClass zope.interface.common.collections.IIterable>
    <InterfaceClass zope.interface.common.mapping.IExtendedReadMapping>      <InterfaceClass zope.interface.common.mapping.IExtendedReadMapping>
    <InterfaceClass zope.interface.common.mapping.IIterableMapping>          <InterfaceClass zope.interface.common.mapping.IIterableMapping>
    <InterfaceClass zope.interface.common.mapping.IExtendedWriteMapping>     <InterfaceClass zope.interface.common.mapping.IExtendedWriteMapping>
    <InterfaceClass zope.interface.common.mapping.IClonableMapping>          <InterfaceClass zope.interface.common.mapping.IClonableMapping>
    <InterfaceClass zope.interface.common.mapping.IMapping>                  <InterfaceClass zope.interface.common.mapping.IMapping>
    <InterfaceClass zope.interface.common.mapping.IWriteMapping>             <InterfaceClass zope.interface.common.mapping.IWriteMapping>
    <InterfaceClass zope.interface.common.mapping.IEnumerableMapping>        <InterfaceClass zope.interface.common.mapping.IEnumerableMapping>
    <ABCInterfaceClass zope.interface.common.collections.ISized>             <ABCInterfaceClass zope.interface.common.collections.ISized>
                                                                           + <ABCInterfaceClass zope.interface.common.collections.IIterable>
    <InterfaceClass zope.interface.common.mapping.IReadMapping>              <InterfaceClass zope.interface.common.mapping.IReadMapping>
    <ABCInterfaceClass zope.interface.common.collections.IContainer>         <ABCInterfaceClass zope.interface.common.collections.IContainer>
    <ABCInterfaceClass zope.interface.common.ABCInterface>                   <ABCInterfaceClass zope.interface.common.ABCInterface>
    <InterfaceClass zope.interface.common.mapping.IItemMapping>              <InterfaceClass zope.interface.common.mapping.IItemMapping>
    <InterfaceClass zope.interface.Interface>                                <InterfaceClass zope.interface.Interface>
Object <InterfaceClass BTrees.Interfaces.ISet> has different legacy and C3 MROs:
  Legacy RO (len=7)                                  C3 RO (len=7; inconsistent=no)
  ====================================================================================================
    <InterfaceClass BTrees.Interfaces.ISet>            <InterfaceClass BTrees.Interfaces.ISet>
    <InterfaceClass BTrees.Interfaces.IKeySequence>    <InterfaceClass BTrees.Interfaces.IKeySequence>
  - <InterfaceClass BTrees.Interfaces.ISized>
    <InterfaceClass BTrees.Interfaces.ISetMutable>     <InterfaceClass BTrees.Interfaces.ISetMutable>
    <InterfaceClass BTrees.Interfaces.IKeyed>          <InterfaceClass BTrees.Interfaces.IKeyed>
    <InterfaceClass BTrees.Interfaces.ICollection>     <InterfaceClass BTrees.Interfaces.ICollection>
                                                     + <InterfaceClass BTrees.Interfaces.ISized>
    <InterfaceClass zope.interface.Interface>          <InterfaceClass zope.interface.Interface>
```

And here's after:

```
Object classImplements(list, IMutableSequence, IIterable) has different legacy and C3 MROs:
  Legacy RO (len=11)                                    C3 RO (len=11; inconsistent=no)
  ==========================================================================================================
    classImplements(list, IMutableSequence, IIterable)    classImplements(list, IMutableSequence, IIterable)
    zope.interface.common.collections.IMutableSequence    zope.interface.common.collections.IMutableSequence
    zope.interface.common.collections.ISequence           zope.interface.common.collections.ISequence
    zope.interface.common.collections.IReversible         zope.interface.common.collections.IReversible
    zope.interface.common.collections.ICollection         zope.interface.common.collections.ICollection
    zope.interface.common.collections.ISized              zope.interface.common.collections.ISized
                                                        + zope.interface.common.collections.IIterable
    zope.interface.common.collections.IContainer          zope.interface.common.collections.IContainer
  - zope.interface.common.collections.IIterable
    zope.interface.common.ABCInterface                    zope.interface.common.ABCInterface
                                                        + classImplements(object)
    zope.interface.Interface                              zope.interface.Interface
  - classImplements(object)
Object <ABCInterfaceClass zope.interface.common.mapping.IFullMapping> has different legacy and C3 MROs:
  Legacy RO (len=18)                                     C3 RO (len=18; inconsistent=no)
  ============================================================================================================
    zope.interface.common.mapping.IFullMapping             zope.interface.common.mapping.IFullMapping
    zope.interface.common.collections.IMutableMapping      zope.interface.common.collections.IMutableMapping
    zope.interface.common.collections.IMapping             zope.interface.common.collections.IMapping
    zope.interface.common.collections.ICollection          zope.interface.common.collections.ICollection
  - zope.interface.common.collections.IIterable
    zope.interface.common.mapping.IExtendedReadMapping     zope.interface.common.mapping.IExtendedReadMapping
    zope.interface.common.mapping.IIterableMapping         zope.interface.common.mapping.IIterableMapping
    zope.interface.common.mapping.IExtendedWriteMapping    zope.interface.common.mapping.IExtendedWriteMapping
    zope.interface.common.mapping.IClonableMapping         zope.interface.common.mapping.IClonableMapping
    zope.interface.common.mapping.IMapping                 zope.interface.common.mapping.IMapping
    zope.interface.common.mapping.IWriteMapping            zope.interface.common.mapping.IWriteMapping
    zope.interface.common.mapping.IEnumerableMapping       zope.interface.common.mapping.IEnumerableMapping
    zope.interface.common.collections.ISized               zope.interface.common.collections.ISized
                                                         + zope.interface.common.collections.IIterable
    zope.interface.common.mapping.IReadMapping             zope.interface.common.mapping.IReadMapping
    zope.interface.common.collections.IContainer           zope.interface.common.collections.IContainer
    zope.interface.common.ABCInterface                     zope.interface.common.ABCInterface
    zope.interface.common.mapping.IItemMapping             zope.interface.common.mapping.IItemMapping
    zope.interface.Interface                               zope.interface.Interface
Object <InterfaceClass BTrees.Interfaces.ISet> has different legacy and C3 MROs:
  Legacy RO (len=7)                 C3 RO (len=7; inconsistent=no)
  ==================================================================
    BTrees.Interfaces.ISet            BTrees.Interfaces.ISet
    BTrees.Interfaces.IKeySequence    BTrees.Interfaces.IKeySequence
  - BTrees.Interfaces.ISized
    BTrees.Interfaces.ISetMutable     BTrees.Interfaces.ISetMutable
    BTrees.Interfaces.IKeyed          BTrees.Interfaces.IKeyed
    BTrees.Interfaces.ICollection     BTrees.Interfaces.ICollection
                                    + BTrees.Interfaces.ISized
    zope.interface.Interface          zope.interface.Interface
```