### PR TITLE
Guard 4 unprotected PyErr_Clear calls with exception type checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,13 @@ Change log
 
 - Add CI testing for free-threaded Python 3.14t (Linux).
 
+- Guard 4 unprotected ``PyErr_Clear()`` calls in the C extension with
+  ``PyErr_ExceptionMatches`` checks, matching the pattern already used at 7
+  other sites in the same file. Without the guard, ``KeyboardInterrupt``,
+  ``MemoryError``, and ``SystemExit`` are silently swallowed in
+  ``implementedBy`` and ``providedBy``.
+  See `issue 358 <https://github.com/zopefoundation/zope.interface/issues/358>`_.
+
 
 8.2 (2026-01-09)
 ----------------

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -2431,8 +2431,10 @@ implementedBy(PyObject* module, PyObject* cls)
         dict = PyObject_GetAttr(cls, str__dict__);
 
     if (dict == NULL) {
-        /* Probably a security proxied class, use more expensive fallback code
-         */
+        /* Probably a security proxied class, use more expensive fallback code.
+         * Only swallow AttributeError — propagate everything else. */
+        if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+            return NULL;
         PyErr_Clear();
         return implementedByFallback(module, cls);
     }
@@ -2449,6 +2451,10 @@ implementedBy(PyObject* module, PyObject* cls)
         return implementedByFallback(module, cls);
     }
 
+    /* PyObject_GetItem raises KeyError when key is not found.
+     * Only swallow KeyError — propagate everything else. */
+    if (!PyErr_ExceptionMatches(PyExc_KeyError))
+        return NULL;
     PyErr_Clear();
 
     /* Maybe we have a builtin */
@@ -2591,7 +2597,12 @@ providedBy(PyObject* module, PyObject* ob)
 
     result = PyObject_GetAttr(ob, str__provides__);
     if (result == NULL) {
-        /* No __provides__, so just fall back to implementedBy */
+        /* No __provides__, so just fall back to implementedBy.
+         * Only swallow AttributeError — propagate everything else. */
+        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            Py_DECREF(cls);
+            return NULL;
+        }
         PyErr_Clear();
         result = implementedBy(module, cls);
         Py_DECREF(cls);
@@ -2600,7 +2611,13 @@ providedBy(PyObject* module, PyObject* ob)
 
     cp = PyObject_GetAttr(cls, str__provides__);
     if (cp == NULL) {
-        /* The the class has no provides, assume we're done: */
+        /* The the class has no provides, assume we're done.
+         * Only swallow AttributeError — propagate everything else. */
+        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            Py_DECREF(cls);
+            Py_DECREF(result);
+            return NULL;
+        }
         PyErr_Clear();
         Py_DECREF(cls);
         return result;

--- a/src/zope/interface/tests/test_declarations.py
+++ b/src/zope/interface/tests/test_declarations.py
@@ -895,6 +895,27 @@ class Test_implementedBy(Test_implementedByFallback,
         from zope.interface.declarations import implementedBy
         return implementedBy
 
+    def test_catches_only_KeyError_on_implemented(self):
+        # C code (line 2454): PyErr_Clear after
+        # PyObject_GetItem(dict, "__implemented__") must not swallow
+        # non-KeyError exceptions. The Python fallback uses dict.get()
+        # which does not call __getitem__, so this is C-only.
+        # Use a non-type object (so C skips PyType_Check/tp_dict) with
+        # a __dict__ whose __getitem__ raises KeyboardInterrupt.
+        class EvilDict(dict):
+            def __getitem__(self, key):
+                if key == "__implemented__":
+                    raise KeyboardInterrupt("getitem bomb")
+                return super().__getitem__(key)
+
+        ob = MissingSomeAttrs(
+            KeyboardInterrupt,
+            __dict__=EvilDict(),
+            __class__=type,
+        )
+        with self.assertRaises(KeyboardInterrupt):
+            self._callFUT(ob)
+
 
 class _ImplementsTestMixin:
     FUT_SETS_PROVIDED_BY = True


### PR DESCRIPTION
## Summary

- Guard 4 bare `PyErr_Clear()` calls in `implementedBy` and `providedBy` with
  `PyErr_ExceptionMatches` checks, matching the pattern already used at 7 other
  sites in the same file
- Without the guard, `KeyboardInterrupt`, `MemoryError`, and `SystemExit` are
  silently swallowed instead of propagated

## Sites fixed

| Function | Line | After | Guard |
|----------|------|-------|-------|
| `implementedBy` | 2436 | `PyObject_GetAttr(cls, "__dict__")` | `PyExc_AttributeError` |
| `implementedBy` | 2454 | `PyObject_GetItem(dict, "__implemented__")` | `PyExc_KeyError` |
| `providedBy` | 2601 | `PyObject_GetAttr(ob, "__provides__")` | `PyExc_AttributeError` |
| `providedBy` | 2615 | `PyObject_GetAttr(cls, "__provides__")` | `PyExc_AttributeError` |

## Performance impact

Zero on the happy path. `PyErr_ExceptionMatches` only executes when an error has
already occurred. Normal operation never enters these blocks.

## Test plan

- [x] New test: `test_catches_only_KeyError_on_implemented` (C-only, verifies
  `KeyboardInterrupt` from `__getitem__` propagates instead of being swallowed)
- [x] Full test suite passes: 1359 tests, both `PURE_PYTHON=0` and `PURE_PYTHON=1`
- [x] No regressions

Fixes #358

Based on analysis from https://gist.github.com/devdanzin/5afbad864934b165a2cc080f110aa720

🤖 Generated with [Claude Code](https://claude.ai/claude-code)