### PR TITLE
Ignore `__annotate_func__` added in Python 3.14b1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Change log
 
 - Move all supported package metadata into ``pyproject.toml``.
 
+- Ignore ``__annotate_func__`` added in Python 3.14b1.
+
 
 8.1.1 (2025-11-15)
 ------------------

--- a/src/zope/interface/interface.py
+++ b/src/zope/interface/interface.py
@@ -827,6 +827,8 @@ class InterfaceClass(_InterfaceClassBase):
                 '__firstlineno__',
                 # __classdictcell__: Python 3.14
                 '__classdictcell__',
+                # __annotate_func__: Python 3.14b1+
+                '__annotate_func__',
             ) and
             aval is not _decorator_non_return  # noqa W503
         }

--- a/src/zope/interface/tests/test_interface.py
+++ b/src/zope/interface/tests/test_interface.py
@@ -718,6 +718,23 @@ class InterfaceClassTests(unittest.TestCase):
         self.assertEqual(inst.__bases__, ())
         self.assertEqual(list(inst.names()), [])
 
+    def test_ctor_attrs_w___annotate_func__(self) -> None:
+        from zope.interface import Attribute
+        from zope.interface import Interface
+        from zope.interface import directlyProvides
+        from zope.interface.verify import verifyObject
+
+        class IAnnotated(Interface):
+            value: int = Attribute("Value")
+
+        class Annotated:
+            value: int = 0
+
+        self.assertEqual(list(IAnnotated.names()), ['value'])
+        annotated = Annotated()
+        directlyProvides(annotated, IAnnotated)
+        verifyObject(IAnnotated, annotated)
+
     def test_ctor_attrs_w__decorator_non_return(self):
         from zope.interface.interface import _decorator_non_return
         ATTRS = {'dropme': _decorator_non_return}


### PR DESCRIPTION
Following https://github.com/python/cpython/pull/132345, type annotations result in the annotate function being stored at `__annotate_func`.  This caused test failures in klein along the lines of:

```
zope.interface.exceptions.BrokenMethodImplementation: The object FrozenHTTPHeaders(rawHeaders=()) has failed to implement interface klein._imessage.IHTTPHeaders: The contract of klein._imessage.IHTTPHeaders.__annotate_func__(format) is violated because 'FrozenHTTPHeaders.__annotate__()' doesn't allow enough arguments.
```

Ignore this new internal name.

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [N/A] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.