### PR TITLE
Fix the documentation so it can be tested with `ZOPE_INTERFACE_STRICT_IRO=1`.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -283,7 +283,7 @@ jobs:
           pip install -U  "`ls dist/zope.interface-*.whl`[docs]"
       - name: Build docs
         env:
-          ZOPE_INTERFACE_STRICT_IRO: 0
+          ZOPE_INTERFACE_STRICT_IRO: 1
         run: |
           sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
           sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest

--- a/docs/api/declarations.rst
+++ b/docs/api/declarations.rst
@@ -784,17 +784,17 @@ Exmples for :meth:`Declaration.__add__`:
    ['IRoot1']
    >>> [iface.getName() for iface in spec2]
    []
-   >>> spec2 += Declaration(IDerived2)
+   >>> spec2 += Declaration(IDerived2, IRoot2)
    >>> [iface.getName() for iface in spec2]
-   ['IDerived2']
+   ['IDerived2', 'IRoot2']
    >>> [iface.getName() for iface in spec+spec2]
-   ['IRoot1', 'IDerived2']
+   ['IRoot1', 'IDerived2', 'IRoot2']
    >>> [iface.getName() for iface in spec2+spec]
-   ['IDerived2', 'IRoot1']
+   ['IDerived2', 'IRoot2', 'IRoot1']
    >>> [iface.getName() for iface in (spec+spec2).__bases__]
-   ['IRoot1', 'IDerived2']
+   ['IRoot1', 'IDerived2', 'IRoot2']
    >>> [iface.getName() for iface in (spec2+spec).__bases__]
-   ['IDerived2', 'IRoot1']
+   ['IDerived2', 'IRoot2', 'IRoot1']
 
 
 

--- a/docs/api/declarations.rst
+++ b/docs/api/declarations.rst
@@ -744,7 +744,7 @@ Exmples for :meth:`Declaration.__sub__`:
    >>> spec -= I1
    >>> [iface.getName() for iface in spec]
    []
-   >>> spec -= Declaration(I1, I2)
+   >>> spec -= Declaration(I2)
    >>> [iface.getName() for iface in spec]
    []
    >>> spec = Declaration(I2, I4)
@@ -755,7 +755,7 @@ Exmples for :meth:`Declaration.__sub__`:
    >>> [iface.getName() for iface in spec - I1]
    ['I4']
    >>> [iface.getName() for iface
-   ...  in spec - Declaration(I3, I4)]
+   ...  in spec - Declaration(I4)]
    ['I2']
 
 Exmples for :meth:`Declaration.__add__`:
@@ -784,17 +784,17 @@ Exmples for :meth:`Declaration.__add__`:
    ['IRoot1']
    >>> [iface.getName() for iface in spec2]
    []
-   >>> spec2 += Declaration(IRoot2, IDerived2)
+   >>> spec2 += Declaration(IDerived2)
    >>> [iface.getName() for iface in spec2]
-   ['IDerived2', 'IRoot2']
+   ['IDerived2']
    >>> [iface.getName() for iface in spec+spec2]
-   ['IRoot1', 'IDerived2', 'IRoot2']
+   ['IRoot1', 'IDerived2']
    >>> [iface.getName() for iface in spec2+spec]
-   ['IDerived2', 'IRoot2', 'IRoot1']
+   ['IDerived2', 'IRoot1']
    >>> [iface.getName() for iface in (spec+spec2).__bases__]
-   ['IRoot1', 'IDerived2', 'IRoot2']
+   ['IRoot1', 'IDerived2']
    >>> [iface.getName() for iface in (spec2+spec).__bases__]
-   ['IDerived2', 'IRoot2', 'IRoot1']
+   ['IDerived2', 'IRoot1']
 
 
 

--- a/docs/verify.rst
+++ b/docs/verify.rst
@@ -83,16 +83,19 @@ desired interface.
    True
 
 If all instances will provide the interface, we can
-mark a class as implementing it.
+mark a class as implementing it. But we have to remove the interface from the
+instance first so a consistent interface resolution order can be achieved.
+(Calling ``gc.collect()`` is also necessary because we use weakrefs.)
 
 .. doctest::
 
-   >>> class Foo2(object):
-   ...     x = 1
-   ...     y = 2
    >>> from zope.interface import classImplements
-   >>> classImplements(Foo2, IFoo)
-   >>> verifyObject(IFoo, Foo2())
+   >>> from zope.interface import noLongerProvides
+   >>> import gc
+   >>> noLongerProvides(foo, IFoo)
+   >>> _ = gc.collect()
+   >>> classImplements(Foo, IFoo)
+   >>> verify_foo()
    True
 
 

--- a/docs/verify.rst
+++ b/docs/verify.rst
@@ -83,13 +83,16 @@ desired interface.
    True
 
 If all instances will provide the interface, we can
-mark the class as implementing it.
+mark a class as implementing it.
 
 .. doctest::
 
+   >>> class Foo2(object):
+   ...     x = 1
+   ...     y = 2
    >>> from zope.interface import classImplements
-   >>> classImplements(Foo, IFoo)
-   >>> verify_foo()
+   >>> classImplements(Foo2, IFoo)
+   >>> verifyObject(IFoo, Foo2())
    True
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -65,5 +65,3 @@ commands =
 deps =
     Sphinx
     repoze.sphinx.autointerface
-setenv =
-    ZOPE_INTERFACE_STRICT_IRO=0


### PR DESCRIPTION
See #241 for the list of failures occurring previously.

Closes #241.