### PR TITLE
Ignore `__static_attributes__` added in Python 3.13a6.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add preliminary support for Python 3.13 as of 3.13a6.
 
 
 6.2 (2024-02-16)

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -799,6 +799,9 @@ class InterfaceClass(_InterfaceClassBase):
                 '__qualname__',
                 # __annotations__: PEP 3107 (Python 3.0+)
                 '__annotations__',
+                # __static_attributes__: Python 3.13a6+
+                # https://github.com/python/cpython/pull/115913
+                '__static_attributes__',
             )
             and aval is not _decorator_non_return
         }


### PR DESCRIPTION
Fixes #289.