### PR TITLE
chore: garden changelog post PR #307

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,12 @@
  Changes
 =========
 
-6.5 (unreleased)
+7.0 (unreleased)
 ================
+
+- Enable heap-based types (PEP 384) for Python >= 3.11.
+
+- Adopt multi-phase module initialization (PEP 489).
 
 - Drop support for Python 3.7.
 

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ long_description = (
 
 setup(
     name='zope.interface',
-    version='6.5.dev0',
+    version='7.0.dev0',
     url='https://github.com/zopefoundation/zope.interface',
     license='ZPL 2.1',
     description='Interfaces for Python',


### PR DESCRIPTION
Bump next version to `7.0` because of the dropped support for Python 3.7.