### PR TITLE
Add Windows ARM64 support in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,10 +95,14 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.15"
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
         exclude:
           - os: macos-latest
             python-version: "pypy-3.11"
+          - os: windows-11-arm
+            python-version: "pypy-3.11"
+          - os: windows-11-arm
+            python-version: "3.10"
         include:
           - python-version: "3.14t"
             os: ubuntu-latest
@@ -232,9 +236,15 @@ jobs:
         with:
           name: zope.interface-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/*arm64.whl
-      - name: Upload zope.interface wheel (all other platforms)
-        if: >
-          !startsWith(runner.os, 'Mac')
+      - name: Upload zope.interface wheel (Windows)
+        if: startsWith(runner.os, 'Windows')
+        uses: actions/upload-artifact@v4
+        with:
+          name: zope.interface-${{ runner.os }}-${{ matrix.python-version }}-${{ runner.arch }}.whl
+          path: dist/*whl
+
+      - name: Upload zope.interface wheel (Linux)
+        if: startsWith(runner.os, 'Linux')
         uses: actions/upload-artifact@v4
         with:
           name: zope.interface-${{ runner.os }}-${{ matrix.python-version }}.whl
@@ -254,10 +264,14 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.15"
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
         exclude:
           - os: macos-latest
             python-version: "pypy-3.11"
+          - os: windows-11-arm
+            python-version: "pypy-3.11"
+          - os: windows-11-arm
+            python-version: "3.10"
         include:
           - python-version: "3.14t"
             os: ubuntu-latest
@@ -308,10 +322,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Download zope.interface wheel
+      - name: Download zope.interface wheel (Linux/macOS)
+        if: "!startsWith(runner.os, 'Windows')"
         uses: actions/download-artifact@v4
         with:
           name: zope.interface-${{ runner.os }}-${{ matrix.python-version }}.whl
+          path: dist/
+
+      - name: Download zope.interface wheel (Windows)
+        if: startsWith(runner.os, 'Windows')
+        uses: actions/download-artifact@v4
+        with:
+          name: zope.interface-${{ runner.os }}-${{ matrix.python-version }}-${{ runner.arch }}.whl
           path: dist/
       - name: Install zope.interface
         # ``python -m unittest discover`` only works with editable


### PR DESCRIPTION
This PR adds Windows ARM64 support to the CI build and test matrix for zope.interface.

- Adds `windows-11-arm` to the os matrix in both build-package and test jobs.
- Excludes pypy-3.11 and 3.10 for `windows-11-arm` as they are not supported on Windows ARM64.
- Splits the artifact upload/download steps into separate Windows and Linux steps, using `runner.arch` in the artifact name for Windows to avoid naming conflicts between `windows-latest` (X64) and `windows-11-arm` (ARM64).


- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.