### PR TITLE
Enable publishing free-threaded Python wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,8 +100,8 @@ jobs:
           - os: macos-latest
             python-version: "pypy-3.11"
         include:
-          - os: ubuntu-latest
-            python-version: "3.14t"
+          - python-version: "3.14t"
+            os: ubuntu-latest
 
     steps:
       - name: checkout
@@ -259,8 +259,8 @@ jobs:
           - os: macos-latest
             python-version: "pypy-3.11"
         include:
-          - os: ubuntu-latest
-            python-version: "3.14t"
+          - python-version: "3.14t"
+            os: ubuntu-latest
 
     steps:
       - name: checkout
@@ -623,11 +623,9 @@ jobs:
           # PyPy wheels shouldn't be uploaded, remove them if present
           find dist/ -name "*pypy*" -type f -delete || true
           find dist/ -name "*none-any*" -type f -delete || true
-          # Wheels for the no-yet-supported future Python version need to go
+          # Wheels for the not-yet-supported future Python version need to go
           find dist/ -name "*3.15*" -type f -delete || true
           find dist/ -name "*cp315*" -type f -delete || true
-          # Free-threaded wheels are not published separately
-          find dist/ -name "*cp314t*" -type f -delete || true
           # For Linux, we only want the manylinux wheels
           find dist/ -name "*linux_x86_64*" -type f -delete || true
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ lib64
 log/
 parts/
 pyvenv.cfg
+share/
 testing.log
 var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/c-code
 [meta]
 template = "c-code"
-commit-id = "f62d8bab"
+commit-id = "2dc4f53b"
 
 [python]
 with-pypy = true
@@ -11,6 +11,7 @@ with-windows = true
 with-future-python = true
 with-docs = true
 with-macos = false
+with-free-threaded-python = true
 
 [tox]
 use-flake8 = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: autopep8
       args: [--in-place, --aggressive, --aggressive]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     - id: pyupgrade
       args: [--py310-plus]

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py313,py313-pure
     py314,py314-pure
     py315,py315-pure
+    py314t,py314t-pure
     pypy3
     docs
     coverage


### PR DESCRIPTION
## Summary
- Update zope.meta configuration to latest
- Enable `with-free-threaded-python` to build and publish free-threaded wheels
- Remove deletion of `cp314t` wheels in publish step

Refs zopefoundation/meta#394