### PR TITLE
Fix segmentation fault and FrameLocalsProxy check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 7.0.4 (unreleased)
 ==================
 
+- Fix segmentation faults on Python 3.13.
+  (`#323 <https://github.com/zopefoundation/zope.interface/issues/323>`_)
+
 
 7.0.3 (2024-08-27)
 ==================

--- a/src/zope/interface/common/tests/test_collections.py
+++ b/src/zope/interface/common/tests/test_collections.py
@@ -12,6 +12,7 @@
 
 
 import array
+import sys
 import unittest
 from collections import OrderedDict
 from collections import abc
@@ -127,6 +128,14 @@ class TestVerifyObject(VerifyObjectMixin,
         'async_generator': unittest.SkipTest,
         type(iter(tuple())): lambda: iter(tuple()),
     }
+    if sys.version_info >= (3, 13):
+        def FrameLocalsProxy_constructor():
+            FrameLocalsProxy = type([sys._getframe().f_locals for x in
+                                     range(1)][0])
+            return FrameLocalsProxy(sys._getframe())
+        FrameLocalsProxy = type([sys._getframe().f_locals for x in
+                                 range(1)][0])
+        CONSTRUCTORS[FrameLocalsProxy] = FrameLocalsProxy_constructor
 
     UNVERIFIABLE_RO = {
         # ``array.array`` fails the ``test_auto_ro_*`` tests with and

--- a/src/zope/interface/common/tests/test_collections.py
+++ b/src/zope/interface/common/tests/test_collections.py
@@ -101,6 +101,10 @@ class TestVerifyClass(VerifyClassMixin, unittest.TestCase):
 add_abc_interface_tests(TestVerifyClass, collections.ISet.__module__)
 
 
+def _get_FrameLocalsProxy():
+    return type(sys._getframe().f_locals)
+
+
 class TestVerifyObject(VerifyObjectMixin,
                        TestVerifyClass):
     CONSTRUCTORS = {
@@ -130,11 +134,8 @@ class TestVerifyObject(VerifyObjectMixin,
     }
     if sys.version_info >= (3, 13):
         def FrameLocalsProxy_constructor():
-            FrameLocalsProxy = type([sys._getframe().f_locals for x in
-                                     range(1)][0])
-            return FrameLocalsProxy(sys._getframe())
-        FrameLocalsProxy = type([sys._getframe().f_locals for x in
-                                 range(1)][0])
+            return _get_FrameLocalsProxy()(sys._getframe())
+        FrameLocalsProxy = _get_FrameLocalsProxy()
         CONSTRUCTORS[FrameLocalsProxy] = FrameLocalsProxy_constructor
 
     UNVERIFIABLE_RO = {


### PR DESCRIPTION
Related to #323 

The original issue, a segmentation fault, was fixed between Python 3.13rc2 and rc3. This PR applies a proposed patch by @vstinner in https://github.com/zopefoundation/zope.interface/issues/323#issuecomment-2374076122 to fix a followup issue.
