### PR TITLE
Fix tests for PyPy3.

### DIFF
--- a/src/zope/interface/common/tests/__init__.py
+++ b/src/zope/interface/common/tests/__init__.py
@@ -60,7 +60,8 @@ def add_verify_tests(cls, iface_classes_iter):
 
                 self.assertTrue(self.verify(iface, stdlib_class))
 
-            suffix = "%s_%s_%s" % (
+            suffix = "%s_%s_%s_%s" % (
+                stdlib_class.__module__.replace('.', '_'),
                 stdlib_class.__name__,
                 iface.__module__.replace('.', '_'),
                 iface.__name__


### PR DESCRIPTION
On PyPy3 the following `registered_classes` for `IMutableMapping` are
found:

```
{<class 'dict'>,
 <class 'pkg_resources._vendor.pyparsing.ParseResults'>,
 <class 'setuptools._vendor.pyparsing.ParseResults'>,
 <class 'collections.UserDict'>}
```

So collecting the tests fails because of a duplicate name which is prevented by this PR.

I have no idea why this does not happen for other Python versions.

Fixes #254.