### PR TITLE
Fix free-threaded data race in the C LookupBase cache (#380)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Change log
 8.7 (unreleased)
 ----------------
 
+- Fix a free-threaded (no-GIL) data race in the C ``LookupBase`` cache: concurrent
+  ``lookup()`` and ``changed()`` calls could crash the interpreter because the
+  ``_cache``/``_mcache``/``_scache`` fields were created and cleared without
+  synchronization.  The field lifecycle is now guarded by a critical section on
+  Python 3.13+.  (`#380 <https://github.com/zopefoundation/zope.interface/issues/380>`_)
+
 
 8.6 (2026-08-20)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,11 @@ Change log
 8.7 (unreleased)
 ----------------
 
-- Fix a free-threaded (no-GIL) data race in the C ``LookupBase`` cache: concurrent
-  ``lookup()`` and ``changed()`` calls could crash the interpreter because the
-  ``_cache``/``_mcache``/``_scache`` fields were created and cleared without
-  synchronization.  The field lifecycle is now guarded by a critical section on
-  Python 3.13+.  (`#380 <https://github.com/zopefoundation/zope.interface/issues/380>`_)
+- Fix free-threaded (no-GIL) data races in the C lookup caches.  Concurrent
+  ``lookup()`` and ``changed()`` calls could crash while cache or
+  ``VerifyingBase`` snapshot fields were being replaced.  Their lifetimes are
+  now guarded by a critical section on Python 3.13+.
+  (`#380 <https://github.com/zopefoundation/zope.interface/issues/380>`_)
 
 
 8.6 (2026-08-20)

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -64,13 +64,6 @@ _PyDict_GetItemRef(PyObject *p, PyObject *key, PyObject **result)
 #define PyDict_GetItemRef _PyDict_GetItemRef
 #endif
 
-#define ASSURE_DICT(N)                                                         \
-    if (N == NULL) {                                                           \
-        N = PyDict_New();                                                      \
-        if (N == NULL)                                                         \
-            return NULL;                                                       \
-    }
-
 /* Py_BEGIN/END_CRITICAL_SECTION arrived in 3.13.  Where it is unavailable the GIL
  * serializes everything, so the fallback is a plain block that takes no lock.
  * Guarded by capability (#ifndef), not version, so a backport is respected. */
@@ -1178,6 +1171,7 @@ LB_traverse(LB* self, visitproc visit, void* arg)
 static int
 LB_clear(LB* self)
 {
+    /* Runtime invalidation uses LB_changed(); this is for GC/deallocation. */
     Py_CLEAR(self->_cache);
     Py_CLEAR(self->_mcache);
     Py_CLEAR(self->_scache);
@@ -1205,10 +1199,7 @@ LB_dealloc(LB* self)
 static PyObject*
 LB_changed(LB* self, PyObject* ignored)
 {
-    /* Detach the three cache dicts under a critical section so this cannot race a
-     * concurrent lookup()'s field access (#380).  DECREF them AFTER releasing the
-     * section: a dict dealloc can run arbitrary Python (__del__), which must not
-     * execute while the lock is held. */
+    /* Detach while locked, then decref where finalizers may safely run. */
     PyObject *cache, *mcache, *scache;
     Py_BEGIN_CRITICAL_SECTION(OBJECT(self));
     cache = self->_cache;   self->_cache = NULL;
@@ -1236,20 +1227,10 @@ LB_changed(LB* self, PyObject* ignored)
             cache = c
         return cache
 */
-/* Ensure *field is a dict and return a NEW strong reference to it, taking a critical
- * section on 'self' so the field's create/read cannot race a concurrent detach in
- * LB_changed() on a free-threaded build (#380 Q2/Q3).  NO Python runs inside the
- * section: Py_NewRef and pointer publication cannot re-enter.  Dict allocation is
- * performed outside the section, after a locked miss, then the field is checked
- * again before publication.  The returned strong reference keeps the dict alive
- * if LB_changed() detaches the field immediately afterward.  Returns NULL (error
- * set) only on allocation failure.
- *
- * NOTE: this guarantees memory safety, not linearizable invalidation -- a lookup that
- * retains a now-detached cache may still populate/return from that retired generation.
- * That is acceptable per the cache's semantics (a stale/duplicate cache entry, never a
- * use-after-free); strict invalidation would require generation checks with callback
- * and deadlock implications out of scope for this fix. */
+/* Return a strong cache-field reference.  Allocation and decref stay outside the
+ * critical section, where Python execution is permitted.  This guarantees memory
+ * safety, not linearizable invalidation: an in-flight lookup may finish against a
+ * cache generation that changed() has detached. */
 static PyObject*
 _assure_cache_field(LB* self, PyObject** field)
 {
@@ -1924,6 +1905,7 @@ VB_traverse(VB* self, visitproc visit, void* arg)
 static int
 VB_clear(VB* self)
 {
+    /* Runtime invalidation uses verify_changed(); this is for GC/deallocation. */
     Py_CLEAR(self->_verify_generations);
     Py_CLEAR(self->_verify_ro);
     return LB_clear((LB*)self);
@@ -1950,11 +1932,13 @@ VB_dealloc(VB* self)
 static PyObject*
 _generations_tuple(PyObject* ro)
 {
-    int i, l;
+    Py_ssize_t i, l;
     PyObject* generations;
 
     l = PyTuple_GET_SIZE(ro);
     generations = PyTuple_New(l);
+    if (generations == NULL)
+        return NULL;
     for (i = 0; i < l; i++) {
         PyObject* generation;
 
@@ -1971,9 +1955,26 @@ _generations_tuple(PyObject* ro)
 static PyObject*
 verify_changed(VB* self, PyObject* ignored)
 {
-    PyObject *t, *ro;
+    PyObject *cache, *mcache, *scache;
+    PyObject *old_ro, *old_generations;
+    PyObject *replaced_ro, *replaced_generations;
+    PyObject *t, *ro, *generations;
 
-    VB_clear(self);
+    /* Clear all lookup and verification fields as one state transition.  The
+     * detached objects remain alive until after the critical section. */
+    Py_BEGIN_CRITICAL_SECTION(OBJECT(self));
+    cache = self->lookup._cache;   self->lookup._cache = NULL;
+    mcache = self->lookup._mcache; self->lookup._mcache = NULL;
+    scache = self->lookup._scache; self->lookup._scache = NULL;
+    old_ro = self->_verify_ro;     self->_verify_ro = NULL;
+    old_generations = self->_verify_generations;
+    self->_verify_generations = NULL;
+    Py_END_CRITICAL_SECTION();
+    Py_XDECREF(cache);
+    Py_XDECREF(mcache);
+    Py_XDECREF(scache);
+    Py_XDECREF(old_ro);
+    Py_XDECREF(old_generations);
 
     t = PyObject_GetAttr(OBJECT(self), str_registry);
     if (t == NULL)
@@ -1994,16 +1995,24 @@ verify_changed(VB* self, PyObject* ignored)
     if (ro == NULL)
         return NULL;
 
-    self->_verify_generations = _generations_tuple(ro);
-    if (self->_verify_generations == NULL) {
+    generations = _generations_tuple(ro);
+    if (generations == NULL) {
         Py_DECREF(ro);
         return NULL;
     }
 
+    /* Another changed() may have published a newer pair while Python ran
+     * above.  Replace both fields atomically and retire that pair afterward. */
+    Py_BEGIN_CRITICAL_SECTION(OBJECT(self));
+    replaced_ro = self->_verify_ro;
+    replaced_generations = self->_verify_generations;
     self->_verify_ro = ro;
+    self->_verify_generations = generations;
+    Py_END_CRITICAL_SECTION();
+    Py_XDECREF(replaced_ro);
+    Py_XDECREF(replaced_generations);
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 /*
@@ -2015,11 +2024,25 @@ verify_changed(VB* self, PyObject* ignored)
 static int
 _verify(VB* self)
 {
+    PyObject* ro = NULL;
+    PyObject* generations = NULL;
     PyObject* changed_result;
 
+    /* Snapshot the pair under the same lock used by verify_changed().  Every
+     * subsequent borrowed item is then owned transitively by these references,
+     * even when PyObject_GetAttr() or comparison runs Python. */
+    Py_BEGIN_CRITICAL_SECTION(OBJECT(self));
     if (self->_verify_ro != NULL && self->_verify_generations != NULL) {
-        int i, l;
-        l = PyTuple_GET_SIZE(self->_verify_ro);
+        ro = Py_NewRef(self->_verify_ro);
+        generations = Py_NewRef(self->_verify_generations);
+    }
+    Py_END_CRITICAL_SECTION();
+
+    if (ro != NULL) {
+        Py_ssize_t i, l;
+        l = PyTuple_GET_SIZE(ro);
+        if (PyTuple_GET_SIZE(generations) != l)
+            goto changed;
 
         /* Compare each registry's current _generation counter against the
          * snapshot stored in _verify_generations, without allocating a
@@ -2028,23 +2051,34 @@ _verify(VB* self)
          * RichCompareBool.  This version compares in-place and exits
          * early on the first mismatch. */
         for (i = 0; i < l; i++) {
-            PyObject *reg = PyTuple_GET_ITEM(self->_verify_ro, i);
+            PyObject *reg = PyTuple_GET_ITEM(ro, i);
             PyObject *current_gen = PyObject_GetAttr(reg, str_generation);
-            if (current_gen == NULL)
+            if (current_gen == NULL) {
+                Py_DECREF(ro);
+                Py_DECREF(generations);
                 return -1;
+            }
 
             PyObject *stored_gen = PyTuple_GET_ITEM(
-                self->_verify_generations, i);
+                generations, i);
             int eq = PyObject_RichCompareBool(current_gen, stored_gen, Py_EQ);
             Py_DECREF(current_gen);
 
-            if (eq < 0) return -1;   /* error */
+            if (eq < 0) {
+                Py_DECREF(ro);
+                Py_DECREF(generations);
+                return -1;
+            }
             if (eq == 0) goto changed; /* mismatch — early exit */
         }
+        Py_DECREF(ro);
+        Py_DECREF(generations);
         return 0;  /* all match, cache is still valid */
     }
 
 changed:
+    Py_XDECREF(ro);
+    Py_XDECREF(generations);
     changed_result =
       PyObject_CallMethodObjArgs(OBJECT(self), strchanged, Py_None, NULL);
     if (changed_result == NULL)

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -71,6 +71,14 @@ _PyDict_GetItemRef(PyObject *p, PyObject *key, PyObject **result)
             return NULL;                                                       \
     }
 
+/* Py_BEGIN/END_CRITICAL_SECTION arrived in 3.13.  Where it is unavailable the GIL
+ * serializes everything, so the fallback is a plain block that takes no lock.
+ * Guarded by capability (#ifndef), not version, so a backport is respected. */
+#ifndef Py_BEGIN_CRITICAL_SECTION
+#define Py_BEGIN_CRITICAL_SECTION(op) {
+#define Py_END_CRITICAL_SECTION() }
+#endif
+
 /*
  *  Don't use heap-allocated types for Python < 3.11:  the API needed
  *  to find the dynamic module, 'PyType_GetModuleByDef', was added then.
@@ -1197,7 +1205,19 @@ LB_dealloc(LB* self)
 static PyObject*
 LB_changed(LB* self, PyObject* ignored)
 {
-    LB_clear(self);
+    /* Detach the three cache dicts under a critical section so this cannot race a
+     * concurrent lookup()'s field access (#380).  DECREF them AFTER releasing the
+     * section: a dict dealloc can run arbitrary Python (__del__), which must not
+     * execute while the lock is held. */
+    PyObject *cache, *mcache, *scache;
+    Py_BEGIN_CRITICAL_SECTION(OBJECT(self));
+    cache = self->_cache;   self->_cache = NULL;
+    mcache = self->_mcache; self->_mcache = NULL;
+    scache = self->_scache; self->_scache = NULL;
+    Py_END_CRITICAL_SECTION();
+    Py_XDECREF(cache);
+    Py_XDECREF(mcache);
+    Py_XDECREF(scache);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -1216,6 +1236,44 @@ LB_changed(LB* self, PyObject* ignored)
             cache = c
         return cache
 */
+/* Ensure *field is a dict and return a NEW strong reference to it, taking a critical
+ * section on 'self' so the field's create/read cannot race a concurrent detach in
+ * LB_changed() on a free-threaded build (#380 Q2/Q3).  NO Python runs inside the
+ * section: the candidate dict is allocated before locking, and only a pointer
+ * publish + Py_NewRef happen while held, so it cannot re-enter or deadlock.  The
+ * returned strong reference keeps the dict alive even if LB_changed() detaches the
+ * field immediately afterward.  Returns NULL (error set) on allocation failure.
+ *
+ * NOTE: this guarantees memory safety, not linearizable invalidation -- a lookup that
+ * retains a now-detached cache may still populate/return from that retired generation.
+ * That is acceptable per the cache's semantics (a stale/duplicate cache entry, never a
+ * use-after-free); strict invalidation would require generation checks with callback
+ * and deadlock implications out of scope for this fix. */
+static PyObject*
+_assure_cache_field(LB* self, PyObject** field)
+{
+    PyObject* candidate = NULL;
+    PyObject* ref = NULL;
+
+    /* Allocate outside the lock; publish only if the field is still empty. */
+    if (*field == NULL) {
+        candidate = PyDict_New();
+        if (candidate == NULL)
+            return NULL;
+    }
+    Py_BEGIN_CRITICAL_SECTION(OBJECT(self));
+    if (*field == NULL && candidate != NULL) {
+        *field = candidate;    /* field takes ownership */
+        candidate = NULL;
+    }
+    if (*field != NULL)
+        ref = Py_NewRef(*field);
+    Py_END_CRITICAL_SECTION();
+    Py_XDECREF(candidate);     /* lost the publish race, or *field was already set */
+    return ref;
+}
+
+
 /* Return a strong reference to a sub-dict of 'cache' for 'key'.
  * Creates a new empty sub-dict if one doesn't exist yet.
  *
@@ -1255,10 +1313,12 @@ static PyObject*
 _getcache(LB* self, PyObject* provided, PyObject* name)
 {
     PyObject* cache;
+    PyObject* parent = _assure_cache_field(self, &self->_cache);  /* strong ref, under lock */
+    if (parent == NULL)
+        return NULL;
 
-    ASSURE_DICT(self->_cache);
-
-    cache = _subcache(self->_cache, provided);  /* strong ref */
+    cache = _subcache(parent, provided);  /* strong ref; user hash runs OUTSIDE the lock */
+    Py_DECREF(parent);
     if (cache == NULL)
         return NULL;
 
@@ -1614,9 +1674,15 @@ _lookupAll(LB* self, PyObject* required, PyObject* provided)
             return NULL;
     }
 
-    ASSURE_DICT(self->_mcache);
-
-    cache = _subcache(self->_mcache, provided);  /* strong ref */
+    {
+        PyObject* parent = _assure_cache_field(self, &self->_mcache);  /* strong ref, under lock */
+        if (parent == NULL) {
+            Py_DECREF(required);
+            return NULL;
+        }
+        cache = _subcache(parent, provided);  /* strong ref; user hash OUTSIDE the lock */
+        Py_DECREF(parent);
+    }
     if (cache == NULL) {
         Py_DECREF(required);
         return NULL;
@@ -1699,9 +1765,15 @@ _subscriptions(LB* self, PyObject* required, PyObject* provided)
             return NULL;
     }
 
-    ASSURE_DICT(self->_scache);
-
-    cache = _subcache(self->_scache, provided);  /* strong ref */
+    {
+        PyObject* parent = _assure_cache_field(self, &self->_scache);  /* strong ref, under lock */
+        if (parent == NULL) {
+            Py_DECREF(required);
+            return NULL;
+        }
+        cache = _subcache(parent, provided);  /* strong ref; user hash OUTSIDE the lock */
+        Py_DECREF(parent);
+    }
     if (cache == NULL) {
         Py_DECREF(required);
         return NULL;

--- a/src/zope/interface/_zope_interface_coptimizations.c
+++ b/src/zope/interface/_zope_interface_coptimizations.c
@@ -1239,10 +1239,11 @@ LB_changed(LB* self, PyObject* ignored)
 /* Ensure *field is a dict and return a NEW strong reference to it, taking a critical
  * section on 'self' so the field's create/read cannot race a concurrent detach in
  * LB_changed() on a free-threaded build (#380 Q2/Q3).  NO Python runs inside the
- * section: the candidate dict is allocated before locking, and only a pointer
- * publish + Py_NewRef happen while held, so it cannot re-enter or deadlock.  The
- * returned strong reference keeps the dict alive even if LB_changed() detaches the
- * field immediately afterward.  Returns NULL (error set) on allocation failure.
+ * section: Py_NewRef and pointer publication cannot re-enter.  Dict allocation is
+ * performed outside the section, after a locked miss, then the field is checked
+ * again before publication.  The returned strong reference keeps the dict alive
+ * if LB_changed() detaches the field immediately afterward.  Returns NULL (error
+ * set) only on allocation failure.
  *
  * NOTE: this guarantees memory safety, not linearizable invalidation -- a lookup that
  * retains a now-detached cache may still populate/return from that retired generation.
@@ -1252,24 +1253,31 @@ LB_changed(LB* self, PyObject* ignored)
 static PyObject*
 _assure_cache_field(LB* self, PyObject** field)
 {
-    PyObject* candidate = NULL;
+    PyObject* candidate;
     PyObject* ref = NULL;
 
-    /* Allocate outside the lock; publish only if the field is still empty. */
-    if (*field == NULL) {
-        candidate = PyDict_New();
-        if (candidate == NULL)
-            return NULL;
-    }
+    /* The first field read must be locked too: LB_changed() writes this pointer. */
     Py_BEGIN_CRITICAL_SECTION(OBJECT(self));
-    if (*field == NULL && candidate != NULL) {
-        *field = candidate;    /* field takes ownership */
-        candidate = NULL;
-    }
     if (*field != NULL)
         ref = Py_NewRef(*field);
     Py_END_CRITICAL_SECTION();
-    Py_XDECREF(candidate);     /* lost the publish race, or *field was already set */
+    if (ref != NULL)
+        return ref;
+
+    /* Allocate outside the lock, then recheck because another lookup may have
+     * published a dict while allocation was in progress. */
+    candidate = PyDict_New();
+    if (candidate == NULL)
+        return NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(OBJECT(self));
+    if (*field == NULL) {
+        *field = candidate;    /* field takes ownership */
+        candidate = NULL;
+    }
+    ref = Py_NewRef(*field);
+    Py_END_CRITICAL_SECTION();
+    Py_XDECREF(candidate);     /* lost the publish race */
     return ref;
 }
 

--- a/src/zope/interface/tests/test_lookup_concurrency.py
+++ b/src/zope/interface/tests/test_lookup_concurrency.py
@@ -1,0 +1,84 @@
+##############################################################################
+#
+# Copyright (c) 2026 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY, TITLE, AND FITNESS FOR A PARTICULAR
+# PURPOSE.
+#
+##############################################################################
+"""Concurrency regression test for the LookupBase cache (see issue #380).
+
+On a free-threaded build, concurrent ``lookup()`` and ``changed()`` calls used to crash the
+interpreter (a data race on the ``_cache``/``_mcache``/``_scache`` fields). This runs the
+reproducer in a subprocess so a regression is observed as a non-zero exit rather than taking
+the whole test run down; on GIL builds it trivially passes.
+"""
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+_CHILD = textwrap.dedent(
+    """
+    import threading, time
+    from zope.interface import Interface
+    from zope.interface.adapter import AdapterRegistry, AdapterLookup
+
+    class IA(Interface): pass
+    class IB(Interface): pass
+
+    reg = AdapterRegistry()
+    reg.register([IA], IB, "", "v")
+    lk = AdapterLookup(reg)
+    stop = threading.Event()
+
+    def reader():
+        while not stop.is_set():
+            try:
+                lk.lookup([IA], IB, "")
+            except Exception:
+                pass
+
+    def clearer():
+        while not stop.is_set():
+            try:
+                lk.changed(None)
+            except Exception:
+                pass
+
+    threads = ([threading.Thread(target=reader) for _ in range(8)]
+               + [threading.Thread(target=clearer) for _ in range(4)])
+    for t in threads:
+        t.start()
+    time.sleep(3)
+    stop.set()
+    for t in threads:
+        t.join()
+    print("ok")
+    """
+)
+
+
+class ConcurrentLookupChangedTests(unittest.TestCase):
+
+    def test_concurrent_lookup_and_changed_does_not_crash(self):
+        result = subprocess.run(
+            [sys.executable, "-c", _CHILD],
+            capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            "concurrent lookup()/changed() crashed the interpreter "
+            "(returncode %r):\n%s" % (result.returncode, result.stderr[-2000:]),
+        )
+        self.assertIn("ok", result.stdout)
+
+
+def test_suite():
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/interface/tests/test_lookup_concurrency.py
+++ b/src/zope/interface/tests/test_lookup_concurrency.py
@@ -13,10 +13,9 @@
 ##############################################################################
 """Concurrency regression test for the LookupBase cache (see issue #380).
 
-On a free-threaded build, concurrent ``lookup()`` and ``changed()`` calls used to crash the
-interpreter (a data race on the ``_cache``/``_mcache``/``_scache`` fields). This runs the
-reproducer in a subprocess so a regression is observed as a non-zero exit rather than taking
-the whole test run down; on GIL builds it trivially passes.
+On a free-threaded build, concurrent lookup and invalidation calls used to
+crash the interpreter.  Run the reproducer in a subprocess so a regression is
+observed as a non-zero exit rather than taking the whole test run down.
 """
 import subprocess
 import sys
@@ -26,40 +25,78 @@ import unittest
 
 _CHILD = textwrap.dedent(
     """
-    import threading, time
-    from zope.interface import Interface
-    from zope.interface.adapter import AdapterRegistry, AdapterLookup
+    import sys
+    import threading
+    import time
+    import traceback
+    from zope.interface.adapter import LookupBase
 
-    class IA(Interface): pass
-    class IB(Interface): pass
+    if LookupBase.__module__ != "_zope_interface_coptimizations":
+        raise SystemExit(
+            "the concurrency regression requires the C implementation"
+        )
 
-    reg = AdapterRegistry()
-    reg.register([IA], IB, "", "v")
-    lk = AdapterLookup(reg)
+    class Lookup(LookupBase):
+        def _uncached_lookup(self, required, provided, name):
+            return None
+
+        def _uncached_lookupAll(self, required, provided):
+            return ()
+
+        def _uncached_subscriptions(self, required, provided):
+            return ()
+
+    lk = Lookup()
+    required = (object(),)
+    provided = object()
     stop = threading.Event()
+    errors = []
+    errors_lock = threading.Lock()
 
-    def reader():
+    if sys._is_gil_enabled():
+        raise SystemExit(
+            "the concurrency regression requires the GIL disabled"
+        )
+
+    operations = (
+        lambda: lk.lookup(required, provided, ""),
+        lambda: lk.lookupAll(required, provided),
+        lambda: lk.subscriptions(required, provided),
+    )
+
+    def record_error():
+        with errors_lock:
+            errors.append(traceback.format_exc())
+        stop.set()
+
+    def reader(index):
+        operation = operations[index % len(operations)]
         while not stop.is_set():
             try:
-                lk.lookup([IA], IB, "")
+                operation()
             except Exception:
-                pass
+                record_error()
 
     def clearer():
         while not stop.is_set():
             try:
                 lk.changed(None)
             except Exception:
-                pass
+                record_error()
 
-    threads = ([threading.Thread(target=reader) for _ in range(8)]
-               + [threading.Thread(target=clearer) for _ in range(4)])
+    threads = (
+        [threading.Thread(target=reader, args=(i,)) for i in range(9)]
+        + [threading.Thread(target=clearer) for _ in range(4)]
+    )
     for t in threads:
         t.start()
     time.sleep(3)
     stop.set()
     for t in threads:
         t.join()
+    if errors:
+        print(errors[0], file=sys.stderr)
+        raise SystemExit("lookup/changed worker raised")
     print("ok")
     """
 )
@@ -68,14 +105,29 @@ _CHILD = textwrap.dedent(
 class ConcurrentLookupChangedTests(unittest.TestCase):
 
     def test_concurrent_lookup_and_changed_does_not_crash(self):
+        from zope.interface.adapter import LookupBase
+
+        if (
+            not hasattr(sys, "_is_gil_enabled") or
+            sys._is_gil_enabled() or
+            LookupBase.__module__ != "_zope_interface_coptimizations"
+        ):
+            self.skipTest(
+                "requires the C implementation on a free-threaded interpreter"
+            )
+
         result = subprocess.run(
             [sys.executable, "-c", _CHILD],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
         self.assertEqual(
-            result.returncode, 0,
+            result.returncode,
+            0,
             "concurrent lookup()/changed() crashed the interpreter "
-            "(returncode %r):\n%s" % (result.returncode, result.stderr[-2000:]),
+            "(returncode %r):\n%s"
+            % (result.returncode, result.stderr[-2000:]),
         )
         self.assertIn("ok", result.stdout)
 

--- a/src/zope/interface/tests/test_lookup_concurrency.py
+++ b/src/zope/interface/tests/test_lookup_concurrency.py
@@ -11,11 +11,12 @@
 # PURPOSE.
 #
 ##############################################################################
-"""Concurrency regression test for the LookupBase cache (see issue #380).
+"""Concurrency regressions for lookup cache lifetimes (see issue #380).
 
 On a free-threaded build, concurrent lookup and invalidation calls used to
-crash the interpreter.  Run the reproducer in a subprocess so a regression is
-observed as a non-zero exit rather than taking the whole test run down.
+crash the interpreter.  VerifyingBase also kept unsynchronized verification
+snapshots across Python callbacks.  Run the reproducers in subprocesses so a
+regression is observed as a non-zero exit rather than taking the test run down.
 """
 import subprocess
 import sys
@@ -23,15 +24,19 @@ import textwrap
 import unittest
 
 
-_CHILD = textwrap.dedent(
+_CACHE_CHILD = textwrap.dedent(
     """
     import sys
     import threading
     import time
     import traceback
     from zope.interface.adapter import LookupBase
+    from zope.interface.adapter import VerifyingBase
 
-    if LookupBase.__module__ != "_zope_interface_coptimizations":
+    if (
+        LookupBase.__module__ != "_zope_interface_coptimizations"
+        or VerifyingBase.__module__ != "_zope_interface_coptimizations"
+    ):
         raise SystemExit(
             "the concurrency regression requires the C implementation"
         )
@@ -46,7 +51,35 @@ _CHILD = textwrap.dedent(
         def _uncached_subscriptions(self, required, provided):
             return ()
 
+    class Generation:
+        @property
+        def _generation(self):
+            # PyObject_GetAttr() in _verify() can run arbitrary Python.  Yield
+            # here to widen the read-versus-changed() lifetime window.
+            time.sleep(0)
+            return 1
+
+    class Registry:
+        def __init__(self):
+            self.ro = (Generation(), Generation())
+
+    class VerifyingLookup(VerifyingBase):
+        def __init__(self):
+            super().__init__()
+            self._registry = Registry()
+            self.changed(None)
+
+        def _uncached_lookup(self, required, provided, name):
+            return None
+
+        def _uncached_lookupAll(self, required, provided):
+            return ()
+
+        def _uncached_subscriptions(self, required, provided):
+            return ()
+
     lk = Lookup()
+    verifying = VerifyingLookup()
     required = (object(),)
     provided = object()
     stop = threading.Event()
@@ -58,10 +91,15 @@ _CHILD = textwrap.dedent(
             "the concurrency regression requires the GIL disabled"
         )
 
-    operations = (
+    plain_operations = (
         lambda: lk.lookup(required, provided, ""),
         lambda: lk.lookupAll(required, provided),
         lambda: lk.subscriptions(required, provided),
+    )
+    verifying_operations = (
+        lambda: verifying.lookup(required, provided, ""),
+        lambda: verifying.lookupAll(required, provided),
+        lambda: verifying.subscriptions(required, provided),
     )
 
     def record_error():
@@ -69,7 +107,7 @@ _CHILD = textwrap.dedent(
             errors.append(traceback.format_exc())
         stop.set()
 
-    def reader(index):
+    def reader(operations, index):
         operation = operations[index % len(operations)]
         while not stop.is_set():
             try:
@@ -77,20 +115,31 @@ _CHILD = textwrap.dedent(
             except Exception:
                 record_error()
 
-    def clearer():
+    def clearer(target):
         while not stop.is_set():
             try:
-                lk.changed(None)
+                target.changed(None)
             except Exception:
                 record_error()
 
     threads = (
-        [threading.Thread(target=reader, args=(i,)) for i in range(9)]
-        + [threading.Thread(target=clearer) for _ in range(4)]
+        [
+            threading.Thread(target=reader, args=(plain_operations, i))
+            for i in range(6)
+        ]
+        + [threading.Thread(target=clearer, args=(lk,)) for _ in range(2)]
+        + [
+            threading.Thread(target=reader, args=(verifying_operations, i))
+            for i in range(6)
+        ]
+        + [
+            threading.Thread(target=clearer, args=(verifying,))
+            for _ in range(2)
+        ]
     )
     for t in threads:
         t.start()
-    time.sleep(3)
+    stop.wait(3)
     stop.set()
     for t in threads:
         t.join()
@@ -101,10 +150,97 @@ _CHILD = textwrap.dedent(
     """
 )
 
+_VERIFY_SNAPSHOT_CHILD = textwrap.dedent(
+    """
+    import sys
+    import threading
+    from zope.interface.adapter import VerifyingBase
+
+    if (
+        sys._is_gil_enabled()
+        or VerifyingBase.__module__ != "_zope_interface_coptimizations"
+    ):
+        raise SystemExit(
+            "the concurrency regression requires the C implementation "
+            "with the GIL disabled"
+        )
+
+    entered = threading.Event()
+    resume = threading.Event()
+
+    class Generation:
+        armed = False
+
+        @property
+        def _generation(self):
+            if self.armed:
+                entered.set()
+                if not resume.wait(10):
+                    raise RuntimeError("timed out waiting for changed()")
+            return 1
+
+    generation = Generation()
+
+    class Registry:
+        short = False
+
+        @property
+        def ro(self):
+            if self.short:
+                return (object(),)
+            return (object(), generation)
+
+    registry = Registry()
+
+    class Lookup(VerifyingBase):
+        def __init__(self):
+            super().__init__()
+            self._registry = registry
+            self.changed(None)
+
+        def _uncached_lookup(self, required, provided, name):
+            return None
+
+        def _uncached_lookupAll(self, required, provided):
+            return ()
+
+        def _uncached_subscriptions(self, required, provided):
+            return ()
+
+    lookup = Lookup()
+    generation.armed = True
+    errors = []
+
+    def read():
+        try:
+            lookup.lookup((object(),), object(), "")
+        except Exception as exc:
+            errors.append(repr(exc))
+
+    thread = threading.Thread(target=read)
+    thread.start()
+    if not entered.wait(10):
+        raise SystemExit("_verify() did not reach the generation callback")
+
+    # Publish a differently-sized verification snapshot while _verify() is
+    # suspended in Python.  The reader must finish against the old strong
+    # snapshot instead of indexing the replacement fields.
+    registry.short = True
+    lookup.changed(None)
+    resume.set()
+    thread.join(10)
+    if thread.is_alive():
+        raise SystemExit("verification reader did not finish")
+    if errors:
+        raise SystemExit("verification reader raised: " + errors[0])
+    print("ok")
+    """
+)
+
 
 class ConcurrentLookupChangedTests(unittest.TestCase):
 
-    def test_concurrent_lookup_and_changed_does_not_crash(self):
+    def _run_child(self, child, label):
         from zope.interface.adapter import LookupBase
 
         if (
@@ -117,7 +253,7 @@ class ConcurrentLookupChangedTests(unittest.TestCase):
             )
 
         result = subprocess.run(
-            [sys.executable, "-c", _CHILD],
+            [sys.executable, "-c", child],
             capture_output=True,
             text=True,
             timeout=60,
@@ -125,11 +261,19 @@ class ConcurrentLookupChangedTests(unittest.TestCase):
         self.assertEqual(
             result.returncode,
             0,
-            "concurrent lookup()/changed() crashed the interpreter "
+            "%s failed "
             "(returncode %r):\n%s"
-            % (result.returncode, result.stderr[-2000:]),
+            % (label, result.returncode, result.stderr[-2000:]),
         )
         self.assertIn("ok", result.stdout)
+
+    def test_concurrent_lookup_and_changed_does_not_crash(self):
+        self._run_child(_CACHE_CHILD, "concurrent lookup()/changed()")
+
+    def test_verify_uses_one_strong_snapshot(self):
+        self._run_child(
+            _VERIFY_SNAPSHOT_CHILD,
+            "concurrent _verify()/changed()")
 
 
 def test_suite():


### PR DESCRIPTION
Fixes #380.

This PR protects the lifetimes of the C `LookupBase` cache fields and the
`VerifyingBase` verification snapshot on free-threaded builds.

The original cache-field race occurs when a lookup initializes or retains
`_cache`, `_mcache`, or `_scache` while `changed()` concurrently detaches the
same field.  That can corrupt memory and terminate the interpreter with either
`PyMutex_Unlock: unlocking mutex that is not locked` or a segmentation fault.

`VerifyingBase` has the same cache fields plus a second lifetime boundary:
`_verify()` used `_verify_ro` and `_verify_generations` through Python callbacks
while `verify_changed()` could clear and replace those raw fields.

At the current head:

- cache dictionaries are allocated outside the object critical section,
  installed or retained while locked, and returned with a strong reference;
- `LookupBase.changed()` and `VerifyingBase.changed()` detach cache fields while
  locked and decref them after unlocking;
- `VerifyingBase.changed()` replaces `_verify_ro` and `_verify_generations` as
  one locked pair; and
- `_verify()` acquires one strong pair snapshot before any attribute lookup or
  comparison can execute Python.

The pre-3.13 fallback remains a no-op block because the GIL serializes those
builds.  `LB_clear()` and `VB_clear()` remain the GC/deallocation paths; runtime
invalidation uses the synchronized methods above.  No allocation, Python
callback, or potentially re-entrant decref occurs while the object critical
section is held.

This is a memory-safety fix, not a claim of linearizable invalidation.  An
in-flight lookup may still finish against a cache generation that `changed()`
has already detached.

Local validation at exact head `5ec2eda9f9e93f8a2c09485684eb1344efcccfa9`:

- both new subprocess regressions fail on predecessor `5a2fdda` (one SIGSEGV;
  one deterministic verification-snapshot `SystemError`);
- the two-test free-threaded regression module passes in 10/10 fresh processes
  on CPython 3.14.6t with the GIL disabled;
- CPython 3.14.6t C-extension suite: 1,369 tests, 0 failures, 7 skipped;
- CPython 3.12.11 C and pure-Python suites: 1,373 tests each, 0 failures,
  9 skipped; and
- changed-file pre-commit checks and C syntax compilation against CPython 3.13
  and 3.11 headers pass.

