### PR TITLE
Add support to use the pipe (`|`) syntax for `typing.Union`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 
 - Add preliminary support for Python 3.13 as of 3.13a3.
 
+- Add support to use the pipe (``|``) syntax for ``typing.Union``.
+  (`#280 <https://github.com/zopefoundation/zope.interface/issues/280>`_)
+
+
 6.1 (2023-10-05)
 ================
 

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -18,6 +18,7 @@ import sys
 from types import MethodType
 from types import FunctionType
 import weakref
+from typing import Union
 
 from zope.interface._compat import _use_c_impl
 from zope.interface.exceptions import Invalid
@@ -940,6 +941,14 @@ class InterfaceClass(_InterfaceClassBase):
 
     def __reduce__(self):
         return self.__name__
+
+    def __or__(self, other):
+        """Allow type hinting syntax: Interface | None."""
+        return Union[self, other]
+
+    def __ror__(self, other):
+        """Allow type hinting syntax: None | Interface."""
+        return Union[other, self]
 
 Interface = InterfaceClass("Interface", __module__='zope.interface')
 # Interface is the only member of its own SRO.

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -2636,3 +2636,37 @@ class _Monkey:
     def __exit__(self, exc_type, exc_val, exc_tb):
         for key, value in self.to_restore.items():
             setattr(self.module, key, value)
+
+class TestTypeAnnotations(unittest.TestCase):
+    """Test using Interfaces in type annotations."""
+
+    def test___or__(self):
+        from zope.interface import Interface
+        from typing import Optional, Union
+        class I1(Interface):
+            pass
+        class I2(Interface):
+            pass
+
+        class B:
+            a: I1|None
+            b: I1|I2
+
+        self.assertEqual(
+            B.__annotations__, {'a': Optional[I1], 'b': Union[I1, I2]})
+
+    def test___ror__(self):
+        from zope.interface import Interface
+        from typing import Optional, Union
+        class I1(Interface):
+            pass
+
+        class A:
+            pass
+
+        class B:
+            a: None|I1
+            b: A|I1
+
+        self.assertEqual(
+            B.__annotations__, {'a': Optional[I1], 'b': Union[A, I1]})


### PR DESCRIPTION
Fixes #280.
Closes #267.