### PR TITLE
Configuring for c-code

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,8 +21,8 @@ jobs:
     name: linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
       with:
         python-version: '3.13'
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  #v3.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,6 +140,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
+      - name: Get pip cache epoch
+        id: pip-cache-epoch
+        # ``actions/cache`` never replaces an entry: "if the provided key
+        # matches an existing cache, a new cache is not created". A corrupt
+        # entry would therefore break every run that restores it until GitHub
+        # evicts it. Rotating the key weekly abandons such an entry instead.
+        run: |
+          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -149,7 +158,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
 
 
       - name: Install Build Dependencies (3.15)
@@ -320,6 +329,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
+      - name: Get pip cache epoch
+        id: pip-cache-epoch
+        # ``actions/cache`` never replaces an entry: "if the provided key
+        # matches an existing cache, a new cache is not created". A corrupt
+        # entry would therefore break every run that restores it until GitHub
+        # evicts it. Rotating the key weekly abandons such an entry instead.
+        run: |
+          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -329,7 +347,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
 
       - name: Download zope.interface wheel (Linux/macOS)
         if: "!startsWith(runner.os, 'Windows')"
@@ -410,6 +428,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
+      - name: Get pip cache epoch
+        id: pip-cache-epoch
+        # ``actions/cache`` never replaces an entry: "if the provided key
+        # matches an existing cache, a new cache is not created". A corrupt
+        # entry would therefore break every run that restores it until GitHub
+        # evicts it. Rotating the key weekly abandons such an entry instead.
+        run: |
+          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -419,7 +446,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
 
       - name: Download zope.interface wheel
         uses: actions/download-artifact@v8
@@ -462,6 +489,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
+      - name: Get pip cache epoch
+        id: pip-cache-epoch
+        # ``actions/cache`` never replaces an entry: "if the provided key
+        # matches an existing cache, a new cache is not created". A corrupt
+        # entry would therefore break every run that restores it until GitHub
+        # evicts it. Rotating the key weekly abandons such an entry instead.
+        run: |
+          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -471,7 +507,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
 
       - name: Download zope.interface wheel
         uses: actions/download-artifact@v8
