### PR TITLE
fix: ensure OSD is sublcassable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,11 @@
  Changes
 =========
 
-7.1 (unreleased)
-================
+7.0.post0 (unreleased)
+======================
 
-- Nothing changed yet.
+- Fix subclassability of ``ObjectSpecificationDescriptor`` (broken in 7.0).
+  (`#312 <https://github.com/zopefoundation/zope.interface/issues/312>`_)
 
 
 7.0 (2024-08-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
  Changes
 =========
 
-7.0.post0 (unreleased)
-======================
+7.0.1 (unreleased)
+==================
 
 - Fix subclassability of ``ObjectSpecificationDescriptor`` (broken in 7.0).
   (`#312 <https://github.com/zopefoundation/zope.interface/issues/312>`_)

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -57,10 +57,6 @@
  *      #c.PyTypeObject.tp_weaklistoffset
  */
 #define USE_EXPLICIT_WEAKREFLIST 0
-#define LEAFTYPE_FLAGS \
-    Py_TPFLAGS_DEFAULT | \
-    Py_TPFLAGS_MANAGED_WEAKREF | \
-    Py_TPFLAGS_HAVE_GC
 #define BASETYPE_FLAGS \
     Py_TPFLAGS_DEFAULT | \
     Py_TPFLAGS_BASETYPE | \
@@ -74,9 +70,6 @@
  *      #c.PyTypeObject.tp_weaklistoffset
  */
 #define USE_EXPLICIT_WEAKREFLIST 1
-#define LEAFTYPE_FLAGS \
-    Py_TPFLAGS_DEFAULT | \
-    Py_TPFLAGS_HAVE_GC
 #define BASETYPE_FLAGS \
     Py_TPFLAGS_DEFAULT | \
     Py_TPFLAGS_BASETYPE | \
@@ -546,7 +539,7 @@ static PyType_Slot OSD_type_slots[] = {
 static PyType_Spec OSD_type_spec = {
     .name               = OSD__name__,
     .basicsize          = 0,
-    .flags              = LEAFTYPE_FLAGS,
+    .flags              = BASETYPE_FLAGS,
     .slots              = OSD_type_slots
 };
 

--- a/src/zope/interface/tests/__init__.py
+++ b/src/zope/interface/tests/__init__.py
@@ -2,21 +2,16 @@ from zope.interface._compat import _should_attempt_c_optimizations
 
 
 class OptimizationTestMixin:
-    """
-    Helper for testing that C optimizations are used
-    when appropriate.
+    """Mixin testing that C optimizations are used when appropriate.
     """
 
     def _getTargetClass(self):
-        """
-        Define this to return the implementation in use,
-        without the 'Py' or 'Fallback' suffix.
+        """Return the implementation in use, without 'Py' or 'Fallback' suffix.
         """
         raise NotImplementedError
 
     def _getFallbackClass(self):
-        """
-        Define this to return the fallback Python implementation.
+        """Return the fallback Python implementation.
         """
         # Is there an algorithmic way to do this? The C
         # objects all come from the same module so I don't see how we can
@@ -31,6 +26,20 @@ class OptimizationTestMixin:
             self.assertIsNot(used, fallback)
         else:
             self.assertIs(used, fallback)
+
+
+class SubclassableMixin:
+
+    def _getTargetClass(self):
+        """Return the implementation in use without 'Py' or 'Fallback' suffix.
+        """
+        raise NotImplementedError
+
+    def test_can_subclass(self):
+        klass = self._getTargetClass()
+
+        class Derived(klass):  # no raise
+            pass
 
 
 class MissingSomeAttrs:

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -17,6 +17,7 @@ import unittest
 
 from zope.interface.tests import MissingSomeAttrs
 from zope.interface.tests import OptimizationTestMixin
+from zope.interface.tests import SubclassableMixin
 from zope.interface.tests.test_interface import \
     NameAndModuleComparisonTestsMixin
 
@@ -1803,8 +1804,11 @@ class ClassProvidesBaseFallbackTests(unittest.TestCase):
         self.assertRaises(AttributeError, getattr, bar, '__provides__')
 
 
-class ClassProvidesBaseTests(OptimizationTestMixin,
-                             ClassProvidesBaseFallbackTests):
+class ClassProvidesBaseTests(
+    OptimizationTestMixin,
+    ClassProvidesBaseFallbackTests,
+    SubclassableMixin,
+):
     # Repeat tests for C optimizations
 
     def _getTargetClass(self):
@@ -2632,7 +2636,9 @@ class ObjectSpecificationDescriptorFallbackTests(unittest.TestCase):
 
 class ObjectSpecificationDescriptorTests(
         ObjectSpecificationDescriptorFallbackTests,
-        OptimizationTestMixin):
+        OptimizationTestMixin,
+        SubclassableMixin,
+):
     # Repeat tests for C optimizations
 
     def _getTargetClass(self):

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -34,6 +34,7 @@ import unittest
 from zope.interface.tests import CleanUp
 from zope.interface.tests import MissingSomeAttrs
 from zope.interface.tests import OptimizationTestMixin
+from zope.interface.tests import SubclassableMixin
 
 
 _marker = object()
@@ -216,8 +217,11 @@ class GenericSpecificationBaseTests(unittest.TestCase):
             self.assertFalse(sb.implementedBy(object()))
 
 
-class SpecificationBaseTests(GenericSpecificationBaseTests,
-                             OptimizationTestMixin):
+class SpecificationBaseTests(
+    GenericSpecificationBaseTests,
+    OptimizationTestMixin,
+    SubclassableMixin,
+):
     # Tests that use the C implementation
 
     def _getTargetClass(self):
@@ -436,9 +440,12 @@ class InterfaceBaseTestsMixin(NameAndModuleComparisonTestsMixin):
         )
 
 
-class InterfaceBaseTests(InterfaceBaseTestsMixin,
-                         OptimizationTestMixin,
-                         unittest.TestCase):
+class InterfaceBaseTests(
+    InterfaceBaseTestsMixin,
+    OptimizationTestMixin,
+    SubclassableMixin,
+    unittest.TestCase,
+):
     # Tests that work with the C implementation
     def _getTargetClass(self):
         from zope.interface.interface import InterfaceBase


### PR DESCRIPTION
Broken in 7.0 release.

Closes #312.