### PR TITLE
Make Declaration.__add__ try harder to produce consistent resolution orders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,14 @@
   shown as ``classImplements(list, IMutableSequence, IIterable)``. See
   `issue 236 <https://github.com/zopefoundation/zope.interface/issues/236>`_.
 
+- Make ``Declaration.__add__`` (as in ``implementedBy(Cls) +
+  ISomething``) try harder to preserve a consistent resolution order
+  when the two arguments share overlapping pieces of the interface
+  inheritance hierarchy. Previously, the right hand side was always
+  put at the end of the resolution order, which could easily produce
+  invalid orders. See `issue 193
+  <https://github.com/zopefoundation/zope.interface/issues/193>`_.
+
 5.3.0 (2020-03-21)
 ==================
 

--- a/docs/api/declarations.rst
+++ b/docs/api/declarations.rst
@@ -763,34 +763,38 @@ Exmples for :meth:`Declaration.__add__`:
 .. doctest::
 
    >>> from zope.interface import Interface
-   >>> class I1(Interface): pass
+   >>> class IRoot1(Interface): pass
    ...
-   >>> class I2(I1): pass
+   >>> class IDerived1(IRoot1): pass
    ...
-   >>> class I3(Interface): pass
+   >>> class IRoot2(Interface): pass
    ...
-   >>> class I4(I3): pass
+   >>> class IDerived2(IRoot2): pass
    ...
    >>> spec = Declaration()
    >>> [iface.getName() for iface in spec]
    []
-   >>> [iface.getName() for iface in spec+I1]
-   ['I1']
-   >>> [iface.getName() for iface in I1+spec]
-   ['I1']
+   >>> [iface.getName() for iface in spec+IRoot1]
+   ['IRoot1']
+   >>> [iface.getName() for iface in IRoot1+spec]
+   ['IRoot1']
    >>> spec2 = spec
-   >>> spec += I1
+   >>> spec += IRoot1
    >>> [iface.getName() for iface in spec]
-   ['I1']
+   ['IRoot1']
    >>> [iface.getName() for iface in spec2]
    []
-   >>> spec2 += Declaration(I3, I4)
+   >>> spec2 += Declaration(IRoot2, IDerived2)
    >>> [iface.getName() for iface in spec2]
-   ['I3', 'I4']
+   ['IDerived2', 'IRoot2']
    >>> [iface.getName() for iface in spec+spec2]
-   ['I1', 'I3', 'I4']
+   ['IRoot1', 'IDerived2', 'IRoot2']
    >>> [iface.getName() for iface in spec2+spec]
-   ['I3', 'I4', 'I1']
+   ['IDerived2', 'IRoot2', 'IRoot1']
+   >>> [iface.getName() for iface in (spec+spec2).__bases__]
+   ['IRoot1', 'IDerived2', 'IRoot2']
+   >>> [iface.getName() for iface in (spec2+spec).__bases__]
+   ['IDerived2', 'IRoot2', 'IRoot1']
 
 
 


### PR DESCRIPTION
By moving things from the RHS to the front of the list if they already extend something from the LHS.

Fixes #193

The [changes in the documentation](https://github.com/zopefoundation/zope.interface/compare/issue193?expand=1#diff-8ef5cd6985c269c8fa159314befb6fc8082c919e8f75727958b7e2fa36e2294a) are a good example of the kind of weird things that used to happen but which should now make more sense. Previously, you could get `IRoot2` ahead of `IDerived2`, which is inconsistent.

I'm not 100% positive this covers all possible cases (deeply nested hierarchies, branching at weird places) but it does fix the easy/common ones that I've seen in the real world. It can be improved as needed given further examples.