### PR TITLE
Fix tests (based on config-with-c-code-template-acd39fc2)

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -15,7 +15,7 @@ with-macos = false
 [tox]
 use-flake8 = true
 testenv-commands = [
-    "coverage run -p -m unittest discover -s src {posargs}",
+    "coverage run -p -m unittest discover -s src/zope/interface {posargs}",
     ]
 testenv-setenv = [
     "ZOPE_INTERFACE_STRICT_IRO=1",

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ else:
 tests_require = [
     # The test dependencies should NOT have direct or transitive
     # dependencies on zope.interface.
-    'coverage >= 5.0.3',
+    'coverage[toml]',
     'zope.event',
     'zope.testing',
 ]

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -680,7 +680,7 @@ class Test_implementedByFallback(unittest.TestCase):
         foo.__name__ = 'foo'
         spec = self._callFUT(foo)
         self.assertEqual(spec.__name__,
-                         'zope.interface.tests.test_declarations.foo')
+                         'tests.test_declarations.foo')
         self.assertIs(spec.inherit, foo)
         self.assertIs(foo.__implemented__, spec)
         self.assertIs(
@@ -696,7 +696,7 @@ class Test_implementedByFallback(unittest.TestCase):
 
         spec = self._callFUT(Foo)
         self.assertEqual(spec.__name__,
-                         'zope.interface.tests.test_declarations.Foo')
+                         'tests.test_declarations.Foo')
         self.assertIs(spec.inherit, Foo)
         self.assertIs(Foo.__implemented__, spec)
         self.assertIsInstance(
@@ -1177,7 +1177,7 @@ class Test_implementer(Test_classImplements):
         self.assertIs(returned, foo)
         spec = foo.__implemented__  # pylint:disable=no-member
         self.assertEqual(
-            spec.__name__, 'zope.interface.tests.test_declarations.?'
+            spec.__name__, 'tests.test_declarations.?'
         )
         self.assertIsNone(spec.inherit,)
         self.assertIs(foo.__implemented__, spec)  # pylint:disable=no-member
@@ -1436,7 +1436,7 @@ class TestProvidesClassRepr(unittest.TestCase):
         self.assertEqual(
             repr(provides),
             "directlyProvides(('zope.interface.tests.dummy', "
-            "'zope.interface.tests.test_declarations'), "
+            "'tests.test_declarations'), "
             "IFoo, IBar)"
         )
 

--- a/src/zope/interface/tests/test_exceptions.py
+++ b/src/zope/interface/tests/test_exceptions.py
@@ -40,7 +40,7 @@ class DoesNotImplementTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             "An object has failed to implement interface "
-            "zope.interface.tests.test_exceptions.IDummy: "
+            "tests.test_exceptions.IDummy: "
             "Does not declaratively implement the interface."
         )
 
@@ -49,7 +49,7 @@ class DoesNotImplementTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             "The object 'candidate' has failed to implement interface "
-            "zope.interface.tests.test_exceptions.IDummy: "
+            "tests.test_exceptions.IDummy: "
             "Does not declaratively implement the interface."
         )
 
@@ -69,7 +69,7 @@ class BrokenImplementationTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             'An object has failed to implement interface '
-            'zope.interface.tests.test_exceptions.IDummy: '
+            'tests.test_exceptions.IDummy: '
             "The 'missing' attribute was not provided.")
 
     def test___str__w_candidate(self):
@@ -77,7 +77,7 @@ class BrokenImplementationTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             'The object \'candidate\' has failed to implement interface '
-            'zope.interface.tests.test_exceptions.IDummy: '
+            'tests.test_exceptions.IDummy: '
             "The 'missing' attribute was not provided.")
 
 
@@ -166,7 +166,7 @@ class MultipleInvalidTests(unittest.TestCase):
         self.assertEqual(
             str(dni),
             "The object 'target' has failed to implement interface "
-            "zope.interface.tests.test_exceptions.IDummy:\n"
+            "tests.test_exceptions.IDummy:\n"
             "    The contract of 'aMethod' is violated because I said so\n"
             "    Regular exception"
         )
@@ -183,7 +183,7 @@ class MultipleInvalidTests(unittest.TestCase):
         self.assertEqual(
             repr(dni),
             "MultipleInvalid("
-            "<InterfaceClass zope.interface.tests.test_exceptions.IDummy>,"
+            "<InterfaceClass tests.test_exceptions.IDummy>,"
             " 'target',"
             " (BrokenMethodImplementation('aMethod', 'I said so'),"
             " Exception('Regular', 'exception')))"

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -1175,7 +1175,7 @@ class InterfaceClassTests(unittest.TestCase):
         iface = self._makeOne('HashMe')
         self.assertEqual(
             hash(iface),
-            hash(('HashMe', 'zope.interface.tests.test_interface'))
+            hash(('HashMe', 'tests.test_interface'))
         )
 
     def test___hash___missing_required_attrs(self):

--- a/src/zope/interface/tests/test_ro.py
+++ b/src/zope/interface/tests/test_ro.py
@@ -298,17 +298,17 @@ class Test_c3_ro(Test_ro):
 
         expected = """\
 Object <InterfaceClass {name}> has different legacy and C3 MROs:
-  Legacy RO (len=7)                 C3 RO (len=7; inconsistent=no)
-  ==================================================================
-    zope.interface.tests.test_ro.A    zope.interface.tests.test_ro.A
-    zope.interface.tests.test_ro.B    zope.interface.tests.test_ro.B
-  - zope.interface.tests.test_ro.E
-    zope.interface.tests.test_ro.C    zope.interface.tests.test_ro.C
-    zope.interface.tests.test_ro.D    zope.interface.tests.test_ro.D
-                                    + zope.interface.tests.test_ro.E
-    zope.interface.tests.test_ro.F    zope.interface.tests.test_ro.F
-    zope.interface.Interface          zope.interface.Interface""".format(
-            name="zope.interface.tests.test_ro.A"
+  Legacy RO (len=7)           C3 RO (len=7; inconsistent=no)
+  ======================================================
+    tests.test_ro.A             tests.test_ro.A
+    tests.test_ro.B             tests.test_ro.B
+  - tests.test_ro.E
+    tests.test_ro.C             tests.test_ro.C
+    tests.test_ro.D             tests.test_ro.D
+                              + tests.test_ro.E
+    tests.test_ro.F             tests.test_ro.F
+    zope.interface.Interface    zope.interface.Interface""".format(
+            name="tests.test_ro.A"
         )
 
         self.assertEqual(

--- a/src/zope/interface/tests/test_sorting.py
+++ b/src/zope/interface/tests/test_sorting.py
@@ -59,9 +59,9 @@ class Test(unittest.TestCase):
         # interfaces with equal names but different modules should sort by
         # module name
         from zope.interface.tests.m1 import I1 as m1_I1
-        iface_list = [I1, m1_I1]
+        iface_list = [m1_I1, I1]
         iface_list.sort()
-        self.assertEqual(iface_list, [m1_I1, I1])
+        self.assertEqual(iface_list, [I1, m1_I1])
 
     def test_I1_I2(self):
         self.assertLess(I1.__name__, I2.__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
     !pure-!pypy3: PURE_PYTHON=0
     ZOPE_INTERFACE_STRICT_IRO=1
 commands =
-    coverage run -p -m unittest discover -s src {posargs}
+    coverage run -p -m unittest discover -s src/zope/interface {posargs}
     sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 extras =
     test


### PR DESCRIPTION
This separate branch shows how interface names as well as unittest commands have to change to work around the issues arising from removing `usedevelop` in the tox configuration.