### PR TITLE
Update to the latest c-code template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
   PIP_NO_WARN_SCRIPT_LOCATION: 1
 
-  CFLAGS: -Ofast -pipe
-  CXXFLAGS: -Ofast -pipe
+  CFLAGS: -O3 -pipe
+  CXXFLAGS: -O3 -pipe
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the
   # github repo settings.
@@ -91,6 +91,7 @@ jobs:
     # Sigh. Note that the matrix must be kept in sync
     # with `test`, and `docs` must use a subset.
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:
@@ -104,7 +105,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.4"
+          - "3.11.0-rc.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -153,8 +154,8 @@ jobs:
           pip install -U pip
           pip install -U setuptools wheel twine cffi
 
-      - name: Build zope.interface (3.11.0-beta.4)
-        if: ${{ startsWith(matrix.python-version, '3.11.0-beta.4') }}
+      - name: Build zope.interface (3.11.0-rc.1)
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.1') }}
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
@@ -209,7 +210,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-beta.4')
+          && !startsWith(matrix.python-version, '3.11.0-rc.1')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -231,7 +232,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.4"
+          - "3.11.0-rc.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "fe41b5a5937ad36d26b62be91d884b7530ec012f"
+commit-id = "a07c82b7813de1e000863e1d01058e417bc4b33d"
 
 [python]
 with-appveyor = true

--- a/src/zope/interface/tests/test_compile_flags.py
+++ b/src/zope/interface/tests/test_compile_flags.py
@@ -1,0 +1,29 @@
+##############################################################################
+#
+# Copyright (c) 2022 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+import struct
+import unittest
+
+import zope.interface  # noqa: try to load a C module for side effects
+
+
+class TestFloatingPoint(unittest.TestCase):
+
+    def test_no_fast_math_optimization(self):
+        # Building with -Ofast enables -ffast-math, which sets certain FPU
+        # flags that can cause breakage elsewhere.  A library such as BTrees
+        # has no business changing global FPU flags for the entire process.
+        zero_bits = struct.unpack("!Q", struct.pack("!d", 0.0))[0]
+        next_up = zero_bits + 1
+        smallest_subnormal = struct.unpack("!d", struct.pack("!Q", next_up))[0]
+        self.assertNotEqual(smallest_subnormal, 0.0)

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,7 @@ envlist =
 usedevelop = true
 pip_pre = py311: true
 deps =
-    # repoze.sphinx.autointerface does not yet support Sphinx >= 5:
-    Sphinx < 5
+    Sphinx
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy-!pypy3: PURE_PYTHON=0


### PR DESCRIPTION
Add a regression test for CFLAGS not having -Ofast, which is known to break things.  See https://github.com/zopefoundation/meta/pull/155 for reference.

Again, I was unable to confirm the regression test locally with
```
$ CFLAGS=-Ofast tox -re py38 -- -k test_no_fast_math_optimization
```