### PR TITLE
Add some more entries to zope.interface.interfaces.__all__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Add missing Trove classifier showing support for Python 3.9.
 
+- Add some more entries to ``zope.interface.interfaces.__all__``.
+
 
 5.4.0 (2021-04-15)
 ==================

--- a/src/zope/interface/interfaces.py
+++ b/src/zope/interface/interfaces.py
@@ -20,6 +20,7 @@ from zope.interface.interface import Interface
 from zope.interface.declarations import implementer
 
 __all__ = [
+    'ComponentLookupError',
     'IAdapterRegistration',
     'IAdapterRegistry',
     'IAttribute',
@@ -32,6 +33,7 @@ __all__ = [
     'IInterface',
     'IInterfaceDeclaration',
     'IMethod',
+    'Invalid',
     'IObjectEvent',
     'IRegistered',
     'IRegistration',
@@ -40,6 +42,9 @@ __all__ = [
     'ISubscriptionAdapterRegistration',
     'IUnregistered',
     'IUtilityRegistration',
+    'ObjectEvent',
+    'Registered',
+    'Unregistered',
 ]
 
 # pylint:disable=inherit-non-class,no-method-argument,no-self-argument


### PR DESCRIPTION
`ComponentLookupError`, `Invalid`, `Registered`, and `Unregistered` are
all documented
(https://zopeinterface.readthedocs.io/en/latest/api/components.html), so
it seems odd not to list them in `__all__`.  `ObjectEvent` isn't
documented there, but it seems reasonable to export it as a base class
for similar events.