@@ -521,6 +557,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
+      - name: Get pip cache epoch
+        id: pip-cache-epoch
+        # ``actions/cache`` never replaces an entry: "if the provided key
+        # matches an existing cache, a new cache is not created". A corrupt
+        # entry would therefore break every run that restores it until GitHub
+        # evicts it. Rotating the key weekly abandons such an entry instead.
+        run: |
+          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -530,7 +575,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}
+          key: ${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
 
 
       - name: Update pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,13 @@ on:
   # Allow to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+defaults:
+  run:
+    # ``pwsh`` propagates only the exit code of the *last* command of a
+    # multi-command block, so failures on Windows go unnoticed. ``bash``
+    # runs with ``-eo pipefail`` and aborts the step on the first failure.
+    shell: bash
+
 env:
   # Weirdly, this has to be a top-level key, not ``defaults.env``
   PYTHONHASHSEED: 8675309
@@ -119,11 +126,11 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -133,30 +140,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache dir (default)
-        id: pip-cache-default
-        if: ${{ !startsWith(runner.os, 'Windows') }}
+      - name: Get pip cache dir
+        id: pip-cache
         run: |
-          echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
-      - name: Get pip cache dir (Windows)
-        id: pip-cache-windows
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        run: |
-          echo "dir=$(pip cache dir)" >> $Env:GITHUB_OUTPUT
-
-      - name: pip cache (default)
+      - name: pip cache
         uses: actions/cache@v5
-        if: ${{ !startsWith(runner.os, 'Windows') }}
         with:
-          path: ${{ steps.pip-cache-default.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
-
-      - name: pip cache (Windows)
-        uses: actions/cache@v5
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        with:
-          path: ${{ steps.pip-cache-windows.outputs.dir }}
+          path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
 
 
@@ -314,11 +306,11 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -328,30 +320,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache dir (default)
-        id: pip-cache-default
-        if: ${{ !startsWith(runner.os, 'Windows') }}
+      - name: Get pip cache dir
+        id: pip-cache
         run: |
-          echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
-      - name: Get pip cache dir (Windows)
-        id: pip-cache-windows
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        run: |
-          echo "dir=$(pip cache dir)" >> $Env:GITHUB_OUTPUT
-
-      - name: pip cache (default)
+      - name: pip cache
         uses: actions/cache@v5
-        if: ${{ !startsWith(runner.os, 'Windows') }}
         with:
-          path: ${{ steps.pip-cache-default.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
-
-      - name: pip cache (Windows)
-        uses: actions/cache@v5
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        with:
-          path: ${{ steps.pip-cache-windows.outputs.dir }}
+          path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
 
       - name: Download zope.interface wheel (Linux/macOS)
@@ -419,11 +396,11 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -433,30 +410,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache dir (default)
-        id: pip-cache-default
-        if: ${{ !startsWith(runner.os, 'Windows') }}
+      - name: Get pip cache dir
+        id: pip-cache
         run: |
-          echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
-      - name: Get pip cache dir (Windows)
-        id: pip-cache-windows
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        run: |
-          echo "dir=$(pip cache dir)" >> $Env:GITHUB_OUTPUT
-
-      - name: pip cache (default)
+      - name: pip cache
         uses: actions/cache@v5
-        if: ${{ !startsWith(runner.os, 'Windows') }}
         with:
-          path: ${{ steps.pip-cache-default.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
-
-      - name: pip cache (Windows)
-        uses: actions/cache@v5
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        with:
-          path: ${{ steps.pip-cache-windows.outputs.dir }}
+          path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
 
       - name: Download zope.interface wheel
@@ -486,11 +448,11 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -500,30 +462,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache dir (default)
-        id: pip-cache-default
-        if: ${{ !startsWith(runner.os, 'Windows') }}
+      - name: Get pip cache dir
+        id: pip-cache
         run: |
-          echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
-      - name: Get pip cache dir (Windows)
-        id: pip-cache-windows
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        run: |
-          echo "dir=$(pip cache dir)" >> $Env:GITHUB_OUTPUT
-
-      - name: pip cache (default)
+      - name: pip cache
         uses: actions/cache@v5
-        if: ${{ !startsWith(runner.os, 'Windows') }}
         with:
-          path: ${{ steps.pip-cache-default.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
-
-      - name: pip cache (Windows)
-        uses: actions/cache@v5
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        with:
-          path: ${{ steps.pip-cache-windows.outputs.dir }}
+          path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
 
       - name: Download zope.interface wheel
@@ -560,11 +507,11 @@ jobs:
             python-version: "3.13"
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -574,30 +521,15 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache dir (default)
-        id: pip-cache-default
-        if: ${{ !startsWith(runner.os, 'Windows') }}
+      - name: Get pip cache dir
+        id: pip-cache
         run: |
-          echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
-      - name: Get pip cache dir (Windows)
-        id: pip-cache-windows
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        run: |
-          echo "dir=$(pip cache dir)" >> $Env:GITHUB_OUTPUT
-
-      - name: pip cache (default)
+      - name: pip cache
         uses: actions/cache@v5
-        if: ${{ !startsWith(runner.os, 'Windows') }}
         with:
-          path: ${{ steps.pip-cache-default.outputs.dir }}
-          key: ${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}
-
-      - name: pip cache (Windows)
-        uses: actions/cache@v5
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        with:
-          path: ${{ steps.pip-cache-windows.outputs.dir }}
+          path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}
 
 
@@ -628,7 +560,7 @@ jobs:
           name: manylinux_${{ matrix.image }}_wheels.zip
 
       - name: Restore pip cache permissions
-        run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
+        run: sudo chown -R $(whoami) ${{ steps.pip-cache.outputs.dir }}
 
       - name: Prevent publishing wheels for unreleased Python versions
         run: VER=$(echo '3.15' | tr -d .) && ls -al wheelhouse && sudo rm -f wheelhouse/*-cp${VER}*.whl && ls -al wheelhouse

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/c-code
 [meta]
 template = "c-code"
-commit-id = "b2dc8de8"
+commit-id = "764de66b"
 
 [python]
 with-pypy = true
@@ -15,9 +15,6 @@ with-free-threaded-python = true
 
 [tox]
 use-flake8 = true
-additional-envlist = [
-    "py314t,py314t-pure",
-]
 testenv-commands = [
     "pip install -U -e .[test]",
     "coverage run -p -m unittest discover -s src/zope {posargs}",

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/c-code
 [meta]
 template = "c-code"
-commit-id = "764de66b"
+commit-id = "2b430234"
 
 [python]
 with-pypy = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
-# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/c-code
 [build-system]
 requires = [
     "setuptools",
@@ -86,4 +84,5 @@ readme = {file = ["README.rst", "CHANGES.rst"]}
 
 [tool.zest-releaser]
 create-wheel = false
+extra-message = ""
 upload-pypi = false

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ pip_pre =
     py315t: true
 deps =
     setuptools >= 78.1.1,< 82
-    Sphinx
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy3: PURE_PYTHON=0


### PR DESCRIPTION
Applies the templates from zopefoundation/meta#437 (not merged yet, hence the
`commit-id` pointing at that branch).

The point of this PR is the Windows CI evidence #437 cannot get on its own:
every `run:` block now uses `bash`, so a failing command no longer gets
swallowed on Windows, and the OS-split pip cache steps collapse into one pair.

`pyproject.toml` loses the `zope.meta` header comment — that is `tomlkit`
round-tripping in `config-package`, unrelated to #437.