### PR TITLE
Upgrade pip via `python -m pip` so the PyPy/Windows job stops failing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,12 +163,12 @@ jobs:
       - name: Install Build Dependencies (3.15)
         if: startsWith(matrix.python-version, '3.15')
         run: |
-          pip install -U pip
+          python -m pip install -U pip
           pip install -U "setuptools >= 78.1.1,< 82" wheel twine cffi pycparser
       - name: Install Build Dependencies
         if: ${{ !startsWith(matrix.python-version, '3.15') }}
         run: |
-          pip install -U pip
+          python -m pip install -U pip
           pip install -U "setuptools >= 78.1.1,< 82" wheel twine
 
       - name: Build zope.interface (macOS x86_64)
@@ -225,7 +225,7 @@ jobs:
         if: ${{ !startsWith(matrix.python-version, '3.15') }}
         run: |
           # Install to collect dependencies into the (pip) cache.
-          pip install -U pip "setuptools >= 78.1.1,< 82"
+          python -m pip install -U pip "setuptools >= 78.1.1,< 82"
           pip install .[test]
 
       - name: Check zope.interface build
@@ -602,7 +602,7 @@ jobs:
 
 
       - name: Update pip
-        run: pip install -U pip
+        run: python -m pip install -U pip
 
       - name: Build zope.interface
         if: matrix.image != 'manylinux2014_i686'


### PR DESCRIPTION
On Windows the `pip.exe` shim refuses to replace itself (`ERROR: To modify pip, please run
the following command: ...python.exe -m pip install -U pip`), and a multi-line `pwsh`
`run:` only propagates the last command's exit code, so that failure went unnoticed. The
PyPy/Windows job therefore stayed on the pip 24.0 that `ensurepip` ships, and pip 24.0
does not invalidate corrupt entries in its HTTP cache — which we persist via
`actions/cache`. Result: `build-package (pypy-3.11, windows-latest)` failed with
`OSError: Connection broken: IncompleteRead(...)` on every run that restored the bad
entry, until GitHub happened to evict it.

Verified over two runs: pip now reaches 26.2.1, and the job passes on a **cache hit** of
the freshly written entry — the condition that failed nine times since May. The stale
cache entry was deleted, so `master` is unblocked regardless of this PR.

Next step: I plan to put this into `zope.meta` — `tests.yml` is generated, so this fix
would otherwise be reverted on the next template run. See zopefoundation/meta#436.
