### PR TITLE
Chore: Fix setuptools version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     tests_require=tests_require,
-    install_requires=['setuptools'],
+    install_requires=['setuptools<=69'],
     python_requires='>=3.8',
     extras_require={
         'docs': ['Sphinx',


### PR DESCRIPTION
This commit constraints setuptools version
lesser than or equal to 69 to be used while
installing zope interface via pip. this has
been done to avoid the error with setup tools
as stated in https://github.com/pypa/setuptools/issues/4519