### PR TITLE
improve `declarations.Provides` documentation

### DIFF
--- a/src/zope/interface/declarations.py
+++ b/src/zope/interface/declarations.py
@@ -789,7 +789,11 @@ ProvidesClass = Provides
 InstanceDeclarations = weakref.WeakValueDictionary()
 
 def Provides(*interfaces): # pylint:disable=function-redefined
-    """Cache instance declarations
+    """Declaration for an instance of *cls*.
+
+       The correct signature is ``cls, *interfaces``.
+       The *cls* is necessary to avoid the
+       construction of inconsistent resolution orders.
 
       Instance declarations are shared among instances that have the same
       declaration. The declarations are cached in a weak value dictionary.


### PR DESCRIPTION
The signature of `declarations.Provides` is given as `*interfaces`. This is wrong; it actually is `cls, *interfaces` where *cls* is the class of the instance for which `Provides` should provide a declaration. This parameter is necessary to avoid the construction of inconsistent resolution orders.

The PR does not change the code but improves the `Provides` docstring and especially documents the correct signature there.